### PR TITLE
Support i386 on OpenBSD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add PEP 656 musllinux support in [#543](https://github.com/PyO3/maturin/pull/543)
 * `--manylinux` is now called `--compatibility` and supports musllinux
 * The pure rust install layout changed from just the shared library to a python module that reexports the shared library. This should have now observable consequences for users of the created wheel expect that `my_project.my_project` is now also importable (and equal to just `my_project`)
+* Support i386 on OpenBSD in [#568](https://github.com/PyO3/maturin/pull/568)
 
 ## 0.10.6 - 2021-05-21
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -74,7 +74,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
         Os::Windows => vec![Arch::X86, Arch::X86_64, Arch::Aarch64],
         Os::Macos => vec![Arch::Aarch64, Arch::X86_64],
         Os::FreeBsd => vec![Arch::X86_64],
-        Os::OpenBsd => vec![Arch::X86_64],
+        Os::OpenBsd => vec![Arch::X86, Arch::X86_64],
     }
 }
 
@@ -149,6 +149,14 @@ impl Target {
                 };
                 let release = info.release().replace(".", "_").replace("-", "_");
                 format!("freebsd_{}_amd64", release)
+            }
+            (Os::OpenBsd, Arch::X86) => {
+                let info = match PlatformInfo::new() {
+                    Ok(info) => info,
+                    Err(error) => panic!("{}", error),
+                };
+                let release = info.release().replace(".", "_").replace("-", "_");
+                format!("openbsd_{}_i386", release)
             }
             (Os::OpenBsd, Arch::X86_64) => {
                 let info = match PlatformInfo::new() {


### PR DESCRIPTION
Compiling py-adblock on OpenBSD-i386, rust 1.52.1, python 3.8.8 breaks up with the following error 

```
i686 is not supported on OpenBSD
```

The given patch allows building with the above configuration. Currently building py-adblock has been the extent of testing maturin has undergone on i386. Let me know if there is anything more to add.