### PR TITLE
Add a workaround for the GitLab PyPI API implementation

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -105,6 +105,12 @@ pub fn upload(registry: &Registry, wheel_path: &Path) -> Result<(), UploadError>
     add_option("requires_python", &metadata.requires_python);
     add_option("summary", &metadata.summary);
 
+    if metadata.requires_python.is_none() {
+        // GitLab PyPI repository API implementation requires this metadata field
+        // and twine always includes it in the request, even when it's empty.
+        api_metadata.push(("requires_python", "".to_string()));
+    }
+
     let mut add_vec = |name, values: &[String]| {
         for i in values {
             api_metadata.push((name, i.clone()));


### PR DESCRIPTION
GitLab includes its own PyPI upload API implementation
that is not based on Warehouse.
It insists that "requires_python" metadata field must
always be sent, even when it's empty.

The package upload to GitLab PyPI fails with:

    400 Bad Request: {"error":"requires_python is missing"}

when it's not included in the request.

The official API reference does not mandate this, though:

    https://warehouse.readthedocs.io/api-reference/legacy.html

Unfortunately, twine always includes these metadata fields
in its requests, even when they are empty, and the GitLab
API implementation happened to depend on this.

Add a workaround that mimics twine behavior and silently
provides "requires_python" field even when the package
developers do not define "Requires-Python".