### PR TITLE
Check interpreter platform instead of target for windows abiflags

### DIFF
--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -334,7 +334,7 @@ fn fun_with_abiflags(
     if message.interpreter == "pypy" {
         // pypy does not specify abi flags
         Ok("".to_string())
-    } else if target.is_windows() {
+    } else if message.platform == "windows" {
         if message.abiflags.is_some() {
             bail!("A python 3 interpreter on windows does not define abiflags in its sysconfig ಠ_ಠ")
         } else {


### PR DESCRIPTION
fixes #200 
This does the trick for cross-compiling windows targets under linux.
I don't really know the implications of this change, but the tests aren't failing because of it, giving me the impression that it works.