### PR TITLE
new: include function example for PyO3 bindings

### DIFF
--- a/src/templates/lib.rs.j2
+++ b/src/templates/lib.rs.j2
@@ -1,8 +1,16 @@
 {%- if bindings == "pyo3" -%}
 use pyo3::prelude::*;
 
+/// Formats the sum of two numbers as string.
+#[pyfunction]
+fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+
+/// A Python module implemented in Rust.
 #[pymodule]
 fn {{crate_name}}(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }
 {%- elif bindings == "rust-cpython" -%}


### PR DESCRIPTION
Thanks for adding `maturin new`, it's a neat solution!

This is just a tiny suggestion to add a function example to the generated template for PyO3 bindings. I think it helps users figure out what to do next as well as removes an "unused variable" warning for `m: &PyModule`.