### PR TITLE
Revert "Upgrade to Rust 2021 edition"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+checksum = "0a03e93e97a28fbc9f42fbc5ba0886a3c67eb637b476dbee711f80a6ffe8223d"
 
 [[package]]
 name = "async-io"
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "quoted_printable"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1238256b09923649ec89b08104c4dfe9f6cb2fea734a5db5384e44916d59e9c5"
+checksum = "3fee2dce59f7a43418e3382c766554c614e06a552d53a8f07ef499ea4b332c0f"
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/pyo3/maturin"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "cffi", "packaging", "pypi", "pyo3"]
 categories = ["api-bindings", "development-tools::ffi", "command-line-utilities"]
-edition = "2021"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "PyO3/maturin" }

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use platform tag from `sysconfig.platform` on non-portable Linux in [#709](https://github.com/PyO3/maturin/pull/709)
 * Consider current machine architecture when generating platform tags for abi3
   wheels on linux in [#709](https://github.com/PyO3/maturin/pull/709)
+* Revert back to Rust 2018 edition in [#710](https://github.com/PyO3/maturin/pull/710)
 
 ## [0.12.2] - 2021-11-26
 

--- a/test-crates/cargo-mock/Cargo.toml
+++ b/test-crates/cargo-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-mock"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 [[bin]]
 name = "cargo"

--- a/test-crates/cffi-mixed/Cargo.toml
+++ b/test-crates/cffi-mixed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-mixed"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 name = "cffi_mixed"

--- a/test-crates/cffi-pure/Cargo.toml
+++ b/test-crates/cffi-pure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-pure"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 name = "cffi_pure"

--- a/test-crates/hello-world/Cargo.toml
+++ b/test-crates/hello-world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello-world"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 # Test references to out-of-project files
 readme = "../../Readme.md"
 

--- a/test-crates/lib_with_disallowed_lib/Cargo.toml
+++ b/test-crates/lib_with_disallowed_lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_disallowed_lib"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/lib_with_path_dep/Cargo.toml
+++ b/test-crates/lib_with_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/pyo3-abi3-without-version/Cargo.toml
+++ b/test-crates/pyo3-abi3-without-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3-abi3-without-version"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 pyo3 = { version = "0.15.1", features = ["abi3", "extension-module"] }

--- a/test-crates/pyo3-feature/Cargo.toml
+++ b/test-crates/pyo3-feature/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-feature"
 version = "0.7.3"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 pyo3 = { version = "0.15.1", optional = true }

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-py-subdir"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 pyo3 = { version = "0.15.1", features = ["extension-module"] }

--- a/test-crates/pyo3-mixed-submodule/Cargo.toml
+++ b/test-crates/pyo3-mixed-submodule/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-submodule"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2021"
+edition = "2018"
 
 [package.metadata.maturin]
 name = "pyo3_mixed_submodule.rust_module.rust"

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "Readme.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 pyo3 = { version = "0.15.1", features = ["extension-module"] }

--- a/test-crates/pyo3-no-extension-module/Cargo.toml
+++ b/test-crates/pyo3-no-extension-module/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-no-extension-module"
 version = "2.1.0"
 description = "Does not use the extension-module feature, thus erroneously linking libpython"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 pyo3 = { version = "0.15.1", default-features = false }

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-pure"
 version = "2.1.2"
-edition = "2021"
+edition = "2018"
 description = "Implements a dummy function (get_fortytwo.DummyClass.get_42()) in rust"
 
 [dependencies]

--- a/test-crates/some_path_dep/Cargo.toml
+++ b/test-crates/some_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "some_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/transitive_path_dep/Cargo.toml
+++ b/test-crates/transitive_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transitive_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/workspace/py/Cargo.toml
+++ b/test-crates/workspace/py/Cargo.toml
@@ -2,6 +2,6 @@
 name = "py"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This reverts commit 55a5fefdfa9c00abfd99b4df7302439b3a3d9461.

We're not using any of new features Rust 2021 edition, will upgrade when we do.

Closes #708 