### PR TITLE
Filter Cargo.toml.orig from sdist

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -69,6 +69,7 @@ pub fn source_distribution(
             let relative_to_cwd = manifest_dir.join(relative_to_manifests);
             (relative_to_manifests.to_path_buf(), relative_to_cwd)
         })
+        .filter(|(target, _)| target != Path::new("Cargo.toml.orig"))
         .collect();
 
     if !target_source


### PR DESCRIPTION
This path began appearing in the output of
cargo package --list --allow-dirty --manifest-path=Cargo.toml around
nightly-2020-02-22. It doesn't exist prior to the call and isn't created
by it. This causes:

💥 maturin failed
  Caused by: Failed to build source distribution
  Caused by: Failed to add file from Cargo.toml.orig to sdist as Cargo.toml.orig
  Caused by: No such file or directory (os error 2) when getting metadata for Cargo.toml.orig