### PR TITLE
Fix `maturin develop` for PyPy on Unix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use UTF-8 encoding when reading `pyproject.toml` by domdfcoding in [#588](https://github.com/PyO3/maturin/pull/588)
 * Use Cargo's `repository` field as `Source Code` in project URL in [#590](https://github.com/PyO3/maturin/pull/590)
 * Fold long header fields in Python metadata in [#594](https://github.com/PyO3/maturin/pull/594)
+* Fix `maturin develop` for PyPy on Unix in [#596](https://github.com/PyO3/maturin/pull/596)
 
 ## [0.11.1] - 2021-07-10
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,3 +1,4 @@
+use crate::python_interpreter::InterpreterKind;
 use crate::{PlatformTag, PythonInterpreter};
 use anyhow::{bail, format_err, Context, Result};
 use platform_info::*;
@@ -316,13 +317,17 @@ impl Target {
         interpreter: &PythonInterpreter,
     ) -> PathBuf {
         if self.is_unix() {
-            let python_dir = format!("python{}.{}", interpreter.major, interpreter.minor);
-
-            venv_base
-                .as_ref()
-                .join("lib")
-                .join(python_dir)
-                .join("site-packages")
+            match interpreter.interpreter_kind {
+                InterpreterKind::CPython => {
+                    let python_dir = format!("python{}.{}", interpreter.major, interpreter.minor);
+                    venv_base
+                        .as_ref()
+                        .join("lib")
+                        .join(python_dir)
+                        .join("site-packages")
+                }
+                InterpreterKind::PyPy => venv_base.as_ref().join("site-packages"),
+            }
         } else {
             venv_base.as_ref().join("Lib").join("site-packages")
         }


### PR DESCRIPTION
Fixes #595 