### PR TITLE
init: new command similar to `cargo init`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add a `maturin init` command as a companion to `maturin new` in [#719](https://github.com/PyO3/maturin/pull/719)
+
 ## [0.12.3] - 2021-11-29
 
 * Use platform tag from `sysconfig.platform` on non-portable Linux in [#709](https://github.com/PyO3/maturin/pull/709)
@@ -122,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.3] - 2021-04-13
 
  * The `upload` command is now implemented, it is mostly similar to `twine upload`. [#484](https://github.com/PyO3/maturin/pull/484)
- * Interpreter search now uses python 3.6 to 3.12 
+ * Interpreter search now uses python 3.6 to 3.12
  * Add basic support for OpenBSD in [#496](https://github.com/PyO3/maturin/pull/496)
  * Fix the PowerPC platform by messense in [#503](https://github.com/PyO3/maturin/pull/503)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::metadata::{Metadata21, WheelMetadata};
 pub use crate::module_writer::{
     write_dist_info, ModuleWriter, PathWriter, SDistWriter, WheelWriter,
 };
-pub use crate::new_project::new_project;
+pub use crate::new_project::{init_project, new_project, GenerateProjectOptions};
 pub use crate::pyproject_toml::PyProjectToml;
 pub use crate::python_interpreter::PythonInterpreter;
 pub use crate::target::Target;


### PR DESCRIPTION
I was writing an updated PyO3 README and found I wanted to create the virtualenv inside the project directory . In particular, this is the sequence of commands I wanted to run:

```bash
$ mkdir string_sum && cd string_sum
$ python -m venv .env
$ source .env/bin/activate
$ pip install maturin
$ maturin init
$ maturin develop
```

... but this needed a hypothetical `maturin init` command instead of `maturin new`, because the directory already existed.

So this PR adds it :smile: