### PR TITLE
Only run pyo3_no_extension_module test on glibc Linux

### DIFF
--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -27,7 +27,7 @@ pub fn abi3_without_version() -> Result<()> {
 }
 
 /// Check that you get a good error message if you forgot to set the extension-module feature
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub fn pyo3_no_extension_module() -> Result<()> {
     // The first argument is ignored by clap
     let cli = vec![

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -79,7 +79,7 @@ fn abi3_without_version() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 fn pyo3_no_extension_module() {
     handle_result(errors::pyo3_no_extension_module())
 }


### PR DESCRIPTION
This test case relies on auditwheel which is not supported on musl libc based Linux distributions for example alpine.

cc @omnivagant