### PR TITLE
Support relative readme path on Windows

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -100,10 +100,10 @@ impl Default for BuildOptions {
 impl BuildOptions {
     /// Tries to fill the missing metadata for a BuildContext by querying cargo and python
     pub fn into_build_context(self, release: bool, strip: bool) -> Result<BuildContext> {
-        let manifest_file = self
-            .manifest_path
-            .canonicalize()
-            .context(format_err!("Can't find {}", self.manifest_path.display()))?;
+        let manifest_file = &self.manifest_path;
+        if !manifest_file.exists() {
+            bail!("Can't find {}", self.manifest_path.display(),);
+        }
 
         if !manifest_file.is_file() {
             bail!(
@@ -111,7 +111,7 @@ impl BuildOptions {
                 self.manifest_path.display(),
                 manifest_file.display()
             );
-        };
+        }
 
         let cargo_toml = CargoToml::from_path(&manifest_file)?;
         let manifest_dir = manifest_file.parent().unwrap();

--- a/test-crates/hello-world/Cargo.toml
+++ b/test-crates/hello-world/Cargo.toml
@@ -3,5 +3,6 @@ name = "hello-world"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
 edition = "2018"
+readme = "../../Readme.md"
 
 [dependencies]

--- a/test-dockerfile.sh
+++ b/test-dockerfile.sh
@@ -13,7 +13,7 @@ source venv-docker/bin/activate
 
 venv-docker/bin/pip install -U pip cffi
 
-docker run -e RUST_BACKTRACE=1 --rm -v $(pwd)/test-crates/hello-world:/io maturin build --no-sdist -b bin
+docker run -e RUST_BACKTRACE=1 --rm -v $(pwd):/io -w /io/test-crates/hello-world maturin build --no-sdist -b bin
 
 venv-docker/bin/pip install hello-world --no-index --find-links test-crates/hello-world/target/wheels/
 


### PR DESCRIPTION
Windows `canonicalize`d UNC path does not support `..`, See https://github.com/rust-lang/rust/issues/76586#issuecomment-691483495

Fixes #509 