### PR TITLE
Look for python interpreters in PATH before invoking them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "walkdir",
+ "which",
  "zip",
 ]
 
@@ -2237,6 +2238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ fat-macho = "0.4.2"
 toml_edit = "0.2.0"
 once_cell = "1.5.2"
 scroll = "0.10.2"
+which = "4.0.2"
 
 [dev-dependencies]
 indoc = "1.0.2"

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -473,10 +473,15 @@ impl PythonInterpreter {
         target: &Target,
         bridge: &BridgeModel,
     ) -> Result<Option<PythonInterpreter>> {
-        let output = Command::new(&executable.as_ref())
-            .args(&["-c", GET_INTERPRETER_METADATA])
-            .stderr(Stdio::inherit())
-            .output();
+        let output = match which::which(&executable.as_ref()) {
+            Ok(path) => Command::new(path)
+                .args(&["-c", GET_INTERPRETER_METADATA])
+                .stderr(Stdio::inherit())
+                .output(),
+            Err(_err) => {
+                return Ok(None);
+            }
+        };
 
         let err_msg = format!(
             "Trying to get metadata from the python interpreter '{}' failed",


### PR DESCRIPTION
Fixes https://github.com/PyO3/maturin/issues/470.