### PR TITLE
Replace 'platforms' crate with `target-lexicon` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -920,7 +920,6 @@ dependencies = [
  "mailparse",
  "once_cell",
  "platform-info",
- "platforms",
  "pretty_env_logger",
  "regex",
  "reqwest",
@@ -932,6 +931,7 @@ dependencies = [
  "shlex",
  "structopt",
  "tar",
+ "target-lexicon",
  "tempfile",
  "thiserror",
  "toml",
@@ -1206,12 +1206,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "platforms"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 
 [[package]]
 name = "ppv-lite86"
@@ -1754,6 +1748,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ goblin = "0.4.0"
 human-panic = { version = "1.0.3", optional = true }
 keyring = { version = "0.10.1", optional = true }
 platform-info = "0.1.0"
-platforms = "1.1.0"
 pretty_env_logger = { version = "0.4.0", optional = true }
 regex = "1.4.5"
 reqwest = { version = "0.11.2", optional = true, default-features = false, features = ["blocking", "multipart"] }
@@ -67,6 +66,7 @@ fat-macho = "0.4.3"
 toml_edit = "0.2.0"
 once_cell = "1.7.2"
 scroll = "0.10.2"
+target-lexicon = "0.12.0"
 
 [dev-dependencies]
 indoc = "1.0.3"


### PR DESCRIPTION
[target-lexicon](https://github.com/bytecodealliance/target-lexicon) is much more flexible and doesn't rely on hard-coded target triple list.