### PR TITLE
Upload aarch64/armv7/i686 artifacts to github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,3 +156,12 @@ jobs:
         run: |
           sudo python3 -m pip install maturin
           maturin publish -u __token__ -b bin --no-sdist -o dist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
+      - name: Archive binary
+        run: tar czvf target/release/maturin.tar.gz -C target/${{ matrix.platform.target }}/release maturin
+      - name: Upload to gitHub release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          asset_name: maturin-${{ matrix.platform.target }}.tar.gz
+          file: target/release/maturin.tar.gz
+          tag: ${{ github.ref }}


### PR DESCRIPTION
I mostly just want the aarch64 release in https://github.com/messense/manylinux2014-cross-arm/commit/2e2c9a14926069d3a8f2e9e0cc8c6b49f329ec4c