### PR TITLE
resulting wheels to work on CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux1_x86_64
+FROM quay.io/pypa/manylinux2010_x86_64
 
 ENV PATH /root/.cargo/bin:$PATH
 # Add all supported python versions


### PR DESCRIPTION
The results of building with maturin don't work on CentOS 7, as I noted when installing blake3 (which is build using maturin).
This is because of libc-2.5 in manylinux1 (which is CentOS 5 based). If you change to manylinux2010 (which is CentOS 6 based) you'll get libc-2.16 and the wheels from that do install on CentOS 7.
Those wheels would no longer work on CentOS 5, but a) that is no longer maintained and b) your current wheels don't work on that  anyway. Those wheels should work on CentOS 6, but you would have to compile a Python3 for that platform yourself.

By switching to manylinux2010 as the base, you'll gain support for CentOS 7 and linux version of the same "generation", only losing older platforms where things (i.e. rust) will not work anyway.