### PR TITLE
Upgrade to Rust 2021 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e2fcbb64ecbe64c8e040a386c3104d384583af58b956d870aaaf229df6e66d"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "plain"
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "pretty_env_logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/pyo3/maturin"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "cffi", "packaging", "pypi", "pyo3"]
 categories = ["api-bindings", "development-tools::ffi", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "PyO3/maturin" }

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for PEP 660 editable installs in [#648](https://github.com/PyO3/maturin/pull/648)
 * Publish musllinux_1_1 wheels for maturin in [#651](https://github.com/PyO3/maturin/pull/651)
 * Refactor `develop` command to act identical to PEP 660 editable wheels in [#653](https://github.com/PyO3/maturin/pull/653)
+* Upgrade to Rust 2021 edition in [#655](https://github.com/PyO3/maturin/pull/655)
 
 ## [0.11.5] - 2021-10-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH /root/.cargo/bin:$PATH
 # Use an explicit version to actually install the version we require instead of using the cache
 # It would be even cooler to invalidate the cache depending on when the official rust image changes,
 # but I don't know how to do that
-RUN curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.55.0 -y
+RUN curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.56.0 -y
 
 # Compile dependencies only for build caching
 ADD Cargo.toml /maturin/Cargo.toml

--- a/test-crates/cargo-mock/Cargo.toml
+++ b/test-crates/cargo-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-mock"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "cargo"

--- a/test-crates/cffi-mixed/Cargo.toml
+++ b/test-crates/cffi-mixed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-mixed"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cffi_mixed"

--- a/test-crates/cffi-pure/Cargo.toml
+++ b/test-crates/cffi-pure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-pure"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cffi_pure"

--- a/test-crates/hello-world/Cargo.toml
+++ b/test-crates/hello-world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello-world"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 # Test references to out-of-project files
 readme = "../../Readme.md"
 

--- a/test-crates/lib_with_disallowed_lib/Cargo.toml
+++ b/test-crates/lib_with_disallowed_lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_disallowed_lib"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/lib_with_path_dep/Cargo.toml
+++ b/test-crates/lib_with_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/pyo3-abi3-without-version/Cargo.toml
+++ b/test-crates/pyo3-abi3-without-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3-abi3-without-version"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.14.0", features = ["abi3", "extension-module"] }

--- a/test-crates/pyo3-feature/Cargo.toml
+++ b/test-crates/pyo3-feature/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-feature"
 version = "0.7.3"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.14.0", optional = true }

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-py-subdir"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.14.0", features = ["extension-module"] }

--- a/test-crates/pyo3-mixed-submodule/Cargo.toml
+++ b/test-crates/pyo3-mixed-submodule/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-submodule"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.maturin]
 name = "pyo3_mixed_submodule.rust_module.rust"

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.14.0", features = ["extension-module"] }

--- a/test-crates/pyo3-no-extension-module/Cargo.toml
+++ b/test-crates/pyo3-no-extension-module/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-no-extension-module"
 version = "2.1.0"
 description = "Does not use the extension-module feature, thus errorneously linking libpython"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.14.0", default-features = false }

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-pure"
 version = "2.1.2"
-edition = "2018"
+edition = "2021"
 description = "Implements a dummy function (get_fortytwo.DummyClass.get_42()) in rust"
 
 [dependencies]

--- a/test-crates/some_path_dep/Cargo.toml
+++ b/test-crates/some_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "some_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/transitive_path_dep/Cargo.toml
+++ b/test-crates/transitive_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transitive_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/workspace/py/Cargo.toml
+++ b/test-crates/workspace/py/Cargo.toml
@@ -2,6 +2,6 @@
 name = "py"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This bumps our MSRV to 1.56.0.