### PR TITLE
Allow dot paths (.conda) to be found

### DIFF
--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -148,7 +148,7 @@ fn find_all_windows(target: &Target) -> Result<Vec<String>> {
         // The regex has three parts: The first matches the name and skips
         // comments, the second skips the part in between and the third
         // extracts the path
-        let re = Regex::new(r"^([^#].*?)[\s*]+([\w\\:-]+)$").unwrap();
+        let re = Regex::new(r"^([^#].*?)[\s*]+([\w\\:.-]+)\s*$").unwrap();
         let mut paths = vec![];
         for i in lines {
             if let Some(capture) = re.captures(&i) {


### PR DESCRIPTION
My conda installs environment in `C:\Users\xxx\.conda\envs` folders. This PR allows searching such paths to find an interpreter.