### PR TITLE
Fix Win32 Conda Python Interpreters

### DIFF
--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -167,7 +167,7 @@ fn find_all_windows(target: &Target, min_python_minor: usize) -> Result<Vec<Stri
 
         for path in paths {
             let executable_win = Path::new(&path).join("python.exe");
-            let executable = if (executable_win.exists()) {
+            let executable = if executable_win.exists() {
                 executable_win
             } else {
                 Path::new(&path).join("python")


### PR DESCRIPTION
Trying to use maturin with a conda environment on Windows that has my `python.exe` in the root with the `.exe` file extension. I keep getting the error message because the Rust Command is sending it to `ShellExecute` and not the in-process command interpreter.