### PR TITLE
Respect CARGO_BUILD_TARGET environment variable

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -58,7 +58,7 @@ pub struct BuildOptions {
     #[structopt(long = "skip-auditwheel")]
     pub skip_auditwheel: bool,
     /// The --target option for cargo
-    #[structopt(long, name = "TRIPLE")]
+    #[structopt(long, name = "TRIPLE", env = "CARGO_BUILD_TARGET")]
     pub target: Option<String>,
     /// Extra arguments that will be passed to cargo as `cargo rustc [...] [arg1] [arg2] --`
     ///


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/environment-variables.html

> CARGO_BUILD_TARGET — The default target platform

`cargo rustc` will use it automatically if set but maturin isn't aware of it so maturin creates wrong manylinux wheel for the host target not the specified target.