### PR TITLE
Add basic support for OpenBSD

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -582,7 +582,7 @@ pub fn write_bindings_module(
         Some(python_interpreter) => python_interpreter.get_library_name(&module_name),
         // abi3
         None => {
-            if target.is_freebsd() || target.is_unix() {
+            if target.is_freebsd() || target.is_unix() || target.is_openbsd() {
                 format!("{base}.abi3.so", base = module_name)
             } else {
                 // Apparently there is no tag for abi3 on windows

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -312,6 +312,7 @@ fn fun_with_abiflags(
             "linux" => target.is_linux(),
             "darwin" => target.is_macos(),
             "freebsd" => target.is_freebsd(),
+            "openbsd" => target.is_openbsd(),
             _ => false,
         };
 
@@ -436,7 +437,7 @@ impl PythonInterpreter {
                         minor = self.minor,
                         abiflags = self.abiflags,
                     )
-                } else if self.target.is_unix() {
+                } else if self.target.is_unix() || self.target.is_openbsd() {
                     format!(
                         "{base}.cpython-{major}{minor}{abiflags}-{platform}.so",
                         base = base,


### PR DESCRIPTION
This adds basic support for OpenBSD targets. I was able to compile python-adblock with this. 

However building on OpenBSD with `pip3 install` fails because of some linking error. 
Compiling with `cargo build --manifest-path Cargo.toml --bin maturin` works. 
Would it be okay to patch `setup.py` to use a `cargo build --manifest-path Cargo.toml --bin maturin` instead
when building on OpenBSD?