### PR TITLE
Fix #277 and #333 by using `sys.executable` for PEP 517

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -128,6 +128,10 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
         "write-dist-info",
         "--metadata-directory",
         metadata_directory,
+        # PEP 517 specifies that only `sys.executable` points to the correct
+        # python interpreter
+        "--interpreter",
+        sys.executable,
     ]
     command.extend(get_config_options())
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,11 +255,14 @@ enum PEP517Command {
 fn pep517(subcommand: PEP517Command) -> Result<()> {
     match subcommand {
         PEP517Command::WriteDistInfo {
-            mut build_options,
+            build_options,
             metadata_directory,
             strip,
         } => {
-            build_options.interpreter = Some(vec![PathBuf::from("python")]);
+            assert!(matches!(
+                build_options.interpreter.as_ref(),
+                Some(version) if version.len() == 1
+            ));
             let context = build_options.into_build_context(true, strip)?;
             let tags = match context.bridge {
                 BridgeModel::Bindings(_) => {


### PR DESCRIPTION
PEP 517 specifies only that `sys.executable` points to the correct
python interpreter, so we need to pass that value to rust