### PR TITLE
Fix `upload::canonicalize_name()` regex subst

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix docs for `new` and `init` commands in `maturin --help` in [#734](https://github.com/PyO3/maturin/pull/734)
 * Add support for x86_64 Haiku in [#735](https://github.com/PyO3/maturin/pull/735)
+* Fix sdist upload for packages where the pkgname contains multiple underscores in [#741](https://github.com/PyO3/maturin/pull/741)
 
 ## [0.12.4] - 2021-12-06
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -198,7 +198,7 @@ fn complete_registry(opt: &PublishOpt) -> Result<Registry> {
 fn canonicalize_name(name: &str) -> String {
     Regex::new("[-_.]+")
         .unwrap()
-        .replace(name, "-")
+        .replace_all(name, "-")
         .to_lowercase()
 }
 


### PR DESCRIPTION
Python `Pattern.sub()` corresponds to Rust `Regex::replace_all()`,
not `Regex::replace()`.

This fixes a bug where the same Python package `a_b_c` is uploaded
as both `a-b-c` (wheel) and `a-b_c` (sdist).