### PR TITLE
Detect musl libc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Autodetect PyPy executables in [#617](https://github.com/PyO3/maturin/pull/617)
+* auditwheel: add `libz.so.1` to whitelisted libraries in [#625](https://github.com/PyO3/maturin/pull/625)
+* auditwheel: detect musl libc in [#629](https://github.com/PyO3/maturin/pull/629)
 
 ## [0.11.3] - 2021-08-25
 

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod musllinux;
 mod platform_tag;
 mod policy;
 

--- a/src/auditwheel/musllinux.rs
+++ b/src/auditwheel/musllinux.rs
@@ -1,0 +1,47 @@
+use anyhow::{Context, Result};
+use goblin::elf::Elf;
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Find musl libc path from executable's ELF header
+pub fn find_musl_libc() -> Result<Option<PathBuf>> {
+    let buffer = fs::read("/bin/ls")?;
+    let elf = Elf::parse(&buffer)?;
+    Ok(elf.interpreter.map(PathBuf::from))
+}
+
+/// Read the musl version from libc library's output
+///
+/// The libc library should output something like this to stderr::
+///
+/// musl libc (x86_64)
+/// Version 1.2.2
+/// Dynamic Program Loader
+pub fn get_musl_version(ld_path: impl AsRef<Path>) -> Result<Option<(u16, u16)>> {
+    let ld_path = ld_path.as_ref();
+    let output = Command::new(&ld_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()?;
+    let stderr = std::str::from_utf8(&output.stderr)?;
+    let expr = Regex::new(r"Version (\d+)\.(\d+)")?;
+    if let Some(capture) = expr.captures(stderr) {
+        let context = "Expected a digit";
+        let major = capture
+            .get(1)
+            .unwrap()
+            .as_str()
+            .parse::<u16>()
+            .context(context)?;
+        let minor = capture
+            .get(2)
+            .unwrap()
+            .as_str()
+            .parse::<u16>()
+            .context(context)?;
+        return Ok(Some((major, minor)));
+    }
+    Ok(None)
+}


### PR DESCRIPTION
Unfortunately, currently [on Alpine Linux Rust programs dynamically link to `libgcc_s` instead of static link to llvm libunwind](https://github.com/alpinelinux/aports/blob/master/community/rust/0006-Prefer-libgcc_eh-over-libunwind-for-musl.patch), so maturin produced wheels are not directly compatible.

Closes #627 