### PR TITLE
Add a `runnable` field to `PythonInterpreter`

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -578,6 +578,7 @@ pub fn find_interpreter(
                         abi_tag,
                         libs_dir: PathBuf::from(cross_lib_dir),
                         platform: None,
+                        runnable: false,
                     }];
                 }
             }
@@ -625,6 +626,7 @@ pub fn find_interpreter(
                         abi_tag: None,
                         libs_dir: PathBuf::from(manual_base_prefix),
                         platform: None,
+                        runnable: false,
                     }])
                 } else {
                     let interp = interpreter

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -219,8 +219,8 @@ fn compile_target(
     }
 
     if let Some(python_interpreter) = python_interpreter {
-        // `python_interpreter.executable` could be empty when cross compiling
-        if python_interpreter.executable != PathBuf::new() {
+        // Target python interpreter isn't runnable when cross compiling
+        if python_interpreter.runnable {
             if bindings_crate.is_bindings("pyo3") {
                 build_command.env("PYO3_PYTHON", &python_interpreter.executable);
             }


### PR DESCRIPTION
Refactored a bit to make it clear that cross compiling target Python interpreter isn't `runnable`.