### PR TITLE
Fix `sdist-include` for PEP 517 compliant packages

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -101,11 +101,12 @@ pub fn source_distribution(
     if let Some(include_targets) = sdist_include {
         for pattern in include_targets {
             println!("📦 Including files matching \"{}\"", pattern);
-            for source in glob::glob(pattern)
+            for source in glob::glob(&manifest_dir.join(pattern).to_string_lossy())
                 .expect("No files found for pattern")
                 .filter_map(Result::ok)
             {
-                writer.add_file(manifest_dir.join(&source).to_path_buf(), source)?;
+                let target = root_dir.join(&source.strip_prefix(manifest_dir)?);
+                writer.add_file(target, source)?;
             }
         }
     }


### PR DESCRIPTION
Hey there!

This PR fixes the following issues:
- As of commit 036fff7adb9ce08fa7a31778aa39be53e25e1641, when building a source distribution the files are placed in a folder `{NAME}-{VERSION}` as required by PEP 517. However, this has not been the case for additional files included via `sdist-include`. With this PR, those additional files are placed inside the `{NAME}-{VERSION}` directory as well.
- The previous usage of `glob` did not search for files relative to `manifest_dir` (at least as far as I can tell).
- It seems like `target` and `source` have previously been been swapped when adding files with `add_file`.