### PR TITLE
Refactor target triple handling

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -126,10 +126,7 @@ impl BuildOptions {
 
         let project_layout = ProjectLayout::determine(manifest_dir, &module_name)?;
 
-        let mut cargo_extra_args = split_extra_args(&self.cargo_extra_args)?;
-        if let Some(target) = self.target.clone() {
-            cargo_extra_args.extend_from_slice(&["--target".to_string(), target]);
-        }
+        let cargo_extra_args = split_extra_args(&self.cargo_extra_args)?;
 
         let cargo_metadata_extra_args = extra_feature_args(&cargo_extra_args);
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -28,7 +28,7 @@ pub fn compile(
             context,
             python_interpreter,
             bindings_crate,
-            Some("aarch64-apple-darwin"),
+            "aarch64-apple-darwin",
         )
         .context("Failed to build a aarch64 library through cargo")?
         .get(build_type)
@@ -47,7 +47,7 @@ pub fn compile(
             context,
             python_interpreter,
             bindings_crate,
-            Some("x86_64-apple-darwin"),
+            "x86_64-apple-darwin",
         )
         .context("Failed to build a x86_64 library through cargo")?
         .get(build_type)
@@ -85,7 +85,12 @@ pub fn compile(
         result.insert(build_type.to_string(), PathBuf::from(output_path));
         Ok(result)
     } else {
-        compile_target(context, python_interpreter, bindings_crate, None)
+        compile_target(
+            context,
+            python_interpreter,
+            bindings_crate,
+            context.target.target_triple(),
+        )
     }
 }
 
@@ -93,7 +98,7 @@ fn compile_target(
     context: &BuildContext,
     python_interpreter: Option<&PythonInterpreter>,
     bindings_crate: &BridgeModel,
-    target: Option<&str>,
+    target: &str,
 ) -> Result<HashMap<String, PathBuf>> {
     let mut shared_args = vec!["--manifest-path", context.manifest_path.to_str().unwrap()];
 
@@ -102,10 +107,8 @@ fn compile_target(
     if context.release {
         shared_args.push("--release");
     }
-    if let Some(target) = target {
-        shared_args.push("--target");
-        shared_args.push(target);
-    }
+    shared_args.push("--target");
+    shared_args.push(target);
 
     let mut rustc_args: Vec<&str> = context
         .rustc_extra_args

--- a/src/target.rs
+++ b/src/target.rs
@@ -82,6 +82,7 @@ pub struct Target {
     os: OS,
     arch: Arch,
     env: Option<Env>,
+    triple: &'static str,
 }
 
 impl Target {
@@ -145,6 +146,7 @@ impl Target {
             os,
             arch,
             env: platform.target_env,
+            triple: platform.target_triple,
         })
     }
 
@@ -158,6 +160,11 @@ impl Target {
             Arch::X86 => 32,
             Arch::X86_64 => 64,
         }
+    }
+
+    /// Returns target triple string
+    pub fn target_triple(&self) -> &str {
+        &self.triple
     }
 
     /// Returns true if the current platform is linux or mac os


### PR DESCRIPTION
Currently `maturin build --target xxx --universal2` would results in two `--target xxx` passed to `cargo rustc` which errored with:

```
error: specifying multiple `--target` flags requires `-Zmultitarget`
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Failed to build a aarch64 library through cargo
  Caused by: Cargo build finished with "exit code: 101": `cargo rustc --message-format json --manifest-path Cargo.toml --target x86_64-apple-darwin --release --target aarch64-apple-darwin --bins --`
```

This patch changes how `target` is passed to `compile_target` function by remove it from `cargo_extra_args` and pass it directly into `compile_target` function.