### PR TITLE
Allow pip warnings in maturin develop command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@21.4b0
+      - uses: psf/black@21.12b0
         with:
           args: ". --check"
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ try:
             _bdist_wheel.finalize_options(self)
             self.root_is_pure = False
 
-
 except ImportError:
     bdist_wheel = None
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -93,11 +93,9 @@ pub fn develop(
             );
         }
         if !output.stderr.is_empty() {
-            bail!(
-                "pip raised a warning running {:?}: {}\n--- Stdout:\n{}\n--- Stderr:\n{}\n---\n",
+            eprintln!(
+                "⚠️  Warning: pip raised a warning running {:?}:\n{}",
                 &command,
-                output.status,
-                str::from_utf8(&output.stdout)?.trim(),
                 str::from_utf8(&output.stderr)?.trim(),
             );
         }


### PR DESCRIPTION
```bash
❯ PYTHONWARNINGS=default cargo run develop -m test-crates/pyo3-pure/Cargo.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/maturin develop -m test-crates/pyo3-pure/Cargo.toml`
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.6
🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
📡 Using build options bindings from pyproject.toml
/Users/messense/.pyenv/versions/3.10.0/envs/test-py310/lib/python3.10/site-packages/pip/_internal/locations/_distutils.py:9: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.cmd import Command as DistutilsCommand
/Users/messense/.pyenv/versions/3.10.0/lib/python3.10/distutils/command/install.py:13: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  from distutils.sysconfig import get_config_vars
Ignoring attrs: markers 'extra == "test"' don't match your environment
Ignoring boltons: markers 'sys_platform == "win32" and extra == "test"' don't match your environment
WARNING: You are using pip version 21.2.3; however, version 21.3.1 is available.
You should consider upgrading via the '/Users/messense/.pyenv/versions/3.10.0/envs/test-py310/bin/python -m pip install --upgrade pip' command.
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
📖 Found type stub file at pyo3_pure.pyi
📦 Built wheel for abi3 Python ≥ 3.6 to /Users/messense/Projects/maturin/test-crates/pyo3-pure/target/wheels/pyo3_pure-2.1.2-cp36-abi3-macosx_11_0_arm64.whl
⚠️  Warning: pip raised a warning running ["-m", "pip", "--disable-pip-version-check", "install", "--force-reinstall", "/Users/messense/Projects/maturin/test-crates/pyo3-pure/target/wheels/pyo3_pure-2.1.2-cp36-abi3-macosx_11_0_arm64.whl"]:
/Users/messense/.pyenv/versions/3.10.0/envs/test-py310/lib/python3.10/site-packages/pip/_internal/locations/_distutils.py:9: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.cmd import Command as DistutilsCommand
/Users/messense/.pyenv/versions/3.10.0/lib/python3.10/distutils/command/install.py:13: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  from distutils.sysconfig import get_config_vars
🛠  Installed pyo3-pure-2.1.2
```

Fixes #731 