### PR TITLE
Fix s390x architecture support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Always output PEP 600 platform tags in [#525](https://github.com/PyO3/maturin/pull/525)
 * Fix missing `PyInit_<module_name>` warning with Rust submodule in [#528](https://github.com/PyO3/maturin/pull/528)
 * Better cross compiling support for PyO3 binding on Unix in [#454](https://github.com/PyO3/maturin/pull/454)
+* Fix s390x architecture support in [#530](https://github.com/PyO3/maturin/pull/530)
 
 ## 0.10.4 - 2021-04-28
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -68,6 +68,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
             Arch::Armv7L,
             Arch::Powerpc64,
             Arch::Powerpc64Le,
+            Arch::S390X,
             Arch::X86,
             Arch::X86_64,
         ],
@@ -128,6 +129,7 @@ impl Target {
             {
                 Arch::Powerpc64Le
             }
+            platforms::target::Arch::S390X => Arch::S390X,
             unsupported => bail!("The architecture {} is not supported", unsupported),
         };
 


### PR DESCRIPTION
```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
💥 maturin failed
  Caused by: The architecture s390x is not supported
```