### PR TITLE
Remove overly-generous CI cache restore keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,22 +36,16 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-registry-
       - name: Cache cargo index
         uses: actions/cache@v2
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-index-
       - name: Cache cargo build
         uses: actions/cache@v2
         with:
           path: target
           key: ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-target-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.rustup.outputs.rustc_hash }}-target-
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
As per https://github.com/PyO3/maturin/pull/340#discussion_r462475099