### PR TITLE
Only use extension name from extra metadata if it contains dot

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -138,7 +138,13 @@ impl BuildOptions {
             .and_then(|lib| lib.name.as_ref())
             .unwrap_or(&crate_name)
             .to_owned();
-        let extension_name = extra_metadata.name.as_ref().unwrap_or(&module_name);
+
+        // Only use extension name from extra metadata if it contains dot
+        let extension_name = extra_metadata
+            .name
+            .as_ref()
+            .filter(|name| name.contains('.'))
+            .unwrap_or(&module_name);
 
         let project_layout = ProjectLayout::determine(manifest_dir, &extension_name)?;
 


### PR DESCRIPTION
Previously the following example would work because maturin will use `lib.name` instead of `package.metadata.maturin.name`

```toml
[package]
name = "py-abc-def"

[lib]
name = "abc_def"
crate-type = ["cdylib"]

[package.metadata.maturin]
name = "abc-def"
```

With #489 it's broken ([example](https://github.com/messense/fat-macho-rs/actions/runs/824473631)) and it will use `package.metadata.maturin.name` for the extension filename which results in `ImportError` at runtime.

This PR restore the previous behavior.