### PR TITLE
Configurable Description-Content-Type

### DIFF
--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -119,6 +119,7 @@ pub struct RemainingCoreMetadata {
     pub requires_external: Option<Vec<String>>,
     pub project_url: Option<Vec<String>>,
     pub provides_extra: Option<Vec<String>>,
+    pub description_content_type: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -54,6 +54,27 @@ pub struct Metadata21 {
     pub provides_extra: Vec<String>,
 }
 
+const PLAINTEXT_CONTENT_TYPE: &str = "text/plain; charset=UTF-8";
+const GFM_CONTENT_TYPE: &str = "text/markdown; charset=UTF-8; variant=GFM";
+
+/// Guess a Description-Content-Type based on the file extension,
+/// defaulting to plaintext if extension is unknown or empty.
+///
+/// See https://packaging.python.org/specifications/core-metadata/#description-content-type
+fn path_to_content_type(path: &PathBuf) -> String {
+    path.extension()
+        .map_or(String::from(PLAINTEXT_CONTENT_TYPE), |ext| {
+            let ext = ext.to_string_lossy().to_lowercase();
+            let type_str = match ext.as_str() {
+                "rst" => "text/x-rst; charset=UTF-8",
+                "md" => GFM_CONTENT_TYPE,
+                "markdown" => GFM_CONTENT_TYPE,
+                _ => PLAINTEXT_CONTENT_TYPE,
+            };
+            String::from(type_str)
+        })
+}
+
 impl Metadata21 {
     /// Uses a Cargo.toml to create the metadata for python packages
     ///
@@ -63,18 +84,6 @@ impl Metadata21 {
         manifest_path: impl AsRef<Path>,
     ) -> Result<Metadata21> {
         let authors = cargo_toml.package.authors.join(", ");
-
-        // See https://packaging.python.org/specifications/core-metadata/#description
-        let description = if let Some(ref readme) = cargo_toml.package.readme {
-            Some(
-                read_to_string(manifest_path.as_ref().join(readme)).context(format!(
-                    "Failed to read readme specified in Cargo.toml, which should be at {}",
-                    manifest_path.as_ref().join(readme).display()
-                ))?,
-            )
-        } else {
-            None
-        };
 
         let classifier = cargo_toml.classifier();
 
@@ -86,15 +95,23 @@ impl Metadata21 {
 
         let extra_metadata = cargo_toml.remaining_core_metadata();
 
-        // See https://packaging.python.org/specifications/core-metadata/#description-content-type
-        let description_content_type = extra_metadata.description_content_type.or_else(|| {
-            if description.is_some() {
-                // I'm not hundred percent sure if that's the best preset
-                Some("text/markdown; charset=UTF-8; variant=GFM".to_owned())
-            } else {
-                None
-            }
-        });
+        let description: Option<String>;
+        let description_content_type: Option<String>;
+        // See https://packaging.python.org/specifications/core-metadata/#description
+        if let Some(ref readme) = cargo_toml.package.readme {
+            let readme_path = manifest_path.as_ref().join(readme);
+            description = Some(read_to_string(&readme_path).context(format!(
+                "Failed to read readme specified in Cargo.toml, which should be at {}",
+                readme_path.display()
+            ))?);
+
+            description_content_type = extra_metadata
+                .description_content_type
+                .or_else(|| Some(path_to_content_type(&readme_path)));
+        } else {
+            description = None;
+            description_content_type = None;
+        };
 
         Ok(Metadata21 {
             metadata_version: "2.1".to_owned(),
@@ -257,7 +274,7 @@ mod test {
 
         readme_md.write_all(readme.as_bytes()).unwrap();
 
-        let toml_with_path = cargo_toml.replace("README_PATH", &readme_path);
+        let toml_with_path = cargo_toml.replace("REPLACE_README_PATH", &readme_path);
 
         let cargo_toml_struct: CargoToml = toml::from_str(&toml_with_path).unwrap();
 
@@ -306,7 +323,7 @@ mod test {
             version = "0.1.0"
             description = "A test project"
             homepage = "https://example.org"
-            readme = "README_PATH"
+            readme = "REPLACE_README_PATH"
             keywords = ["ffi", "test"]
 
             [lib]
@@ -335,7 +352,7 @@ mod test {
             Home-Page: https://example.org
             Author: konstin <konstin@mailbox.org>
             Author-Email: konstin <konstin@mailbox.org>
-            Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM
+            Description-Content-Type: text/plain; charset=UTF-8
 
             # Some test package
 
@@ -363,7 +380,7 @@ mod test {
             version = "0.1.0"
             description = "A test project"
             homepage = "https://example.org"
-            readme = "README_PATH"
+            readme = "REPLACE_README_PATH"
             keywords = ["ffi", "test"]
 
             [lib]
@@ -401,5 +418,27 @@ mod test {
         );
 
         assert_metadata_from_cargo_toml(readme, cargo_toml, expected);
+    }
+
+    #[test]
+    fn test_path_to_content_type() {
+        for (filename, expected) in vec![
+            ("r.md", GFM_CONTENT_TYPE),
+            ("r.markdown", GFM_CONTENT_TYPE),
+            ("r.mArKdOwN", GFM_CONTENT_TYPE),
+            ("r.rst", "text/x-rst; charset=UTF-8"),
+            ("r.somethingelse", PLAINTEXT_CONTENT_TYPE),
+            ("r", PLAINTEXT_CONTENT_TYPE),
+        ] {
+            let result = path_to_content_type(&PathBuf::from(filename));
+            assert_eq!(
+                result.as_str(),
+                expected,
+                "Wrong content type for file '{}'. Expected '{}', got '{}'",
+                filename,
+                expected,
+                result
+            );
+        }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -257,12 +257,13 @@ mod test {
 
         readme_md.write_all(readme.as_bytes()).unwrap();
 
-        let cargo_toml = cargo_toml.replace("readme.md", &readme_path);
+        let toml_with_path = cargo_toml.replace("README_PATH", &readme_path);
 
-        let cargo_toml: CargoToml = toml::from_str(&cargo_toml).unwrap();
+        let cargo_toml_struct: CargoToml = toml::from_str(&toml_with_path).unwrap();
 
         let metadata =
-            Metadata21::from_cargo_toml(&cargo_toml, &readme_md.path().parent().unwrap()).unwrap();
+            Metadata21::from_cargo_toml(&cargo_toml_struct, &readme_md.path().parent().unwrap())
+                .unwrap();
 
         let actual = metadata.to_file_contents();
 
@@ -272,6 +273,13 @@ mod test {
             "Actual metadata differed from expected\nEXPECTED:\n{}\n\nGOT:\n{}",
             expected,
             actual
+        );
+
+        // get_dist_info_dir test checks against hard-coded values - check that they are as expected in the source first
+        assert!(
+            cargo_toml.contains("name = \"info-project\"")
+                && cargo_toml.contains("version = \"0.1.0\""),
+            "cargo_toml name and version string do not match hardcoded values, test will fail",
         );
         assert_eq!(
             metadata.get_dist_info_dir(),
@@ -298,7 +306,7 @@ mod test {
             version = "0.1.0"
             description = "A test project"
             homepage = "https://example.org"
-            readme = "readme.md"
+            readme = "README_PATH"
             keywords = ["ffi", "test"]
 
             [lib]
@@ -355,7 +363,7 @@ mod test {
             version = "0.1.0"
             description = "A test project"
             homepage = "https://example.org"
-            readme = "readme.rst"
+            readme = "README_PATH"
             keywords = ["ffi", "test"]
 
             [lib]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -269,9 +269,15 @@ mod test {
         if actual.trim() != expected.trim() {
             panic!(
                 "Actual metadata differed from expected\nEXPECTED:\n{}\n\nGOT:\n{}",
-                expected, actual
-            );
-        }
+            expected,
+            actual
+        );
+        assert_eq!(
+            metadata.get_dist_info_dir(),
+            PathBuf::from("info_project-0.1.0.dist-info"),
+            "Dist info dir differed from expected"
+        );
+    }
 
         assert_eq!(actual.trim(), expected.trim());
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -266,9 +266,10 @@ mod test {
 
         let actual = metadata.to_file_contents();
 
-        if actual.trim() != expected.trim() {
-            panic!(
-                "Actual metadata differed from expected\nEXPECTED:\n{}\n\nGOT:\n{}",
+        assert_eq!(
+            actual.trim(),
+            expected.trim(),
+            "Actual metadata differed from expected\nEXPECTED:\n{}\n\nGOT:\n{}",
             expected,
             actual
         );
@@ -277,13 +278,6 @@ mod test {
             PathBuf::from("info_project-0.1.0.dist-info"),
             "Dist info dir differed from expected"
         );
-    }
-
-        assert_eq!(actual.trim(), expected.trim());
-
-        if metadata.get_dist_info_dir() != PathBuf::from("info_project-0.1.0.dist-info") {
-            panic!("Dist info dir differed from expected");
-        }
     }
 
     #[test]
@@ -348,7 +342,8 @@ mod test {
     fn test_metadata_from_cargo_toml_rst() {
         let readme = indoc!(
             r#"
-            # Some test package
+            Some test package
+            =================
         "#
         );
 
@@ -360,7 +355,7 @@ mod test {
             version = "0.1.0"
             description = "A test project"
             homepage = "https://example.org"
-            readme = "readme.md"
+            readme = "readme.rst"
             keywords = ["ffi", "test"]
 
             [lib]
@@ -392,7 +387,8 @@ mod test {
             Author-Email: konstin <konstin@mailbox.org>
             Description-Content-Type: text/x-rst
 
-            # Some test package
+            Some test package
+            =================
         "#
         );
 


### PR DESCRIPTION
No validation is performed.
The defaults are unchanged (and inconsistent with setuptools/PyPI): that is, None if there is no readme, GFM if there is a readme and no explicit content type.

Basic test for checking metadata gets through.

See #247