### PR TITLE
Add --skip-existing option to publish

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Change manylinux default version based on target arch by messense in [#424](https://github.com/PyO3/maturin/pull/424)
  * Support local path dependencies in source distribution (i.e. you can now package a workspace into an sdist)
  * Set a more reasonable LC_ID_DYLIB entry on macOS by messense [#433](https://github.com/PyO3/maturin/pull/433)
+ * Add `--skip-existing` option to publish by messense [#444](https://github.com/PyO3/maturin/pull/444)
 
 ## 0.9.4 - 2021-02-18
 

--- a/Readme.md
+++ b/Readme.md
@@ -277,6 +277,10 @@ FLAGS:
         --skip-auditwheel
             Don't check for manylinux compliance
 
+        --skip-existing
+            Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other implementations
+            may not support this.)
+
         --universal2
             Control whether to build universal2 wheel for macOS or not. Only applies to macOS targets, do nothing
             otherwise


### PR DESCRIPTION
Without `--skip-existing`

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.6
🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
    Finished release [optimized] target(s) in 0.05s
📦 Built wheel for abi3 Python ≥ 3.6 to /Users/messense/Projects/rjieba-py/target/wheels/rjieba-0.1.7-cp36-abi3-macosx_10_7_x86_64.whl
📦 Built source distribution to /Users/messense/Projects/rjieba-py/target/wheels/rjieba-0.1.7.tar.gz
🚀 Uploading 2 packages
💥 maturin failed
  Caused by: 💥 Failed to upload "rjieba-0.1.7-cp36-abi3-macosx_10_7_x86_64.whl" (2.8 MB)
  Caused by: File already exists: <html>
 <head>
  <title>400 File already exists. See https://pypi.org/help/#file-name-reuse for more information.</title>
 </head>
 <body>
  <h1>400 File already exists. See https://pypi.org/help/#file-name-reuse for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
File already exists. See https://pypi.org/help/#file-name-reuse for more information.


 </body>
</html>
```

With `--skip-existing`

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.6
🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
    Finished release [optimized] target(s) in 0.07s
📦 Built wheel for abi3 Python ≥ 3.6 to /Users/messense/Projects/rjieba-py/target/wheels/rjieba-0.1.7-cp36-abi3-macosx_10_7_x86_64.whl
📦 Built source distribution to /Users/messense/Projects/rjieba-py/target/wheels/rjieba-0.1.7.tar.gz
🚀 Uploading 2 packages
⚠  Skipping "rjieba-0.1.7-cp36-abi3-macosx_10_7_x86_64.whl" because it appears to already exist
⚠  Skipping "rjieba-0.1.7.tar.gz" because it appears to already exist
✨ Packages uploaded successfully
```

Closes #354 