### PR TITLE
Add support for Apple Silicon macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc77a3fc329982cbf3ea772aa265b742a550998bad65747c630406ee52dac425"
+checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 
 [[package]]
 name = "podio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ goblin = "0.2.3"
 human-panic = { version = "1.0.3", optional = true }
 keyring = { version = "0.9.0", optional = true }
 platform-info = "0.0.1"
-platforms = "1.0.3"
+platforms = "1.1.0"
 pretty_env_logger = { version = "0.4.0", optional = true }
 regex = "1.3.9"
 reqwest = { version = "0.10.8", optional = true, default-features = false, features = ["blocking"] }

--- a/src/target.rs
+++ b/src/target.rs
@@ -133,7 +133,6 @@ impl Target {
                     Err(error) => bail!(error),
                 };
             }
-            (OS::Macos, Arch::AARCH64) => bail!("aarch64 is not supported for macOS"),
             (OS::Macos, Arch::ARMV7L) => bail!("armv7l is not supported for macOS"),
             (OS::Macos, Arch::X86) => bail!("32-bit wheels are not supported for macOS"),
             (OS::Windows, Arch::AARCH64) => bail!("aarch64 is not supported for Windows"),
@@ -193,6 +192,7 @@ impl Target {
             }
             (OS::Linux, _) => format!("{}_{}", manylinux, self.arch),
             (OS::Macos, Arch::X86_64) => "macosx_10_7_x86_64".to_string(),
+            (OS::Macos, Arch::AARCH64) => "macosx_11_0_arm64".to_string(),
             (OS::Windows, Arch::X86) => "win32".to_string(),
             (OS::Windows, Arch::X86_64) => "win_amd64".to_string(),
             (_, _) => panic!("unsupported target should not have reached get_platform_tag()"),
@@ -215,6 +215,7 @@ impl Target {
             (OS::Linux, Arch::X86) => "i386-linux-gnu", // not i686
             (OS::Linux, Arch::X86_64) => "x86_64-linux-gnu",
             (OS::Macos, Arch::X86_64) => "darwin",
+            (OS::Macos, Arch::AARCH64) => "darwin",
             (OS::Windows, Arch::X86) => "win32",
             (OS::Windows, Arch::X86_64) => "win_amd64",
             (OS::Macos, _) => {


### PR DESCRIPTION
This PR adds support for building and developing PyO3 extensions in macOS on Apple Silicon (aarch64-apple-darwin). 
Before this PR, maturin gives out an error while guessing the current architecture on arm64 mac. 

This PR includes:

- Updates `platforms` crate to 1.1.0 to include support for Apple Silicon macOS: https://github.com/RustSec/platforms-crate/pull/32
- Sets Python Wheel filename with binary format string `macosx_11_0_arm64`, ref: https://github.com/pypa/packaging/pull/319
- Leaves the native extension suffix as it is `darwin`, ref: https://docs.python.org/3/whatsnew/3.5.html#build-and-c-api-changes

This PR does NOT include Universal 2 binary format support, and only produces native arm64 binary wheels on M1 machines.

A screenshot of before and after:

<img width="1199" alt="Screen Shot 2020-12-29 at 12 01 35 AM" src="https://user-images.githubusercontent.com/10568668/103227333-11905f00-4969-11eb-8fce-8ac876e0a2a3.png">


---

<details>

```
The target whl filename will include binary format string
`macosx_11_0_arm64` as indicated in the CPython packaging PR that added
support for Apple Silicon: https://github.com/pypa/packaging/pull/319

The dot so file will have the same extension suffix as x86_64 darwin,
specified at
https://docs.python.org/3/whatsnew/3.5.html#build-and-c-api-changes

Updated `platforms` crates to 1.1.0 to include the PR for apple silicon
support, so that guessing platform will not throw an unsupported error.
Ref: https://github.com/RustSec/platforms-crate/pull/32

Signed-off-by: LER0ever <i+git@rongyi.io>
```

</details>
