### PR TITLE
Refuse to include the sdist output tarball into itself

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -327,6 +327,13 @@ impl ModuleWriter for SDistWriter {
     }
 
     fn add_file(&mut self, target: impl AsRef<Path>, source: impl AsRef<Path>) -> Result<()> {
+        if source.as_ref() == self.path {
+            bail!(
+            "Attempting to include the sdist output tarball {} into itself! Check 'cargo package --list' output.",
+            source.as_ref().display()
+            );
+        }
+
         self.tar
             .append_path_with_name(&source, &target)
             .context(format!(


### PR DESCRIPTION
Add a sanity check preventing unbounded sdist tarball growth
when the user forgets to add the sdist output directory to .gitignore.

Accidentally discovered by running tox on a project where .tox directory
is not in .gitignore. tox builds its sdists inside .tox/dist/.