### PR TITLE
 Fix rewriting of path dependencies and include only path dependencies of root crate

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -3,7 +3,6 @@ use crate::{Metadata21, SDistWriter};
 use anyhow::{bail, format_err, Context, Result};
 use cargo_metadata::Metadata;
 use fs_err as fs;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Hey there!

This PR contains the following changes:
- ~~A fix for issue #449.~~ It seems like it fixed only a similar problem for me.
- It correctly rewrites the path to path dependencies of path dependencies. Previously these paths have been rewritten relative to the root directory of the source distribution causing Cargo not to find them on installation. 
- It changes the way path dependencies are collected. In particular, the new method only collects path dependencies of the actual root crate (and their path dependencies) but not all path dependencies of the Cargo workspace.