### PR TITLE
pep517: print output on build failure

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -59,14 +59,17 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     command.extend(get_config_options())
 
     print("Running `{}`".format(" ".join(command)))
-    try:
-        output = subprocess.check_output(command)
-    except subprocess.CalledProcessError as e:
-        print("Error: {}".format(e))
-        sys.exit(1)
-    sys.stdout.buffer.write(output)
     sys.stdout.flush()
-    output = output.decode(errors="replace")
+    result = subprocess.run(command, stdout=subprocess.PIPE)
+    sys.stdout.buffer.write(result.stdout)
+    sys.stdout.flush()
+    if result.returncode != 0:
+        print("Error: command {} returned non-zero exit status {}".format(
+            command,
+            result.returncode
+        ))
+        sys.exit(1)
+    output = result.stdout.decode(errors="replace")
     wheel_path = output.strip().splitlines()[-1]
     filename = os.path.basename(wheel_path)
     shutil.copy2(wheel_path, os.path.join(wheel_directory, filename))
@@ -78,14 +81,17 @@ def build_sdist(sdist_directory, config_settings=None):
     command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
 
     print("Running `{}`".format(" ".join(command)))
-    try:
-        output = subprocess.check_output(command)
-    except subprocess.CalledProcessError as e:
-        print(e)
-        sys.exit(1)
-    sys.stdout.buffer.write(output)
     sys.stdout.flush()
-    output = output.decode(errors="replace")
+    result = subprocess.run(command, stdout=subprocess.PIPE)
+    sys.stdout.buffer.write(result.stdout)
+    sys.stdout.flush()
+    if result.returncode != 0:
+        print("Error: command {} returned non-zero exit status {}".format(
+            command,
+            result.returncode
+        ))
+        sys.exit(1)
+    output = result.stdout.decode(errors="replace")
     return output.strip().splitlines()[-1]
 
 


### PR DESCRIPTION
While debugging https://github.com/PyO3/pyo3/pull/1269 I learned that if the maturin pep517 build fails, no rust compiler output is shown.

This PR reworks those functions so that build output is printed even if the `maturin pep517` invocation was unsuccessful, which makes debugging errors easier!