### PR TITLE
Remove unused interpreter metadata message fields

### DIFF
--- a/src/get_interpreter_metadata.py
+++ b/src/get_interpreter_metadata.py
@@ -10,9 +10,6 @@ metadata = {
     "interpreter": platform.python_implementation().lower(),
     "ext_suffix": sysconfig.get_config_var("EXT_SUFFIX"),
     "abi_tag": (sysconfig.get_config_var("SOABI") or "-").split("-")[1] or None,
-    "m": sysconfig.get_config_var("WITH_PYMALLOC") == 1,
-    "u": sysconfig.get_config_var("Py_UNICODE_SIZE") == 4,
-    "d": sysconfig.get_config_var("Py_DEBUG") == 1,
     # This one isn't technically necessary, but still very useful for sanity checks
     "platform": platform.system().lower(),
     # We need this one for windows abi3 builds

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -2,7 +2,7 @@ use crate::Target;
 use crate::{BridgeModel, Manylinux};
 use anyhow::{bail, format_err, Context, Result};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashSet;
 use std::fmt;
 use std::io;
@@ -248,16 +248,13 @@ impl fmt::Display for InterpreterKind {
 }
 
 /// The output format of [GET_INTERPRETER_METADATA]
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 struct IntepreterMetadataMessage {
     major: usize,
     minor: usize,
     abiflags: Option<String>,
     interpreter: String,
     ext_suffix: Option<String>,
-    m: bool,
-    u: bool,
-    d: bool,
     platform: String,
     abi_tag: Option<String>,
     base_prefix: String,


### PR DESCRIPTION
`Py_UNICODE_SIZE` is obsolete since CPython 3.3.
"m" and "d" are duplicated in "abi_tag".

No need to derive Serialize for the message struct.