### PR TITLE
Merge target specific RUSTFLAGS

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -119,6 +119,17 @@ fn compile_target(
         .collect();
 
     let mut rust_flags = env::var_os("RUSTFLAGS").unwrap_or_default();
+    // Merge target specific RUSTFLAGS
+    let target_uppercase = context
+        .target
+        .target_triple()
+        .replace("-", "_")
+        .to_ascii_uppercase();
+    if let Some(target_rust_flags) =
+        env::var_os(format!("CARGO_TARGET_{}_RUSTFLAGS", target_uppercase))
+    {
+        rust_flags.push(target_rust_flags);
+    }
 
     // We need to pass --bins / --lib to set the rustc extra args later
     // TODO: What do we do when there are multiple bin targets?


### PR DESCRIPTION
Useful for supporting target like `powerpc64le-unknown-linux-musl` which doesn't have std library binary distribution yet but can be built with `cargo build -Zbuild-std` on nightly.

See also https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags

Before this patch build failed cause of missing some `-L` flags which are set by `CARGO_TARGET_XXX_RUSTFLAGS` env var: https://github.com/messense/maturin/runs/2537804583?check_suite_focus=true
After: https://github.com/messense/maturin/runs/2537949957?check_suite_focus=true