### PR TITLE
Add a flag to pass an already compiled library

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -59,6 +59,10 @@ pub struct BuildOptions {
     /// directory in the project's target directory
     #[structopt(short, long, parse(from_os_str))]
     pub out: Option<PathBuf>,
+    /// A path to an already compiled artifact. If provided this will be used instead of
+    /// the output from running Cargo.
+    #[structopt(short, long, parse(from_os_str))]
+    pub artifact_path: Option<PathBuf>,
     /// [deprecated, use --manylinux instead] Don't check for manylinux compliance
     #[structopt(long = "skip-auditwheel")]
     pub skip_auditwheel: bool,
@@ -85,6 +89,7 @@ impl Default for BuildOptions {
             bindings: None,
             manifest_path: PathBuf::from("Cargo.toml"),
             out: None,
+            artifact_path: None,
             skip_auditwheel: false,
             target: None,
             cargo_extra_args: Vec::new(),
@@ -181,6 +186,7 @@ impl BuildOptions {
             scripts,
             module_name,
             manifest_path: self.manifest_path,
+            artifact: self.artifact_path,
             out: wheel_dir,
             release,
             strip,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -170,7 +170,7 @@ pub fn compile(
     let mut progress_plan = get_progress_plan(&shared_args);
 
     if progress_plan.is_some() {
-        // We have out own progess bar, so we don't need cargo's bar
+        // We have our own progess bar, so we don't need cargo's bar
         cargo_args.push("--quiet");
     }
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -39,6 +39,7 @@ pub fn develop(
         bindings,
         manifest_path: manifest_file.to_path_buf(),
         out: None,
+        artifact_path: None,
         skip_auditwheel: false,
         target: None,
         cargo_extra_args,


### PR DESCRIPTION
For the build system I'm using (Nix), using Cargo directly is annoying because I need to build everything from scratch each time. This adds a flag so that you can point to an already compiled library to make the wheel.