### PR TITLE
fix python executable path for conda environment

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -192,11 +192,11 @@ impl Metadata21 {
     pub fn to_file_contents(&self) -> String {
         let mut fields = self.to_vec();
         let mut out = "".to_string();
-
-        let body = match fields.clone().last() {
+        let body = match fields.last() {
             Some((key, description)) if key == "Description" => {
+                let desc = description.clone();
                 fields.pop().unwrap();
-                Some(description.clone())
+                Some(desc)
             }
             Some((_, _)) => None,
             None => None,

--- a/src/target.rs
+++ b/src/target.rs
@@ -226,7 +226,12 @@ impl Target {
     /// Returns the path to the python executable inside a venv
     pub fn get_venv_python(&self, venv_base: impl AsRef<Path>) -> PathBuf {
         if self.is_windows() {
-            venv_base.as_ref().join("Scripts").join("python.exe")
+            let path = venv_base.as_ref().join("Scripts").join("python.exe");
+            if path.exists() {
+                path
+            } else { // for conda environment
+                venv_base.as_ref().join("python.exe")
+            }
         } else {
             venv_base.as_ref().join("bin").join("python")
         }

--- a/src/target.rs
+++ b/src/target.rs
@@ -229,7 +229,8 @@ impl Target {
             let path = venv_base.as_ref().join("Scripts").join("python.exe");
             if path.exists() {
                 path
-            } else { // for conda environment
+            } else {
+                // for conda environment
                 venv_base.as_ref().join("python.exe")
             }
         } else {


### PR DESCRIPTION
In conda virtual environment (Windows) , python.exe is located in directly below `$CONDA_PREFIX` instead of `$CONDA_PREFIX\Scripts`.
so I added fallback to `$CONDA_PREFIX\python.exe` .