### PR TITLE
Publish maturin wheel for s390x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,3 +167,41 @@ jobs:
           file: target/release/maturin.tar.gz
           tag: ${{ github.ref }}
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+
+  release-gnu-pypi:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [
+          { target: "s390x-unknown-linux-gnu", image: "messense/manylinux2014-cross:s390x", manylinux: "2014" },
+        ]
+    container:
+      image: docker://${{ matrix.platform.image }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: ${{ matrix.platform.target }}
+      - name: Build and publish wheel
+        env:
+          MATURIN_PASSWORD: ${{ secrets.MATURIN_PASSWORD }}
+        run: |
+          sudo python3 -m pip install maturin==0.10.5_beta.4
+          maturin publish -u __token__ -b bin --no-sdist -o dist \
+            --target ${{ matrix.platform.target }} \
+            --manylinux ${{ matrix.platform.manylinux }} \
+            --cargo-extra-args="--no-default-features" \
+            --cargo-extra-args="--features log,upload,human-panic"
+      - name: Archive binary
+        run: tar czvf target/release/maturin.tar.gz -C target/${{ matrix.platform.target }}/release maturin
+      - name: Upload to gitHub release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          asset_name: maturin-${{ matrix.platform.target }}.tar.gz
+          file: target/release/maturin.tar.gz
+          tag: ${{ github.ref }}
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.MATURIN_PASSWORD }}
         run: |
           sudo python3 -m pip install maturin
-          maturin publish -u __token__ -b bin --no-sdist -o dist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
+          maturin publish -u __token__ -b bin --no-sdist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
       - name: Archive binary
         run: tar czvf target/release/maturin.tar.gz -C target/${{ matrix.platform.target }}/release maturin
       - name: Upload to gitHub release
@@ -190,7 +190,7 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.MATURIN_PASSWORD }}
         run: |
           sudo python3 -m pip install maturin==0.10.5_beta.4
-          maturin publish -u __token__ -b bin --no-sdist -o dist \
+          maturin publish -u __token__ -b bin --no-sdist \
             --target ${{ matrix.platform.target }} \
             --manylinux ${{ matrix.platform.manylinux }} \
             --cargo-extra-args="--no-default-features" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
         platform: [
           { target: "aarch64-unknown-linux-gnu", arch: "aarch64" },
           { target: "armv7-unknown-linux-gnueabihf", arch: "armv7" },
+          { target: "s390x-unknown-linux-gnu", arch: "s390x" },
         ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
[ring doesn't build on s390x yet](https://github.com/briansmith/ring/issues/986), so I've disabled the `rustls` feature.

Test run: https://github.com/messense/maturin/runs/2532708951?check_suite_focus=true