### PR TITLE
build_wheel: return absolute path from pep517 command

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -67,8 +67,9 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     sys.stdout.buffer.write(output)
     sys.stdout.flush()
     output = output.decode(errors="replace")
-    filename = output.strip().splitlines()[-1]
-    shutil.copy2("target/wheels/" + filename, os.path.join(wheel_directory, filename))
+    wheel_path = output.strip().splitlines()[-1]
+    filename = os.path.basename(wheel_path)
+    shutil.copy2(wheel_path, os.path.join(wheel_directory, filename))
     return filename
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ fn pep517(subcommand: PEP517Command) -> Result<()> {
             let build_context = build.into_build_context(true, strip)?;
             let wheels = build_context.build_wheels()?;
             assert_eq!(wheels.len(), 1);
-            println!("{}", wheels[0].0.file_name().unwrap().to_str().unwrap());
+            println!("{}", wheels[0].0.to_str().unwrap());
         }
         PEP517Command::WriteSDist {
             sdist_directory,


### PR DESCRIPTION
I hit an edge case while testing https://github.com/PyO3/pyo3/pull/1269 where a package inside a workspace has the target directory not where maturin expects, so copying the wheel to the final output directory fails.

This hasn't been an issue until now because I am testing with the upcoming pip option `--use-feature=in-tree-build`, which preserves the workspace hierarchy. (In out-of-tree build, once the source is copied then the workspace Cargo.toml will no longer affect the build.)

Solution is easy: just return the absolute path to the built wheel from the `maturin pep517` command.