### PR TITLE
correct a Docker command in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -172,7 +172,7 @@ maturin contains a reimplementation of a major part of auditwheel automatically 
 For full manylinux compliance you need to compile in a cent os 5 docker container. The [konstin2/maturin](https://hub.docker.com/r/konstin2/maturin) image is based on the official manylinux image. You can use it like this:
 
 ```
-docker run --rm -v $(pwd):/io konstin2/maturin build
+docker run --rm -v $(pwd):/io konstin2/maturin:master build
 ```
 
 maturin itself is manylinux compliant when compiled for the musl target. The binaries on the release pages have additional keyring integration (through the `password-storage` feature), which is not manylinux compliant.


### PR DESCRIPTION
When I try the Docker command as written, I see this error:

```
Unable to find image 'konstin2/maturin:latest' locally
docker: Error response from daemon: manifest for konstin2/maturin:latest not found: manifest unknown: manifest unknown.
See 'docker run --help'.
```

It looks like Docker is implicitly looking for a "latest" tag, but
according to the tags list on dockerhub, we need to use "master".
Replacing "konstin2/maturin" with "konstin2/maturin:master" fixes the
error.