### PR TITLE
[win-arm64] Build without rustls package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,10 @@ class PostInstallCommand(install):
                 "--message-format=json",
             ]
 
-            if platform.machine() in ("ppc64le", "ppc64", "powerpc") or get_platform() == "win-arm64":
+            if (
+                platform.machine() in ("ppc64le", "ppc64", "powerpc")
+                or get_platform() == "win-arm64"
+            ):
                 cargo_args.extend(
                     ["--no-default-features", "--features=upload,log,human-panic"]
                 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import sys
 import toml
 from setuptools import setup
 from setuptools.command.install import install
+from setuptools._distutils.util import get_platform
 
 # Force the wheel to be platform specific
 # https://stackoverflow.com/a/45150383/3549270
@@ -69,7 +70,7 @@ class PostInstallCommand(install):
                 "--message-format=json",
             ]
 
-            if platform.machine() in ("ppc64le", "ppc64", "powerpc"):
+            if platform.machine() in ("ppc64le", "ppc64", "powerpc") or get_platform() == "win-arm64":
                 cargo_args.extend(
                     ["--no-default-features", "--features=upload,log,human-panic"]
                 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ import sys
 import toml
 from setuptools import setup
 from setuptools.command.install import install
-from setuptools._distutils.util import get_platform
 
 # Force the wheel to be platform specific
 # https://stackoverflow.com/a/45150383/3549270
@@ -70,9 +69,8 @@ class PostInstallCommand(install):
                 "--message-format=json",
             ]
 
-            if (
-                platform.machine() in ("ppc64le", "ppc64", "powerpc")
-                or get_platform() == "win-arm64"
+            if platform.machine() in ("ppc64le", "ppc64", "powerpc") or (
+                sys.platform == "win32" and platform.machine() == "ARM64"
             ):
                 cargo_args.extend(
                     ["--no-default-features", "--features=upload,log,human-panic"]


### PR DESCRIPTION
Build without rustls package as ring dependency is missing win/arm64 support.