### PR TITLE
32 bit Python modules use i386, not x86

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -187,7 +187,7 @@ impl Target {
                 if self.is_64_bit {
                     "x86_64-linux-gnu"
                 } else {
-                    "x86-linux-gnu"
+                    "i386-linux-gnu"
                 }
             }
             OS::Macos => "darwin",


### PR DESCRIPTION
The generated .so files on a 32 bit machine weren't being recognised by Python. When renaming to 'i386' instead of 'x86', Python is able to pick them up. Tested on a 32 bit Ubuntu 16.04 machine using Python 3.5.