### PR TITLE
Complete abi3 support with PyO3 0.13

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1,5 +1,4 @@
 use crate::build_context::{BridgeModel, ProjectLayout};
-use crate::python_interpreter::Interpreter;
 use crate::BuildContext;
 use crate::CargoToml;
 use crate::Manylinux;
@@ -180,22 +179,34 @@ impl BuildOptions {
 }
 
 /// pyo3 supports building abi3 wheels if the unstable-api feature is not selected
-fn has_abi3(cargo_metadata: &Metadata) -> Result<bool> {
-    let pyo3_packages = cargo_metadata
-        .packages
+fn has_abi3(cargo_metadata: &Metadata) -> Result<Option<(u8, u8)>> {
+    let resolve = cargo_metadata
+        .resolve
+        .as_ref()
+        .context("Expected cargo to return metadata with resolve")?;
+    let pyo3_packages = resolve
+        .nodes
         .iter()
-        .filter(|package| package.name == "pyo3")
+        .filter(|package| cargo_metadata[&package.id].name == "pyo3")
         .collect::<Vec<_>>();
     match pyo3_packages.as_slice() {
         [pyo3_crate] => {
-            let root_id = cargo_metadata
-                .resolve
-                .as_ref()
-                .and_then(|resolve| resolve.root.as_ref())
-                .context("Expected cargo to return a root package")?;
-            // Check that we have a pyo3 version with abi3 and that abi3 is selected
-            Ok(pyo3_crate.features.contains_key("abi3")
-                && !cargo_metadata[&root_id].features.contains_key("abi3"))
+            // Find the minimal abi3 python version. If there is none, abi3 hasn't been selected
+            // This parser abi3-py{major}{minor} and returns the minimal (major, minor) tuple
+            Ok(pyo3_crate
+                .features
+                .iter()
+                .filter(|x| x.starts_with("abi3-py") && x.len() == "abi3-pyxx".len())
+                .map(|x| {
+                    Ok((
+                        (x.as_bytes()[7] as char).to_string().parse::<u8>()?,
+                        (x.as_bytes()[8] as char).to_string().parse::<u8>()?,
+                    ))
+                })
+                .collect::<Result<Vec<(u8, u8)>>>()
+                .context("Bogus pyo3 cargo features")?
+                .into_iter()
+                .min())
         }
         _ => bail!(format!(
             "Expected exactly one pyo3 dependency, found {}",
@@ -268,9 +279,12 @@ pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<Br
             );
         }
 
-        if has_abi3(&cargo_metadata)? {
-            println!("🔗 Found pyo3 bindings with abi3 support");
-            return Ok(BridgeModel::BindingsAbi3);
+        if let Some((major, minor)) = has_abi3(&cargo_metadata)? {
+            println!(
+                "🔗 Found pyo3 bindings with abi3 support for Python ≥ {}.{}",
+                major, minor
+            );
+            return Ok(BridgeModel::BindingsAbi3(major, minor));
         } else {
             println!("🔗 Found pyo3 bindings");
             return Ok(bridge);
@@ -315,37 +329,6 @@ pub fn find_interpreter(
 
             Ok(interpreter)
         }
-        BridgeModel::BindingsAbi3 => {
-            let interpreter = if interpreter.is_empty() {
-                // Since we do not autodetect pypy anyway, we only need one interpreter.
-                // Ideally we'd pick the lowest supported version, but there's no way to
-                // specify that yet in pyo3 yet
-                let interpreter =
-                    PythonInterpreter::check_executable(target.get_python(), &target, &bridge)
-                        .context(format_err!(err_message))?
-                        .ok_or_else(|| format_err!(err_message))?;
-                vec![interpreter]
-            } else {
-                let interpreter =
-                    PythonInterpreter::check_executables(&interpreter, &target, &bridge)
-                        .context("The given list of python interpreters is invalid")?;
-                // It's ok if there are pypy versions, but there should be either no or exactly one
-                // cpython version. We can build wheels for more since the minimum version is in
-                // the tag, but that is unnecessary
-                if interpreter
-                    .iter()
-                    .filter(|python| python.interpreter == Interpreter::CPython)
-                    .count()
-                    > 1
-                {
-                    println!("⚠ You have more than one cpython version specified when compiling with abi3, \
-                     while you only need to lowest compatible version to build a single abi3 wheel.");
-                }
-                interpreter
-            };
-
-            Ok(interpreter)
-        }
         BridgeModel::Cffi => {
             let executable = if interpreter.is_empty() {
                 target.get_python()
@@ -363,7 +346,7 @@ pub fn find_interpreter(
 
             Ok(vec![interpreter])
         }
-        BridgeModel::Bin => Ok(vec![]),
+        BridgeModel::Bin | BridgeModel::BindingsAbi3(_, _) => Ok(vec![]),
     }
 }
 
@@ -447,11 +430,11 @@ mod test {
 
         assert!(matches!(
             find_bridge(&pyo3_pure, None),
-            Ok(BridgeModel::BindingsAbi3)
+            Ok(BridgeModel::BindingsAbi3(3, 8))
         ));
         assert!(matches!(
             find_bridge(&pyo3_pure, Some("pyo3")),
-            Ok(BridgeModel::BindingsAbi3)
+            Ok(BridgeModel::BindingsAbi3(3, 8))
         ));
         assert!(find_bridge(&pyo3_pure, Some("rust-cpython")).is_err());
     }

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -430,11 +430,11 @@ mod test {
 
         assert!(matches!(
             find_bridge(&pyo3_pure, None),
-            Ok(BridgeModel::BindingsAbi3(3, 8))
+            Ok(BridgeModel::BindingsAbi3(3, 6))
         ));
         assert!(matches!(
             find_bridge(&pyo3_pure, Some("pyo3")),
-            Ok(BridgeModel::BindingsAbi3(3, 8))
+            Ok(BridgeModel::BindingsAbi3(3, 6))
         ));
         assert!(find_bridge(&pyo3_pure, Some("rust-cpython")).is_err());
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -23,7 +23,7 @@ pub fn compile(
     // TODO: What do we do when there are multiple bin targets?
     match bindings_crate {
         BridgeModel::Bin => shared_args.push("--bins"),
-        BridgeModel::Cffi | BridgeModel::Bindings(_) | BridgeModel::BindingsAbi3 => {
+        BridgeModel::Cffi | BridgeModel::Bindings(_) | BridgeModel::BindingsAbi3(_, _) => {
             shared_args.push("--lib")
         }
     }
@@ -44,7 +44,7 @@ pub fn compile(
 
     // https://github.com/PyO3/pyo3/issues/88#issuecomment-337744403
     if context.target.is_macos() {
-        if let BridgeModel::Bindings(_) | BridgeModel::BindingsAbi3 = bindings_crate {
+        if let BridgeModel::Bindings(_) | BridgeModel::BindingsAbi3(_, _) = bindings_crate {
             let mac_args = &["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"];
             rustc_args.extend(mac_args);
         }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -78,6 +78,13 @@ pub fn compile(
             build_command.env("PYO3_PYTHON", &python_interpreter.executable);
         }
 
+        if let BridgeModel::BindingsAbi3(_, _) = bindings_crate {
+            // If the target is not Windows, set PYO3_NO_PYTHON to speed up the build
+            if !context.target.is_windows() {
+                build_command.env("PYO3_NO_PYTHON", "1");
+            }
+        }
+
         // rust-cpython, and legacy pyo3 versions
         build_command.env("PYTHON_SYS_EXECUTABLE", &python_interpreter.executable);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,10 +309,11 @@ fn pep517(subcommand: PEP517Command) -> Result<()> {
             let context = build_options.into_build_context(true, strip)?;
             let tags = match context.bridge {
                 BridgeModel::Bindings(_) => {
-                    vec![context.interpreter[0].get_tag(&context.manylinux, false)]
+                    vec![context.interpreter[0].get_tag(&context.manylinux)]
                 }
-                BridgeModel::BindingsAbi3 => {
-                    vec![context.interpreter[0].get_tag(&context.manylinux, true)]
+                BridgeModel::BindingsAbi3(major, minor) => {
+                    let platform = context.target.get_platform_tag(&context.manylinux);
+                    vec![format!("cp{}{}-abi3-{}", major, minor, platform)]
                 }
                 BridgeModel::Bin | BridgeModel::Cffi => {
                     context.target.get_universal_tags(&context.manylinux).1

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -554,11 +554,22 @@ pub fn write_bindings_module(
     project_layout: &ProjectLayout,
     module_name: &str,
     artifact: &Path,
-    python_interpreter: &PythonInterpreter,
+    python_interpreter: Option<&PythonInterpreter>,
+    target: &Target,
     develop: bool,
-    abi3: bool,
 ) -> Result<()> {
-    let so_filename = python_interpreter.get_library_name(&module_name, abi3);
+    let so_filename = match python_interpreter {
+        Some(python_interpreter) => python_interpreter.get_library_name(&module_name),
+        // abi3
+        None => {
+            if target.is_freebsd() || target.is_unix() {
+                format!("{base}.abi3.so", base = module_name)
+            } else {
+                // Apparently there is no tag for abi3 on windows
+                format!("{base}.pyd", base = module_name)
+            }
+        }
+    };
 
     match project_layout {
         ProjectLayout::Mixed(ref python_module) => {

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -359,18 +359,11 @@ impl PythonInterpreter {
     /// Don't ask me why or how, this is just what setuptools uses so I'm also going to use
     ///
     /// If abi3 is true, cpython wheels use the generic abi3 with the given version as minimum
-    pub fn get_tag(&self, manylinux: &Manylinux, abi3: bool) -> String {
+    pub fn get_tag(&self, manylinux: &Manylinux) -> String {
         match self.interpreter {
             Interpreter::CPython => {
                 let platform = self.target.get_platform_tag(manylinux);
-                if abi3 {
-                    format!(
-                        "cp{major}{minor}-abi3-{platform}",
-                        major = self.major,
-                        minor = self.minor,
-                        platform = platform
-                    )
-                } else if self.target.is_unix() {
+                if self.target.is_unix() {
                     format!(
                         "cp{major}{minor}-cp{major}{minor}{abiflags}-{platform}",
                         major = self.major,
@@ -433,19 +426,12 @@ impl PythonInterpreter {
     ///
     /// The pypy3 value appears to be wrong for Windows: instead of
     /// e.g., ".pypy3-70-x86_64-linux-gnu.so", it is just ".pyd".
-    pub fn get_library_name(&self, base: &str, abi3: bool) -> String {
+    pub fn get_library_name(&self, base: &str) -> String {
         match self.interpreter {
             Interpreter::CPython => {
                 let platform = self.target.get_shared_platform_tag();
 
-                if abi3 {
-                    if self.target.is_freebsd() || self.target.is_unix() {
-                        format!("{base}.abi3.so", base = base)
-                    } else {
-                        // Apparently there is no tag for abi3 on windows
-                        format!("{base}.pyd", base = base)
-                    }
-                } else if self.target.is_freebsd() {
+                if self.target.is_freebsd() {
                     format!(
                         "{base}.cpython-{major}{minor}{abiflags}.so",
                         base = base,

--- a/test-crates/pyo3-feature/Cargo.lock
+++ b/test-crates/pyo3-feature/Cargo.lock
@@ -13,6 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cloudabi"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,24 +50,10 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
  "unindent",
 ]
 
@@ -71,7 +63,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -128,7 +120,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -139,15 +131,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0520af26d4cf99643dbbe093a61507922b57232d9978d8491fdc8f7b44573c8c"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
 name = "proc-macro2"
@@ -160,29 +146,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa4dd0cac57e3a0460cca3a549138feaf94ed04464d058d39a4820f677b49d"
+checksum = "5cdd01a4c2719dd1f3ceab0875fa1a2c2cd3c619477349d78f43cd716b345436"
 dependencies = [
+ "cfg-if 1.0.0",
  "ctor",
  "indoc",
  "inventory",
  "libc",
  "parking_lot",
  "paste",
- "pyo3cls",
+ "pyo3-macros",
  "unindent",
-]
-
-[[package]]
-name = "pyo3-derive-backend"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58eafd88c5ec9ac372bf53b364e5460a1db01af70a6b7bdae9e6798edff0dc9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -193,12 +169,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3cls"
-version = "0.12.2"
+name = "pyo3-macros"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b973ea9680c23f07f05039be464b2c55046e8ca9cd11ee09de4bffe6431c8"
+checksum = "7f8218769d13e354f841d559a19b0cf22cfd55959c7046ef594e5f34dbe46d16"
 dependencies = [
- "pyo3-derive-backend",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4da0bfdf76f0a5971c698f2cb6b3f832a6f80f16dedeeb3f123eb0431ecce2"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/test-crates/pyo3-feature/Cargo.toml
+++ b/test-crates/pyo3-feature/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.7.3"
 edition = "2018"
 
 [dependencies]
-pyo3 = { version = "0.12", optional = true }
+pyo3 = { version = "0.13", optional = true }

--- a/test-crates/pyo3-mixed/Cargo.lock
+++ b/test-crates/pyo3-mixed/Cargo.lock
@@ -13,6 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cloudabi"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,24 +50,10 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
  "unindent",
 ]
 
@@ -71,7 +63,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -128,7 +120,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -139,15 +131,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0520af26d4cf99643dbbe093a61507922b57232d9978d8491fdc8f7b44573c8c"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
 name = "proc-macro2"
@@ -160,25 +146,37 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa4dd0cac57e3a0460cca3a549138feaf94ed04464d058d39a4820f677b49d"
+checksum = "5cdd01a4c2719dd1f3ceab0875fa1a2c2cd3c619477349d78f43cd716b345436"
 dependencies = [
+ "cfg-if 1.0.0",
  "ctor",
  "indoc",
  "inventory",
  "libc",
  "parking_lot",
  "paste",
- "pyo3cls",
+ "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-derive-backend"
-version = "0.12.2"
+name = "pyo3-macros"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58eafd88c5ec9ac372bf53b364e5460a1db01af70a6b7bdae9e6798edff0dc9"
+checksum = "7f8218769d13e354f841d559a19b0cf22cfd55959c7046ef594e5f34dbe46d16"
+dependencies = [
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4da0bfdf76f0a5971c698f2cb6b3f832a6f80f16dedeeb3f123eb0431ecce2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -190,17 +188,6 @@ name = "pyo3-mixed"
 version = "2.1.1"
 dependencies = [
  "pyo3",
-]
-
-[[package]]
-name = "pyo3cls"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b973ea9680c23f07f05039be464b2c55046e8ca9cd11ee09de4bffe6431c8"
-dependencies = [
- "pyo3-derive-backend",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 get_42 = "pyo3_mixed:get_42"
 
 [dependencies]
-pyo3 = { version = "0.12", features = ["extension-module"] }
+pyo3 = { version = "0.13", features = ["extension-module"] }
 
 [lib]
 name = "pyo3_mixed"

--- a/test-crates/pyo3-pure/Cargo.lock
+++ b/test-crates/pyo3-pure/Cargo.lock
@@ -13,6 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cloudabi"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,24 +50,10 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
  "unindent",
 ]
 
@@ -71,7 +63,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -128,7 +120,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -139,28 +131,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
 
 [[package]]
 name = "proc-macro2"
@@ -173,23 +146,37 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdd01a4c2719dd1f3ceab0875fa1a2c2cd3c619477349d78f43cd716b345436"
 dependencies = [
+ "cfg-if 1.0.0",
  "ctor",
  "indoc",
  "inventory",
  "libc",
  "parking_lot",
  "paste",
- "pyo3cls",
+ "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-derive-backend"
-version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
+name = "pyo3-macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8218769d13e354f841d559a19b0cf22cfd55959c7046ef594e5f34dbe46d16"
+dependencies = [
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4da0bfdf76f0a5971c698f2cb6b3f832a6f80f16dedeeb3f123eb0431ecce2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,16 +188,6 @@ name = "pyo3-pure"
 version = "2.1.0"
 dependencies = [
  "pyo3",
-]
-
-[[package]]
-name = "pyo3cls"
-version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
-dependencies = [
- "pyo3-derive-backend",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/test-crates/pyo3-pure/Cargo.lock
+++ b/test-crates/pyo3-pure/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.12.3"
+source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
 dependencies = [
  "ctor",
  "indoc",
@@ -188,6 +189,7 @@ dependencies = [
 [[package]]
 name = "pyo3-derive-backend"
 version = "0.12.3"
+source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -204,6 +206,7 @@ dependencies = [
 [[package]]
 name = "pyo3cls"
 version = "0.12.3"
+source = "git+https://github.com/PyO3/pyo3?branch=konstin-abi3#bf0dccb7efd5d05f68f72a195b1d4bd47956c8d9"
 dependencies = [
  "pyo3-derive-backend",
  "quote",

--- a/test-crates/pyo3-pure/Cargo.lock
+++ b/test-crates/pyo3-pure/Cargo.lock
@@ -174,7 +174,6 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?rev=3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1#3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1"
 dependencies = [
  "ctor",
  "indoc",
@@ -189,7 +188,6 @@ dependencies = [
 [[package]]
 name = "pyo3-derive-backend"
 version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?rev=3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1#3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -206,7 +204,6 @@ dependencies = [
 [[package]]
 name = "pyo3cls"
 version = "0.12.3"
-source = "git+https://github.com/PyO3/pyo3?rev=3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1#3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1"
 dependencies = [
  "pyo3-derive-backend",
  "quote",

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -10,8 +10,7 @@ edition = "2018"
 get_42 = "pyo3_pure:DummyClass.get_42"
 
 [dependencies]
-#pyo3 = { git = "https://github.com/PyO3/pyo3", branch = "abi3-min-python", features = ["extension-module", "abi3-py38"] }
-pyo3 = { path = "../../../pyo3", features = ["extension-module", "abi3-py38"] }
+pyo3 = { git = "https://github.com/PyO3/pyo3", branch = "konstin-abi3", features = ["extension-module", "abi3-py38"] }
 
 [lib]
 name = "pyo3_pure"

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 get_42 = "pyo3_pure:DummyClass.get_42"
 
 [dependencies]
-pyo3 = { git = "https://github.com/PyO3/pyo3", branch = "konstin-abi3", features = ["extension-module", "abi3-py38"] }
+pyo3 = "0.13"
 
 [lib]
 name = "pyo3_pure"

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2018"
 get_42 = "pyo3_pure:DummyClass.get_42"
 
 [dependencies]
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "3b3ba4e3abd57bc3b8f86444b3f61e6e2f4c5fc1", features = ["extension-module", "abi3"] }
+#pyo3 = { git = "https://github.com/PyO3/pyo3", branch = "abi3-min-python", features = ["extension-module", "abi3-py38"] }
+pyo3 = { path = "../../../pyo3", features = ["extension-module", "abi3-py38"] }
 
 [lib]
 name = "pyo3_pure"

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 get_42 = "pyo3_pure:DummyClass.get_42"
 
 [dependencies]
-pyo3 = "0.13"
+pyo3 = { version = "0.13", features = ["abi3-py36", "extension-module"] }
 
 [lib]
 name = "pyo3_pure"


### PR DESCRIPTION
Built on #383.
- Update PyO3
- Set `PYO3_NO_PYTHON` if the target is not Windows for speeding up the build
  - I think this is OK but please let me know if you have another idea

BTW, I was planning of adding an option that changes the tag name to `cp3-abi3-...`.
But now I'm sad to know that it actually does not work with pip 😢. See https://github.com/pypa/packaging/issues/261 for more.