### PR TITLE
Fix `build_sdist` return value for PEP 517

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 include arbitrary files in source distributions ([#296](https://github.com/PyO3/maturin/pull/296)).
  * cffi is installed if it's missing and python is running inside a virtualenv.
 
+### Fixed
+ * Fix incorrectly returning full path (not basename) from PEP 517 `build_sdist` hook
+
 ## 0.8.0 - 2020-04-03
 
 ### Added

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -85,7 +85,10 @@ def build_sdist(sdist_directory, config_settings=None):
     sys.stdout.buffer.write(output)
     sys.stdout.flush()
     output = output.decode(errors="replace")
-    return output.strip().splitlines()[-1]
+    sdist_path = output.strip().splitlines()[-1]
+    dirname, basename = sdist_path.rpartition(os.sep)
+    assert dirname == sdist_directory
+    return basename
 
 
 # noinspection PyUnusedLocal


### PR DESCRIPTION
According to [PEP 517] the `build_sdist` hook should return just the `basename` of the output archive.

https://www.python.org/dev/peps/pep-0517/#build-sdist