### PR TITLE
Make `Cargo.toml`'s `authors` field optional

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support i386 on OpenBSD in [#568](https://github.com/PyO3/maturin/pull/568)
 * Support Aarch64 on OpenBSD in [#570](https://github.com/PyO3/maturin/pull/570)
 * Support Aarch64 on FreeBSD in [#571](https://github.com/PyO3/maturin/pull/571)
+* `Cargo.toml`'s `authors` field is now optional per Rust [RFC 3052](https://github.com/rust-lang/rfcs/blob/master/text/3052-optional-authors-field.md) in [#573](https://github.com/PyO3/maturin/pull/573)
 
 ## 0.10.6 - 2021-05-21
 

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -20,8 +20,8 @@ pub(crate) struct CargoTomlPackage {
     // https://doc.rust-lang.org/cargo/reference/manifest.html#the-package-section
     pub(crate) name: String,
     pub(crate) version: String,
-    pub(crate) authors: Vec<String>,
     // All other fields are optional
+    pub(crate) authors: Option<Vec<String>>,
     pub(crate) description: Option<String>,
     pub(crate) documentation: Option<String>,
     pub(crate) homepage: Option<String>,
@@ -199,5 +199,33 @@ mod test {
         let classifiers = vec!["Programming Language :: Python".to_string()];
 
         assert_eq!(cargo_toml.classifiers(), classifiers);
+    }
+
+    #[test]
+    fn test_metadata_from_cargo_toml_without_authors() {
+        let cargo_toml = indoc!(
+            r#"
+            [package]
+            name = "info-project"
+            version = "0.1.0"
+            description = "A test project"
+            homepage = "https://example.org"
+            keywords = ["ffi", "test"]
+
+            [lib]
+            crate-type = ["cdylib"]
+            name = "pyo3_pure"
+
+            [package.metadata.maturin.scripts]
+            ph = "maturin:print_hello"
+
+            [package.metadata.maturin]
+            classifiers = ["Programming Language :: Python"]
+            requires-dist = ["flask~=1.1.0", "toml==0.10.0"]
+        "#
+        );
+
+        let cargo_toml: Result<CargoToml, _> = toml::from_str(&cargo_toml);
+        assert!(cargo_toml.is_ok());
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -256,15 +256,21 @@ impl Metadata21 {
         cargo_toml: &CargoToml,
         manifest_path: impl AsRef<Path>,
     ) -> Result<Metadata21> {
-        let authors = cargo_toml.package.authors.join(", ");
+        let authors = cargo_toml
+            .package
+            .authors
+            .as_ref()
+            .map(|authors| authors.join(", "));
 
         let classifiers = cargo_toml.classifiers();
 
-        let author_email = if authors.contains('@') {
-            Some(authors.clone())
-        } else {
-            None
-        };
+        let author_email = authors.as_ref().and_then(|authors| {
+            if authors.contains('@') {
+                Some(authors.clone())
+            } else {
+                None
+            }
+        });
 
         let extra_metadata = cargo_toml.remaining_core_metadata();
 
@@ -313,7 +319,7 @@ impl Metadata21 {
             home_page: cargo_toml.package.homepage.clone(),
             download_url: None,
             // Cargo.toml has no distinction between author and author email
-            author: Some(authors),
+            author: authors,
             author_email,
             license: cargo_toml.package.license.clone(),
 


### PR DESCRIPTION
Per https://github.com/rust-lang/rfcs/pull/3052

Closes #572 