### PR TITLE
Specify python_requires >= 3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "development-tools::ffi", "command-line-utilities"
 edition = "2018"
 
 [package.metadata.maturin]
+requires-python = ">=3.5"
 classifier = [
     "Software Development :: Build Tools",
     "Programming Language :: Rust",

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (for the cli, not for the crate).
 
+## Unreleased
+
+### Changed
+
+* maturin's metadata now lists a requirement of python3.5 or later to install.
+
 ## [0.7.6] - 2019-09-28
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
     long_description_content_type="text/markdown",
     version="0.7.6",
     license="MIT OR Apache-2.0",
+    python_requires=">=3.5",
     cmdclass={"install": PostInstallCommand, "bdist_wheel": bdist_wheel},
     classifiers=[
         "Software Development :: Build Tools",


### PR DESCRIPTION
This is needed to prevent pip to try to install it on unsupported versions. https://github.com/ijl/orjson/issues/35