### PR TITLE
Fix docs for `new` and `init` commands in `maturin --help`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix docs for `new` and `init` commands in `maturin --help` in [#734](https://github.com/PyO3/maturin/pull/734)
+
 ## [0.12.4] - 2021-12-06
 
 * Add a `maturin init` command as a companion to `maturin new` in [#719](https://github.com/PyO3/maturin/pull/719)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,10 @@
 use anyhow::{bail, Context, Result};
 use cargo_metadata::MetadataCommand;
 use fs_err as fs;
-use maturin::GenerateProjectOptions;
 use maturin::{
     develop, init_project, new_project, source_distribution, write_dist_info, BridgeModel,
-    BuildOptions, CargoToml, Metadata21, PathWriter, PlatformTag, PyProjectToml, PythonInterpreter,
-    Target,
+    BuildOptions, CargoToml, GenerateProjectOptions, Metadata21, PathWriter, PlatformTag,
+    PyProjectToml, PythonInterpreter, Target,
 };
 #[cfg(feature = "upload")]
 use maturin::{upload_ui, PublishOpt};

--- a/src/new_project.rs
+++ b/src/new_project.rs
@@ -89,8 +89,10 @@ impl<'a> ProjectGenerator<'a> {
     }
 }
 
+// workaround for https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(doc, doc = "Options common to `maturin new` and `maturin init`.")]
 #[derive(Debug, StructOpt)]
-/// Options common to `maturin new` and `maturin init`.
 pub struct GenerateProjectOptions {
     /// Set the resulting package name, defaults to the directory name
     #[structopt(long)]


### PR DESCRIPTION
Before

```bash
❯ maturin --help
maturin 0.12.4
Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages

USAGE:
    maturin <SUBCOMMAND>

FLAGS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information


SUBCOMMANDS:
    build          High level API for building wheels from a crate which is also used for the CLI
    develop        Installs the crate as module in the current virtualenv
    help           Prints this message or the help of the given subcommand(s)
    init           Options common to `maturin new` and `maturin init`
    list-python    Searches and lists the available python installations
    new            Options common to `maturin new` and `maturin init`
    publish        An account with a registry, possibly incomplete
    sdist          Build only a source distribution (sdist) without compiling
    upload         An account with a registry, possibly incomplete
```

> Options common to `maturin new` and `maturin init`

This is caused by https://github.com/TeXitoi/structopt/issues/333

After

```bash
❯ cargo run -- --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/maturin --help`
maturin 0.12.4
Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages

USAGE:
    maturin <SUBCOMMAND>

FLAGS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information


SUBCOMMANDS:
    build          High level API for building wheels from a crate which is also used for the CLI
    develop        Installs the crate as module in the current virtualenv
    help           Prints this message or the help of the given subcommand(s)
    init           Create a new cargo project in an existing directory
    list-python    Searches and lists the available python installations
    new            Create a new cargo project
    publish        An account with a registry, possibly incomplete
    sdist          Build only a source distribution (sdist) without compiling
    upload         An account with a registry, possibly incomplete
```