### PR TITLE
Forbid caret in requires-python

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.8
       - name: Build Docker container
         run: |
-          docker pull konstin2/maturin
-          docker build --cache-from konstin2/maturin -t maturin .
+          docker pull konstin2/maturin:main
+          docker build --cache-from konstin2/maturin:main -t maturin .
       - name: Test the Docker container
         run: ./test-dockerfile.sh

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -230,7 +230,7 @@ impl BuildOptions {
 /// minimum supported python minor version for interpreter search
 fn get_min_python_minor(metadata21: &Metadata21) -> Option<usize> {
     if let Some(requires_python) = &metadata21.requires_python {
-        let regex = Regex::new(r#"(?:\^|>=)3\.(\d+)(?:\.\d)?"#).unwrap();
+        let regex = Regex::new(r#">=3\.(\d+)(?:\.\d)?"#).unwrap();
         if let Some(captures) = regex.captures(&requires_python) {
             let min_python_minor = captures[1]
                 .parse::<usize>()
@@ -239,8 +239,8 @@ fn get_min_python_minor(metadata21: &Metadata21) -> Option<usize> {
         } else {
             println!(
                 "⚠  Couldn't parse the value of requires-python, \
-                    not taking it into account when searching for python interpreter.\
-                    Note: Only the forms `^3.x` and `>=3.x.y` are currently supported."
+                    not taking it into account when searching for python interpreter. \
+                    Note: Only `>=3.x.y` is currently supported."
             );
             None
         }
@@ -693,10 +693,5 @@ mod test {
         let metadata21 =
             Metadata21::from_cargo_toml(&cargo_toml, &"test-crates/pyo3-pure").unwrap();
         assert_eq!(get_min_python_minor(&metadata21), None);
-        // ^3.7
-        let cargo_toml = CargoToml::from_path("test-crates/pyo3-mixed/Cargo.toml").unwrap();
-        let metadata21 =
-            Metadata21::from_cargo_toml(&cargo_toml, &"test-crates/pyo3-mixed").unwrap();
-        assert_eq!(get_min_python_minor(&metadata21), Some(7));
     }
 }

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -15,7 +15,7 @@ classifier = [
     "Programming Language :: Rust"
 ]
 requires-dist = ["boltons"]
-requires-python = "^3.7"
+requires-python = ">=3.7"
 
 [dependencies]
 pyo3 = { version = "0.13.2", features = ["extension-module"] }

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -136,6 +136,7 @@ fn create_conda_env(name: &str, major: usize, minor: usize) {
 #[cfg(target_os = "windows")]
 pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String>) -> Result<()> {
     use std::env;
+    use std::process::Stdio;
 
     let package_string = package.as_ref().join("Cargo.toml").display().to_string();
 


### PR DESCRIPTION
pip 21.1 complained that carets aren't PEP 440 compliant