### PR TITLE
Use UTF-8 encoding when reading pyproject.toml

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -35,7 +35,7 @@ available_options = [
 
 
 def get_config() -> Dict[str, str]:
-    with open("pyproject.toml") as fp:
+    with open("pyproject.toml", encoding="utf-8") as fp:
         pyproject_toml = toml.load(fp)
     return pyproject_toml.get("tool", {}).get("maturin", {})
 


### PR DESCRIPTION
This avoids a `UnicodeDecodeError` when reading `pyproject.toml` files containing unicode characters on Windows. These characters may be present in a project's metadata, such as its description or an author's name.

```python
>>> from maturin import get_config
>>> get_config()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib\site-packages\maturin\__init__.py", line 39, in get_config
    pyproject_toml = toml.load(fp)
  File "lib\site-packages\toml\decoder.py", line 156, in load
    return loads(f.read(), _dict, decoder)
  File "lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 242: character maps to <undefined>
```

Furthermore, the [TOML specification](https://toml.io/en/v1.0.0#spec) requires files to be encoded in UTF-8.