### PR TITLE
Allow building mixed projects with __init__.pyi file

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -66,8 +66,10 @@ impl ProjectLayout {
     pub fn determine(project_root: impl AsRef<Path>, module_name: &str) -> Result<ProjectLayout> {
         let python_package_dir = project_root.as_ref().join(module_name);
         if python_package_dir.is_dir() {
-            if !python_package_dir.join("__init__.py").is_file() {
-                bail!("Found a directory with the module name ({}) next to Cargo.toml, which indicates a mixed python/rust project, but the directory didn't contain an __init__.py file.", module_name)
+            if !python_package_dir.join("__init__.py").is_file()
+                && !python_package_dir.join("__init__.pyi").is_file()
+            {
+                bail!("Found a directory with the module name ({}) next to Cargo.toml, which indicates a mixed python/rust project, but the directory didn't contain an __init__.{{py,pyi}} file.", module_name)
             }
 
             println!("🍹 Building a mixed python/rust project");


### PR DESCRIPTION
This makes it possible to hand author a pyi stub file for the root module until we have something like https://github.com/PyO3/pyo3/issues/510.