### PR TITLE
Cookiecutter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,6 +98,8 @@ my-project
     └── lib.rs
 ```
 
+For quickly setting up a package, there is a *WIP* [cookiecutter-rust-pypackage](https://github.com/pattonw/cookiecutter-rust-pypackage) adapted from audreyr's [cookiecutter-pypackage](https://github.com/audreyr/cookiecutter-pypackage)
+
 ## Python metadata
 
 To specifiy python dependecies, add a list `requires-dist` in a `[package.metadata.pyo3-pack]` section in the Cargo.toml. This list is equivalent to `install_requires` in setuptools:


### PR DESCRIPTION
Add a reference to a mixed layout python/rust package cookiecutter.

Very much still a work in progress.

`pip install .` and deploying to pypi on tagged commit through travis_ci should work out of the box.

Most other features have not been tested.

Contributions welcome