### PR TITLE
Use `[tool.maturin]` options from `pyproject.toml` in build command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -211,7 +211,7 @@ To include arbitrary files in the sdist for use during compilation specify `sdis
 sdist-include = ["path/**/*"]
 ```
 
-There's a `cargo sdist` command for only building a source distribution as workaround for [pypa/pip#6041](https://github.com/pypa/pip/issues/6041).
+There's a `maturin sdist` command for only building a source distribution as workaround for [pypa/pip#6041](https://github.com/pypa/pip/issues/6041).
 
 ## Manylinux and auditwheel
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -14,24 +14,9 @@ import shutil
 import subprocess
 import sys
 from subprocess import SubprocessError
-from typing import List, Dict
+from typing import Dict
 
 import toml
-
-# these are only used when creating the sdist, not when building it
-create_only_options = [
-    "sdist-include",
-]
-
-available_options = [
-    "bindings",
-    "cargo-extra-args",
-    "compatibility",
-    "manylinux",
-    "rustc-extra-args",
-    "skip-auditwheel",
-    "strip",
-]
 
 
 def get_config() -> Dict[str, str]:
@@ -40,25 +25,11 @@ def get_config() -> Dict[str, str]:
     return pyproject_toml.get("tool", {}).get("maturin", {})
 
 
-def get_config_options() -> List[str]:
-    config = get_config()
-    options = []
-    for key, value in config.items():
-        if key in create_only_options:
-            continue
-        if key not in available_options:
-            # attempt to install even if keys from newer or older versions are present
-            sys.stderr.write(f"WARNING: {key} is not a recognized option for maturin\n")
-        options.append("--{}={}".format(key, value))
-    return options
-
-
 # noinspection PyUnusedLocal
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     # PEP 517 specifies that only `sys.executable` points to the correct
     # python interpreter
     command = ["maturin", "pep517", "build-wheel", "-i", sys.executable]
-    command.extend(get_config_options())
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()
@@ -140,7 +111,6 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
         "--interpreter",
         sys.executable,
     ]
-    command.extend(get_config_options())
 
     print("Running `{}`".format(" ".join(command)))
     try:

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -1,3 +1,4 @@
+use crate::PlatformTag;
 use anyhow::{format_err, Context, Result};
 use pyproject_toml::PyProjectToml as ProjectToml;
 use serde::{Deserialize, Serialize};
@@ -16,6 +17,15 @@ pub struct Tool {
 #[serde(rename_all = "kebab-case")]
 pub struct ToolMaturin {
     sdist_include: Option<Vec<String>>,
+    bindings: Option<String>,
+    cargo_extra_args: Option<String>,
+    #[serde(alias = "manylinux")]
+    compatibility: Option<PlatformTag>,
+    rustc_extra_args: Option<String>,
+    #[serde(default)]
+    skip_auditwheel: bool,
+    #[serde(default)]
+    strip: bool,
 }
 
 /// A pyproject.toml as specified in PEP 517
@@ -57,9 +67,57 @@ impl PyProjectToml {
         Ok(pyproject)
     }
 
-    /// Returns the value of `[maturin.sdist-include]` in pyproject.toml
+    /// Returns the value of `[tool.maturin.sdist-include]` in pyproject.toml
     pub fn sdist_include(&self) -> Option<&Vec<String>> {
         self.tool.as_ref()?.maturin.as_ref()?.sdist_include.as_ref()
+    }
+
+    /// Returns the value of `[tool.maturin.bindings]` in pyproject.toml
+    pub fn bindings(&self) -> Option<&str> {
+        self.tool.as_ref()?.maturin.as_ref()?.bindings.as_deref()
+    }
+
+    /// Returns the value of `[tool.maturin.cargo-extra-args]` in pyproject.toml
+    pub fn cargo_extra_args(&self) -> Option<&str> {
+        self.tool
+            .as_ref()?
+            .maturin
+            .as_ref()?
+            .cargo_extra_args
+            .as_deref()
+    }
+
+    /// Returns the value of `[tool.maturin.compatibility]` in pyproject.toml
+    pub fn compatibility(&self) -> Option<PlatformTag> {
+        self.tool.as_ref()?.maturin.as_ref()?.compatibility
+    }
+
+    /// Returns the value of `[tool.maturin.rustc-extra-args]` in pyproject.toml
+    pub fn rustc_extra_args(&self) -> Option<&str> {
+        self.tool
+            .as_ref()?
+            .maturin
+            .as_ref()?
+            .rustc_extra_args
+            .as_deref()
+    }
+
+    /// Returns the value of `[tool.maturin.skip-auditwheel]` in pyproject.toml
+    pub fn skip_auditwheel(&self) -> bool {
+        self.tool
+            .as_ref()
+            .and_then(|tool| tool.maturin.as_ref())
+            .map(|maturin| maturin.skip_auditwheel)
+            .unwrap_or_default()
+    }
+
+    /// Returns the value of `[tool.maturin.strip]` in pyproject.toml
+    pub fn strip(&self) -> bool {
+        self.tool
+            .as_ref()
+            .and_then(|tool| tool.maturin.as_ref())
+            .map(|maturin| maturin.strip)
+            .unwrap_or_default()
     }
 
     /// Having a pyproject.toml without a version constraint is a bad idea

--- a/test-crates/pyo3-pure/pyproject.toml
+++ b/test-crates/pyo3-pure/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["maturin>=0.11,<0.12"]
 build-backend = "maturin"
 
+[tool.maturin]
+bindings = "pyo3"
+
 [project]
 name = "pyo3-pure"
 classifiers = [


### PR DESCRIPTION
`maturin build` should respect these settings even when not building using PEP 517

https://github.com/PyO3/maturin/blob/a37c450cfbbca50003f6ee3e33204c7bbe416741/maturin/__init__.py#L26-L34

The primary use case of this feature is that when a crate have an off-by-default optional feature say `pyo3` to enable Python extension module, user can specify `cargo-extra-args = "--features pyo3"` in `pyproject.toml` to automatically "pass" them to `maturin build`/`maturin publish`