### PR TITLE
Build aarch64 musl wheel on GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,22 @@ jobs:
           file: '*.{tar.gz,zip,deb}'
           file_glob: true
           tag: ${{ github.ref }}
+
+  release-musl-github-pypi:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ aarch64-musl ]
+    container:
+      image: docker://benfred/rust-musl-cross:${{ matrix.target }}
+      env:
+        RUSTUP_HOME: /root/.rustup
+        CARGO_HOME: /root/.cargo
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish wheel
+        env:
+          MATURIN_PASSWORD: ${{ secrets.MATURIN_PASSWORD }}
+        run: |
+          sudo python3 -m pip install maturin
+          maturin publish -u __token__ -b bin --no-sdist -o dist --target aarch64-unknown-linux-musl --manylinux 2014


### PR DESCRIPTION
You can try the aarch64 wheel built in https://github.com/messense/maturin/actions/runs/573701516,
download link: https://github.com/messense/maturin/suites/2056522682/artifacts/41476397

Inspired by py-spy: https://github.com/benfred/py-spy/blob/master/.github/workflows/build.yml