### PR TITLE
Use a module folder for the pure rust layout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add PEP 656 musllinux support in [#543](https://github.com/PyO3/maturin/pull/543)
 * `--manylinux` is now called `--compatibility` and supports musllinux
+* The pure rust install layout changed from just the shared library to a python module that reexports the shared library. This should have now observable consequences for users of the created wheel expect that `my_project.my_project` is now also importable (and equal to just `my_project`)
 
 ## 0.10.6 - 2021-05-21
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -608,7 +608,14 @@ pub fn write_bindings_module(
             writer.add_file_with_permissions(relative.join(&so_filename), &artifact, 0o755)?;
         }
         ProjectLayout::PureRust(_) => {
-            writer.add_file_with_permissions(so_filename, &artifact, 0o755)?;
+            let module = PathBuf::from(module_name);
+            writer.add_directory(&module)?;
+            // Reexport the shared library as if it were the top level module
+            writer.add_bytes(
+                &module.join("__init__.py"),
+                format!("from .{} import *\n", module_name).as_bytes(),
+            )?;
+            writer.add_file_with_permissions(&module.join(so_filename), &artifact, 0o755)?;
         }
     }
 


### PR DESCRIPTION
Old layout:

```
site-packages
├── my_project.cpython-36m-x86_64-linux-gnu.so
└── my_project-2.1.2.dist-info
    └── ...
```

New layout:

```
site-packages
├── my_project
│   ├── __init__.py
│   └── my_project.cpython-36m-x86_64-linux-gnu.so
└── my_project-2.1.2.dist-info
    └── ...
```

This layout is much more like normal python installs (the module is always in `site-packages/my_project` like all pure python module instead of `site-packages/my_project.some-complex-tag-that-sometimes-changes.so`), but more importantly it should allow shipping pyi files for #553