### PR TITLE
Implement `maturin upload` command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (for the cli, not for the crate).
 
+## Unreleased
+
+ * The `upload` command is now implemented, it is mostly similar to `twine upload`. [#484](https://github.com/PyO3/maturin/pull/484)
+
 ## 0.10.2 - 2021-04-03
 
  * Fix `--target` being silently ignored

--- a/Readme.md
+++ b/Readme.md
@@ -373,6 +373,44 @@ OPTIONS:
             Use as `--rustc-extra-args="--my-arg"`
 ```
 
+### Upload
+
+```
+Uploads python packages to pypi
+
+It is mostly similar to `twine upload`, but can only upload python wheels and source distributions.
+
+USAGE:
+    maturin upload [FLAGS] [OPTIONS] [FILE]...
+
+FLAGS:
+    -h, --help
+            Prints help information
+
+        --skip-existing
+            Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other implementations
+            may not support this.)
+    -V, --version
+            Prints version information
+
+
+OPTIONS:
+    -p, --password <password>
+            Password for pypi or your custom registry. Note that you can also pass the password through MATURIN_PASSWORD
+
+    -r, --repository-url <registry>
+            The url of registry where the wheels are uploaded to [default: https://upload.pypi.org/legacy/]
+
+    -u, --username <username>
+            Username for pypi or your custom registry
+
+
+ARGS:
+    <FILE>...
+            The python packages to upload
+
+```
+
 ## Code
 
 The main part is the maturin library, which is completely documented and should be well integrable. The accompanying `main.rs` takes care username and password for the pypi upload and otherwise calls into the library.


### PR DESCRIPTION
It behaves like `twine upload`, but is restricted to the python wheels and source distributions.

The upload command mostly reuses the publish command implementation.