### PR TITLE
Provide modern CMake in the docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,14 @@ RUN cargo rustc --bin maturin --manifest-path /maturin/Cargo.toml --release -- -
     && mv /maturin/target/release/maturin /usr/bin/maturin \
     && rm -rf /maturin
 
+ADD https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1.tar.gz .
+RUN tar -xf cmake-3.19.1.tar.gz && \
+    cd cmake-3.19.1 && \
+    ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF && \
+    make -j8 install && \
+    cd .. && \
+    rm -r cmake*
+
 WORKDIR /io
 
 ENTRYPOINT ["/usr/bin/maturin"]


### PR DESCRIPTION
Hi!  Thanks for your work on `maturin`.

I have a [Rust package](https://github.com/MWATelescope/mwa_hyperbeam) that depends on the HDF5 library (usable with the [hdf5 crate](https://github.com/aldanor/hdf5-rust)). Because of manylinux compliance, I can't ship the Python wheel that I compile with `maturin`, as it would depend on a specific version of the HDF5 C library. However, the `hdf5` crate allows one to statically compile the HDF5 C library into Rust packages (great!). This would "just work", except that to build `hdf5` this way, it relies on the system having `CMake` > 3.10 available.

Looking at the CentOS image that the `maturin` docker images is based off of (6?), the most recent version `CMake` available in the repos is much older than 3.10.  This commit adds code to download and compile `CMake` 3.19 from source.  It may be convenient to other users of the `maturin` docker image to have this available by default, hence this PR.

I'm happy for the `CMake` version to be backed off a bit, if there are opinions on that. Perhaps more importantly, though, I couldn't get `CMake` to compile without `-DCMAKE_USE_OPENSSL=OFF`.  I'm not sure of all of the ramifications of doing this, but maybe this could be easily fixed?