### PR TITLE
Fix false positive missing pyinit warning on arm64 macOS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Refactor `develop` command to act identical to PEP 660 editable wheels in [#653](https://github.com/PyO3/maturin/pull/653)
 * Upgrade to Rust 2021 edition in [#655](https://github.com/PyO3/maturin/pull/655)
 * Add support for powerpc64 and powerpc64le on FreeBSD by pkubaj in [#656](https://github.com/PyO3/maturin/pull/656)
+* Fix false positive missing pyinit warning on arm64 macOS in [#673](https://github.com/PyO3/maturin/pull/673)
 
 ## [0.11.5] - 2021-10-13
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -318,6 +318,15 @@ pub fn warn_missing_py_init(artifact: &Path, module_name: &str) -> Result<()> {
                             break;
                         }
                     }
+                    if !found {
+                        for sym in macho.symbols() {
+                            let (sym_name, _) = sym?;
+                            if py_init == sym_name.strip_prefix('_').unwrap_or(sym_name) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
                 }
                 goblin::mach::Mach::Fat(_) => {
                     // Ignore fat macho,


### PR DESCRIPTION
Fixes #672 