### PR TITLE
Use platform tag from `sysconfig.platform` on non-portable Linux

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Use platform tag from `sysconfig.platform` on non-portable Linux in [#709](https://github.com/PyO3/maturin/pull/709)
+* Consider current machine architecture when generating platform tags for abi3
+  wheels on linux in [#709](https://github.com/PyO3/maturin/pull/709)
+
 ## [0.12.2] - 2021-11-26
 
 * Add support for excluding files from wheels by `.gitignore` in [#695](https://github.com/PyO3/maturin/pull/695)

--- a/src/auditwheel/platform_tag.rs
+++ b/src/auditwheel/platform_tag.rs
@@ -54,6 +54,13 @@ impl PlatformTag {
             PlatformTag::Linux => Vec::new(),
         }
     }
+
+    /// Is this a portable linux platform tag
+    ///
+    /// Only manylinux and musllinux are portable
+    pub fn is_portable(&self) -> bool {
+        !matches!(self, PlatformTag::Linux)
+    }
 }
 
 impl fmt::Display for PlatformTag {

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1,6 +1,6 @@
 use crate::auditwheel::PlatformTag;
 use crate::build_context::{BridgeModel, ProjectLayout};
-use crate::cross_compile::{find_sysconfigdata, is_cross_compiling, parse_sysconfigdata};
+use crate::cross_compile::{find_sysconfigdata, parse_sysconfigdata};
 use crate::python_interpreter::InterpreterKind;
 use crate::BuildContext;
 use crate::CargoToml;
@@ -515,7 +515,7 @@ pub fn find_interpreter(
                 }
             }
 
-            if binding_name == "pyo3" && target.is_unix() && is_cross_compiling(target)? {
+            if binding_name == "pyo3" && target.is_unix() && target.cross_compiling() {
                 if let Some(cross_lib_dir) = std::env::var_os("PYO3_CROSS_LIB_DIR") {
                     println!("⚠️ Cross-compiling is poorly supported");
                     let host_python = &interpreter[0];

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -1,5 +1,4 @@
 use crate::auditwheel::PlatformTag;
-use crate::cross_compile::is_cross_compiling;
 use crate::{BridgeModel, Target};
 use anyhow::{bail, format_err, Context, Result};
 use regex::Regex;
@@ -314,7 +313,7 @@ fn fun_with_abiflags(
 ) -> Result<String> {
     if bridge != &BridgeModel::Cffi
         && target.get_python_os() != message.system
-        && !is_cross_compiling(target)?
+        && !target.cross_compiling()
     {
         bail!(
             "platform.system() in python, {}, and the rust target, {:?}, don't match ಠ_ಠ",

--- a/src/python_interpreter.rs
+++ b/src/python_interpreter.rs
@@ -379,9 +379,11 @@ impl PythonInterpreter {
     ///
     /// If abi3 is true, cpython wheels use the generic abi3 with the given version as minimum
     pub fn get_tag(&self, platform_tag: PlatformTag, universal2: bool) -> String {
-        let platform = if self.target.is_windows() {
-            // Restrict `sysconfig.get_platform()` usage to Windows only for now
-            // so we don't need to deal with macOS deployment target
+        // Restrict `sysconfig.get_platform()` usage to Windows and non-portable Linux only for now
+        // so we don't need to deal with macOS deployment target
+        let use_sysconfig_platform =
+            self.target.is_windows() || (self.target.is_linux() && !platform_tag.is_portable());
+        let platform = if use_sysconfig_platform {
             self.platform
                 .clone()
                 .unwrap_or_else(|| self.target.get_platform_tag(platform_tag, universal2))

--- a/tests/common/editable.rs
+++ b/tests/common/editable.rs
@@ -23,6 +23,8 @@ pub fn test_editable(package: impl AsRef<Path>, bindings: Option<String>) -> Res
         &interpreter,
         "--manifest-path",
         &package_string,
+        "--compatibility",
+        "linux",
         "--cargo-extra-args='--quiet'",
     ];
 


### PR DESCRIPTION
Stop hard-code linux platform tag for non-portable Linux. This allows build `linux_armv8l` wheels on 64-bit Linux running in 32-bit mode, for example `linux32 python3 -m sysconfig`:

```
Platform: "linux-armv8l"
Python version: "3.8"
Current installation scheme: "posix_prefix"
```

This removes the need for patch on Alpine Linux armhf and armv7 CI runners, [it was painful](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/25616).

I've tested on a Raspberry Pi running a 64-bit Ubuntu.

See also https://github.com/pypa/packaging/issues/476