### PR TITLE
Add public `get_supported_version_for_distribution()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ pub use crate::module_writer::{
     write_dist_info, ModuleWriter, PathWriter, SDistWriter, WheelWriter,
 };
 pub use crate::python_interpreter::PythonInterpreter;
-pub use crate::read_distribution::get_metadata_for_distribution;
+pub use crate::read_distribution::{
+    get_metadata_for_distribution, get_supported_version_for_distribution,
+};
 pub use crate::target::Target;
 pub use auditwheel::Manylinux;
 pub use source_distribution::{get_pyproject_toml, source_distribution};


### PR DESCRIPTION
The new function extracts the supported Python version tag (aka "pyversion")
from the wheel file name.

Factor out the common filename parsing code into a function.

This new public API was needed to implement "maturin upload" command.
I split it out from the upload command branch to make the code review easier.