### PR TITLE
Fix OpenOptions to truncate module files on write

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -113,7 +113,7 @@ impl BuildOptions {
             .lib
             .as_ref()
             .and_then(|lib| lib.name.as_ref())
-            .unwrap_or_else(|| &cargo_toml.package.name)
+            .unwrap_or(&cargo_toml.package.name)
             .to_owned();
 
         let project_layout = ProjectLayout::determine(manifest_dir, &module_name)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,10 +488,12 @@ fn run() -> Result<()> {
             release,
             strip,
         } => {
-            let venv_dir = match (env::var_os("VIRTUAL_ENV"),env::var_os("CONDA_PREFIX")) {
+            let venv_dir = match (env::var_os("VIRTUAL_ENV"), env::var_os("CONDA_PREFIX")) {
                 (Some(dir), None) => PathBuf::from(dir),
                 (None, Some(dir)) => PathBuf::from(dir),
-                (Some(_), Some(_)) => bail!("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them"),
+                (Some(_), Some(_)) => {
+                    bail!("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them")
+                }
                 (None, None) => {
                     bail!("You need to be inside a virtualenv or conda environment to use develop (neither VIRTUAL_ENV nor CONDA_PREFIX are set)")
                 }

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -160,6 +160,7 @@ impl ModuleWriter for PathWriter {
                 fs::OpenOptions::new()
                     .create(true)
                     .write(true)
+                    .truncate(true)
                     .mode(_permissions)
                     .open(&path)
             }


### PR DESCRIPTION
Without `truncate`, reinstalling packages by `maturin develop` partially overwrites old files. Reinstalling smaller files results in broken files.