### PR TITLE
Remove redundant Content-Type header field

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -88,10 +88,6 @@ pub fn upload(
     let response = client
         .post(registry.url.clone())
         .header(
-            reqwest::header::CONTENT_TYPE,
-            "application/json; charset=utf-8",
-        )
-        .header(
             reqwest::header::USER_AGENT,
             format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
         )


### PR DESCRIPTION
When a Form is being submitted

    content-type: multipart/form-data; ...

header field is added automatically by reqwest.

Multiple Content-Type header fields are explicitly
forbidden by the HTTP standard.

GitLab CI/CD has its own PyPI repo implementation not based on warehouse
and it rejects `maturin publish` HTTP POSTs with "400 Bad request".
Uploading with twine works with their PyPI repos.

Example malformed header:

```
POST /api HTTP/1.1                                                                         
content-type: application/json; charset=utf-8                                              
content-type: multipart/form-data; boundary=80af855856470fd9-fb8863f69240e724-9ec3dea5c4f8a82e-643e4dc328c898c8 
user-agent: maturin/0.9.4                                                                                       
authorization: Basic X190b2tlbl9fOlVLM3JldjlHMlhDYnZkeUZvWkt3                     
content-length: 348349                                                                     
accept: */*                                                                                                     
host: 127.0.0.1:8080                                                                                            
                                                                                                                
```