### PR TITLE
Make `BuiltWheelMetadata` type public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,7 @@
 #![deny(missing_docs)]
 
 pub use crate::auditwheel::{auditwheel_rs, AuditWheelError};
-pub use crate::build_context::BridgeModel;
-pub use crate::build_context::BuildContext;
+pub use crate::build_context::{BridgeModel, BuildContext, BuiltWheelMetadata};
 pub use crate::build_options::BuildOptions;
 pub use crate::cargo_toml::CargoToml;
 pub use crate::compile::compile;


### PR DESCRIPTION
Document the tuple structure and re-export it from the library crate.

Reason:
I'm working on the implementation of `maturin upload` command,
but then decided that this patch requires a separate PR.