### PR TITLE
Fix musllinux auditwheel wrongly detects libc forbidden link

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |
-          sudo xcode-select -s /Applications/Xcode_12.3.app
+          sudo xcode-select -s /Applications/Xcode.app
           bindir="$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/bin"
           echo "CC=${bindir}/clang" >> "${GITHUB_ENV}"
           echo "CXX=${bindir}/clang++" >> "${GITHUB_ENV}"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fixed module documentation missing bug of pyo3 bindings in [#639](https://github.com/PyO3/maturin/pull/639)
+* Fix musllinux auditwheel wrongly detects libc forbidden link in [#643](https://github.com/PyO3/maturin/pull/643)
 
 ## [0.11.4] - 2021-09-28
 

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -257,9 +257,7 @@ pub fn auditwheel_rs(
         None => {
             let mut policies = get_default_platform_policies();
             for policy in &mut policies {
-                if policy.name.starts_with("musllinux") {
-                    policy.fixup_musl_libc_so_name(target.target_arch());
-                }
+                policy.fixup_musl_libc_so_name(target.target_arch());
             }
             policies
         }
@@ -283,7 +281,8 @@ pub fn auditwheel_rs(
     }
 
     if let Some(platform_tag) = platform_tag {
-        let policy = Policy::from_name(&platform_tag.to_string()).unwrap();
+        let mut policy = Policy::from_name(&platform_tag.to_string()).unwrap();
+        policy.fixup_musl_libc_so_name(target.target_arch());
 
         if let Some(highest_policy) = highest_policy {
             if policy.priority < highest_policy.priority {

--- a/src/auditwheel/policy.rs
+++ b/src/auditwheel/policy.rs
@@ -104,7 +104,7 @@ impl Policy {
 
     pub(crate) fn fixup_musl_libc_so_name(&mut self, target_arch: Arch) {
         // Fixup musl libc lib_whitelist
-        if self.lib_whitelist.remove("libc.so") {
+        if self.name.starts_with("musllinux") && self.lib_whitelist.remove("libc.so") {
             let new_soname = match target_arch {
                 Arch::Aarch64 => "libc.musl-aarch64.so.1",
                 Arch::Armv7L => "libc.musl-armv7.so.1",
@@ -123,7 +123,7 @@ impl Policy {
 
 #[cfg(test)]
 mod test {
-    use super::{Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
+    use super::{Arch, Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
 
     #[test]
     fn test_load_policy() {
@@ -153,5 +153,12 @@ mod test {
         for policy in MUSLLINUX_POLICIES.iter() {
             let _tag = policy.platform_tag();
         }
+    }
+
+    #[test]
+    fn test_policy_musllinux_fixup_libc_so_name() {
+        let mut policy = Policy::from_name("musllinux_1_1").unwrap();
+        policy.fixup_musl_libc_so_name(Arch::Aarch64);
+        assert!(policy.lib_whitelist.contains("libc.musl-aarch64.so.1"));
     }
 }


### PR DESCRIPTION
Fixes #642 