### PR TITLE
Optionally build type information stub packages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unrelease
 
 * Add PEP 656 musllinux support in [#543](https://github.com/PyO3/maturin/pull/543)
+* Build PEP 561 compatible type information stubs packages
 
 ## 0.10.6 - 2021-05-21
 

--- a/Readme.md
+++ b/Readme.md
@@ -108,6 +108,15 @@ my-project
     └── lib.rs
 ```
 
+## Python type information stubs
+
+maturin can automatically build and publish PEP 561 compatible type information stubs packages
+for Rust-only extensions when a type information source file name `<module_name>.pyi` exists
+in the project directory. As with mixed Rust/Python projects, `<module_name>` corresponds
+to `lib.name` in `Cargo.toml`.
+
+The type stubs package can be also built manually by running `maturin stubs`.
+
 ## Python metadata
 
 To specify python dependencies, add a list `requires-dist` in a `[package.metadata.maturin]` section in the Cargo.toml. This list is equivalent to `install_requires` in setuptools:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use crate::target::Target;
 pub use auditwheel::PlatformTag;
 pub use sdist_context::SDistContext;
 pub use source_distribution::source_distribution;
+pub use stubs_package::stubs_package;
 #[cfg(feature = "upload")]
 pub use {
     crate::registry::Registry,
@@ -67,6 +68,7 @@ mod read_distribution;
 mod registry;
 mod sdist_context;
 mod source_distribution;
+mod stubs_package;
 mod target;
 #[cfg(feature = "upload")]
 mod upload;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub use crate::read_distribution::{
 };
 pub use crate::target::Target;
 pub use auditwheel::PlatformTag;
+pub use sdist_context::SDistContext;
 pub use source_distribution::source_distribution;
 #[cfg(feature = "upload")]
 pub use {
@@ -64,6 +65,7 @@ mod python_interpreter;
 mod read_distribution;
 #[cfg(feature = "upload")]
 mod registry;
+mod sdist_context;
 mod source_distribution;
 mod target;
 #[cfg(feature = "upload")]

--- a/src/sdist_context.rs
+++ b/src/sdist_context.rs
@@ -1,0 +1,90 @@
+use crate::{source_distribution, CargoToml, Metadata21, PyProjectToml};
+use anyhow::{Context, Result};
+use cargo_metadata::{Metadata, MetadataCommand};
+use fs_err as fs;
+use std::path::PathBuf;
+
+/// Contains all the metadata required to build the source distribution
+#[derive(Clone)]
+pub struct SDistContext {
+    /// Python Package Metadata 2.1
+    pub metadata21: Metadata21,
+    /// The name of the module can be distinct from the package name, mostly
+    /// because package names normally contain minuses while module names
+    /// have underscores. The package name is part of metadata21
+    pub module_name: String,
+    /// The directory where Cargo.toml is located
+    pub manifest_dir: PathBuf,
+    /// The path to the Cargo.toml. Required for the cargo invocations
+    pub manifest_path: PathBuf,
+    /// The directory to store the built wheels in. Defaults to a new "wheels"
+    /// directory in the project's target directory
+    pub out: PathBuf,
+    /// Cargo.toml as resolved by [cargo_metadata]
+    pub cargo_metadata: Metadata,
+}
+
+impl SDistContext {
+    /// Creates a new source distribution build context from the project
+    /// `Cargo.toml` path and the tarball output directory.
+    ///
+    /// Tries to fill the missing metadata by parsing `Cargo.toml` and
+    /// querying `cargo metadata`.
+    pub fn new(manifest_path: PathBuf, out: Option<PathBuf>) -> Result<Self> {
+        let manifest_dir = manifest_path.parent().unwrap().to_path_buf();
+
+        let cargo_toml = CargoToml::from_path(&manifest_path)?;
+
+        let metadata21 = Metadata21::from_cargo_toml(&cargo_toml, &manifest_dir)
+            .context("Failed to parse Cargo.toml into python metadata")?;
+
+        let crate_name = &cargo_toml.package.name;
+
+        // If the package name contains minuses, you must declare a module with
+        // underscores as lib name
+        let module_name = cargo_toml
+            .lib
+            .as_ref()
+            .and_then(|lib| lib.name.as_ref())
+            .unwrap_or(&crate_name)
+            .to_owned();
+
+        let cargo_metadata = MetadataCommand::new()
+            .manifest_path(&manifest_path)
+            .exec()
+            .context("Cargo metadata failed. Do you have cargo in your PATH?")?;
+
+        let wheel_dir = match out {
+            Some(ref dir) => dir.clone(),
+            None => PathBuf::from(&cargo_metadata.target_directory).join("wheels"),
+        };
+
+        Ok(SDistContext {
+            metadata21,
+            module_name,
+            manifest_dir,
+            manifest_path,
+            out: wheel_dir,
+            cargo_metadata,
+        })
+    }
+
+    /// Builds a source distribution and returns the source tarball file path.
+    pub fn build_source_distribution(&self) -> Result<PathBuf> {
+        fs::create_dir_all(&self.out)
+            .context("Failed to create the target directory for the source distribution")?;
+
+        // Ensure the project has a compliant pyproject.toml
+        let pyproject = PyProjectToml::new(&self.manifest_dir)
+            .context("A pyproject.toml with a PEP 517 compliant `[build-system]` table is required to build a source distribution")?;
+
+        source_distribution(
+            &self.out,
+            &self.metadata21,
+            &self.manifest_path,
+            &self.cargo_metadata,
+            pyproject.sdist_include(),
+        )
+        .context("Failed to build source distribution")
+    }
+}

--- a/src/stubs_package.rs
+++ b/src/stubs_package.rs
@@ -1,0 +1,57 @@
+use crate::{Metadata21, ModuleWriter, WheelWriter};
+use anyhow::{Context, Result};
+use fs_err as fs;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Creates the type information stubs package if the type information
+/// source file exists.
+pub fn stubs_package(
+    wheel_dir: impl AsRef<Path>,
+    module_name: &str,
+    metadata21: &Metadata21,
+) -> Result<Option<(PathBuf, Metadata21)>> {
+    let mut stubs_source_path: PathBuf = module_name.into();
+    stubs_source_path.set_extension("pyi");
+
+    if !stubs_source_path.exists() {
+        return Ok(None);
+    }
+
+    let mut stubs_metadata21 = metadata21.clone();
+
+    // Build PEP 561 compliant stubs package name
+    stubs_metadata21.name += "-stubs";
+    // Module name may differ from the package name
+    let mut stubs_module_name = module_name.to_string();
+    stubs_module_name += "-stubs";
+
+    let scripts = HashMap::new();
+    let tags = ["py3-none-any".to_string()];
+
+    fs::create_dir_all(&wheel_dir)
+        .context("Failed to create the target directory for the stubs package")?;
+
+    let mut writer = WheelWriter::new(
+        "py3-none-any",
+        wheel_dir.as_ref(),
+        &stubs_metadata21,
+        &scripts,
+        &tags,
+    )
+    .context("Failed to create the type information stubs package wheel file")?;
+
+    let mut stubs_package_initpy: PathBuf = stubs_module_name.into();
+    stubs_package_initpy.push("__init__.pyi");
+
+    writer.add_file(&stubs_package_initpy, &stubs_source_path)?;
+
+    let stubs_package_path = writer.finish()?;
+
+    println!(
+        "📦 Built type information stubs package to {}",
+        stubs_package_path.display()
+    );
+
+    Ok(Some((stubs_package_path, stubs_metadata21)))
+}


### PR DESCRIPTION
PEP 561 allows to distribute the Python type information for
the extension modules by creating separate stub-only packages.

Mixed language projects can embed the type information stubs (.pyi)
into the package by simply adding a `py.typed` marker file.

`maturin stubs` command accomplishes this also for the module-only extensions
by automatically building and publishing an associated `foo-stubs` package
when the `foo` extension is being built and the `foo.pyi` type information
stubs file is found in the project directory.

`maturin build` and `maturin publish` commands build and publish
the stubs package automatically unless `--no-stubs` flag is passed.