### PR TITLE
Re-export `__doc__` in `__init__.py` for pure Rust project

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fixed module documentation missing bug of pyo3 bindings in [#639](https://github.com/PyO3/maturin/pull/639)
+
 ## [0.11.4] - 2021-09-28
 
 * Autodetect PyPy executables in [#617](https://github.com/PyO3/maturin/pull/617)

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -621,7 +621,11 @@ pub fn write_bindings_module(
             // Reexport the shared library as if it were the top level module
             writer.add_bytes(
                 &module.join("__init__.py"),
-                format!("from .{} import *\n", module_name).as_bytes(),
+                format!(
+                    "from .{module_name} import *\n\n__doc__ = {module_name}.__doc__\n",
+                    module_name = module_name
+                )
+                .as_bytes(),
             )?;
             let type_stub = rust_module.join(format!("{}.pyi", module_name));
             if type_stub.exists() {

--- a/test-crates/pyo3-pure/src/lib.rs
+++ b/test-crates/pyo3-pure/src/lib.rs
@@ -11,6 +11,7 @@ impl DummyClass {
     }
 }
 
+/// module level doc string
 #[pymodule]
 fn pyo3_pure(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<DummyClass>()?;


### PR DESCRIPTION
Fixes https://github.com/PyO3/pyo3/issues/1894