### PR TITLE
Fix build on FreeBSD on powerpc*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PostInstallCommand(install):
 
             cargo_args = [cargo, "rustc", "--bin", "maturin", "--message-format=json"]
 
-            if platform.machine() in ("ppc64le", "ppc64"):
+            if platform.machine() in ("ppc64le", "ppc64", "powerpc"):
                 cargo_args.extend(
                     ["--no-default-features", "--features=auditwheel,log,human-panic"]
                 )


### PR DESCRIPTION
FreeBSD uses powerpc64 and powerpc64le names for 64-bit POWER architecture.

However, they are actually subarchitectures of powerpc architecture, and Python returns powerpc,
even on 64-bits:
>>> platform.machine()
'powerpc'

The more correct way to check for architecture would be:
>>> platform.processor()
'powerpc64le'