### PR TITLE
Fix building bin bindings on Apple Silicon

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -258,6 +258,7 @@ pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<Br
         if bindings == "cffi" {
             BridgeModel::Cffi
         } else if bindings == "bin" {
+            println!("🔗 Found bin bindings");
             BridgeModel::Bin
         } else {
             if !deps.contains_key(bindings) {


### PR DESCRIPTION
#403 breaks bin bindings on Apple Silicon Mac machines, found out when trying to use maturin to build [py-spy](https://github.com/benfred/py-spy)