### PR TITLE
Implement auditwheel repair with patchelf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.9"
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.10.0"
       - name: Install cffi and virtualenv
         run: pip install cffi virtualenv
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lddtree"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5d1501bcbb2572cd5aaec64307faf409b52f25c0d8adbaeaa8afe01387f467"
+dependencies = [
+ "fs-err",
+ "glob",
+ "goblin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1085,7 @@ dependencies = [
  "ignore",
  "indoc",
  "keyring",
+ "lddtree",
  "minijinja",
  "once_cell",
  "platform-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ignore = "0.4.18"
 dialoguer = "0.9.0"
 console = "0.15.0"
 minijinja = "0.8.2"
-lddtree = "0.1.2"
+lddtree = "0.1.4"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ ignore = "0.4.18"
 dialoguer = "0.9.0"
 console = "0.15.0"
 minijinja = "0.8.2"
+lddtree = "0.1.2"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix undefined auditwheel policy panic in [#740](https://github.com/PyO3/maturin/pull/740)
 * Fix sdist upload for packages where the pkgname contains multiple underscores in [#741](https://github.com/PyO3/maturin/pull/741)
 * Add `Cargo.lock` to sdist when `--locked` or `--frozen` specified in [#749](https://github.com/PyO3/maturin/pull/749)
+* Implement auditwheel repair with patchelf in [#742](https://github.com/PyO3/maturin/pull/742)
 
 ## [0.12.4] - 2021-12-06
 

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -255,6 +255,7 @@ pub fn auditwheel_rs(
     if !target.is_linux() || platform_tag == Some(PlatformTag::Linux) {
         return Ok((Policy::default(), false));
     }
+    let cross_compiling = target.cross_compiling();
     let arch = target.target_arch().to_string();
     let mut file = File::open(path).map_err(AuditWheelError::IoError)?;
     let mut buffer = Vec::new();
@@ -298,10 +299,15 @@ pub fn auditwheel_rs(
                 should_repair = false;
                 break;
             }
-            Err(AuditWheelError::LinksForbiddenLibrariesError(..)) => {
-                highest_policy = Some(policy.clone());
-                should_repair = true;
-                break;
+            Err(err @ AuditWheelError::LinksForbiddenLibrariesError(..)) => {
+                // TODO: support repair for cross compiled wheels
+                if !cross_compiling {
+                    highest_policy = Some(policy.clone());
+                    should_repair = true;
+                    break;
+                } else {
+                    return Err(err);
+                }
             }
             Err(AuditWheelError::VersionedSymbolTooNewError(..))
             | Err(AuditWheelError::BlackListedSymbolsError(..))
@@ -333,9 +339,14 @@ pub fn auditwheel_rs(
                 should_repair = false;
                 Ok(policy)
             }
-            Err(AuditWheelError::LinksForbiddenLibrariesError(..)) => {
-                should_repair = true;
-                Ok(policy)
+            Err(err @ AuditWheelError::LinksForbiddenLibrariesError(..)) => {
+                // TODO: support repair for cross compiled wheels
+                if !cross_compiling {
+                    should_repair = true;
+                    Ok(policy)
+                } else {
+                    Err(err)
+                }
             }
             Err(err) => Err(err),
         }

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -37,7 +37,7 @@ pub enum AuditWheelError {
     /// The elf file isn't manylinux/musllinux compatible. Contains the list of offending
     /// libraries.
     #[error(
-    "Your library is not {0} compliant because of the presence of too-recent versioned symbols: {1:?}",
+    "Your library is not {0} compliant because of the presence of too-recent versioned symbols: {1:?}. Consider building in a manylinux docker container",
     )]
     VersionedSymbolTooNewError(Policy, Vec<String>),
     /// The elf file isn't manylinux/musllinux compatible. Contains the list of offending
@@ -240,8 +240,9 @@ fn get_default_platform_policies() -> Vec<Policy> {
 /// An reimplementation of auditwheel, which checks elf files for
 /// manylinux/musllinux compliance.
 ///
-/// If `platform_tag`, is None, it returns the the highest matching manylinux/musllinux policy, or `linux`
-/// if nothing else matches. It will error for bogus cases, e.g. if libpython is linked.
+/// If `platform_tag`, is None, it returns the the highest matching manylinux/musllinux policy
+/// and whether we need to repair with patchelf,, or `linux` if nothing else matches.
+/// It will error for bogus cases, e.g. if libpython is linked.
 ///
 /// If a specific manylinux/musllinux version is given, compliance is checked and a warning printed if
 /// a higher version would be possible.

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -3,7 +3,9 @@ mod musllinux;
 mod patchelf;
 mod platform_tag;
 mod policy;
+mod repair;
 
-pub use self::audit::*;
+pub use audit::*;
 pub use platform_tag::PlatformTag;
 pub use policy::{Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
+pub use repair::repair;

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod musllinux;
+mod patchelf;
 mod platform_tag;
 mod policy;
 

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -1,6 +1,6 @@
 mod audit;
 mod musllinux;
-mod patchelf;
+pub mod patchelf;
 mod platform_tag;
 mod policy;
 mod repair;
@@ -8,4 +8,4 @@ mod repair;
 pub use audit::*;
 pub use platform_tag::PlatformTag;
 pub use policy::{Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
-pub use repair::repair;
+pub use repair::{get_external_libs, hash_file};

--- a/src/auditwheel/patchelf.rs
+++ b/src/auditwheel/patchelf.rs
@@ -1,0 +1,80 @@
+use anyhow::{bail, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// Replace a declared dependency on a dynamic library with another one (`DT_NEEDED`)
+pub fn replace_needed(file: impl AsRef<Path>, old_lib: &str, new_lib: &str) -> Result<()> {
+    let mut cmd = Command::new("patchelf");
+    cmd.arg("--replace-needed")
+        .arg(old_lib)
+        .arg(new_lib)
+        .arg(file.as_ref());
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!(
+            "patchelf failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Change `SONAME` of a dynamic library
+pub fn set_soname(file: impl AsRef<Path>, soname: &str) -> Result<()> {
+    let mut cmd = Command::new("patchelf");
+    cmd.arg("--set-soname").arg(soname).arg(file.as_ref());
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!(
+            "patchelf failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// /// Remove a `RPATH` from executables and libraries
+pub fn remove_rpath(file: impl AsRef<Path>, rpath: &str) -> Result<()> {
+    let mut cmd = Command::new("patchelf");
+    cmd.arg("--remove-rpath").arg(file.as_ref()).arg(rpath);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!(
+            "patchelf failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Change the `RPATH` of executables and libraries
+pub fn set_rpath(file: impl AsRef<Path>, rpath: &str) -> Result<()> {
+    let mut cmd = Command::new("patchelf");
+    cmd.arg("--force-rpath")
+        .arg("--set-rpath")
+        .arg(rpath)
+        .arg(file.as_ref());
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!(
+            "patchelf failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Get the `RPATH` of executables and libraries
+pub fn get_rpath(file: impl AsRef<Path>) -> Result<String> {
+    let mut cmd = Command::new("patchelf");
+    cmd.arg("--print-rpath").arg(file.as_ref());
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!(
+            "patchelf failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let rpath = String::from_utf8(output.stdout)?;
+    Ok(rpath.trim().to_string())
+}

--- a/src/auditwheel/repair.rs
+++ b/src/auditwheel/repair.rs
@@ -1,19 +1,40 @@
-use super::audit::{find_versioned_libraries, AuditWheelError};
+use super::audit::AuditWheelError;
+use crate::auditwheel::Policy;
 use anyhow::Result;
 use fs_err as fs;
-use goblin::elf::Elf;
-use std::io::Read;
+use lddtree::DependencyAnalyzer;
+use sha2::{Digest, Sha256};
+use std::io;
 use std::path::Path;
 
-pub fn repair(artifact: impl AsRef<Path>) -> Result<(), AuditWheelError> {
-    let mut file = fs::File::open(artifact.as_ref()).map_err(AuditWheelError::IoError)?;
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)
-        .map_err(AuditWheelError::IoError)?;
-    let elf = Elf::parse(&buffer).map_err(AuditWheelError::GoblinError)?;
-    let ext_libs = find_versioned_libraries(&elf);
-    for lib in ext_libs {
-        println!("{}", lib.name);
+pub fn get_external_libs(
+    artifact: impl AsRef<Path>,
+    policy: &Policy,
+) -> Result<Vec<lddtree::Library>, AuditWheelError> {
+    let dep_analyzer = DependencyAnalyzer::new();
+    let deps = dep_analyzer.analyze(artifact).unwrap();
+    let mut ext_libs = Vec::new();
+    for (name, lib) in deps.libraries {
+        // Skip dynamic linker/loader and white-listed libs
+        if name.starts_with("ld-linux")
+            || name == "ld64.so.2"
+            || name == "ld64.so.1"
+            // musl libc, eg: libc.musl-aarch64.so.1
+            || name.starts_with("libc.")
+            || policy.lib_whitelist.contains(&name)
+        {
+            continue;
+        }
+        ext_libs.push(lib);
     }
-    Ok(())
+    Ok(ext_libs)
+}
+
+/// Calculate the sha256 of a file
+pub fn hash_file(path: impl AsRef<Path>) -> Result<String, AuditWheelError> {
+    let mut file = fs::File::open(path.as_ref()).map_err(AuditWheelError::IoError)?;
+    let mut hasher = Sha256::new();
+    io::copy(&mut file, &mut hasher).map_err(AuditWheelError::IoError)?;
+    let hex = format!("{:x}", hasher.finalize());
+    Ok(hex)
 }

--- a/src/auditwheel/repair.rs
+++ b/src/auditwheel/repair.rs
@@ -1,0 +1,19 @@
+use super::audit::{find_versioned_libraries, AuditWheelError};
+use anyhow::Result;
+use fs_err as fs;
+use goblin::elf::Elf;
+use std::io::Read;
+use std::path::Path;
+
+pub fn repair(artifact: impl AsRef<Path>) -> Result<(), AuditWheelError> {
+    let mut file = fs::File::open(artifact.as_ref()).map_err(AuditWheelError::IoError)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)
+        .map_err(AuditWheelError::IoError)?;
+    let elf = Elf::parse(&buffer).map_err(AuditWheelError::GoblinError)?;
+    let ext_libs = find_versioned_libraries(&elf);
+    for lib in ext_libs {
+        println!("{}", lib.name);
+    }
+    Ok(())
+}

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1,15 +1,19 @@
-use crate::auditwheel::{auditwheel_rs, repair, PlatformTag, Policy};
+use crate::auditwheel::{
+    auditwheel_rs, get_external_libs, hash_file, patchelf, PlatformTag, Policy,
+};
 use crate::compile::warn_missing_py_init;
 use crate::module_writer::{
     write_bin, write_bindings_module, write_cffi_module, write_python_part, WheelWriter,
 };
 use crate::python_interpreter::InterpreterKind;
 use crate::source_distribution::source_distribution;
-use crate::{compile, Metadata21, PyProjectToml, PythonInterpreter, Target};
+use crate::{compile, Metadata21, ModuleWriter, PyProjectToml, PythonInterpreter, Target};
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_metadata::Metadata;
 use fs_err as fs;
+use lddtree::Library;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// The way the rust code is used in the wheel
@@ -250,9 +254,9 @@ impl BuildContext {
         python_interpreter: Option<&PythonInterpreter>,
         artifact: &Path,
         platform_tag: Option<PlatformTag>,
-    ) -> Result<Policy> {
+    ) -> Result<(Policy, Vec<Library>)> {
         if self.skip_auditwheel {
-            return Ok(Policy::default());
+            return Ok((Policy::default(), Vec::new()));
         }
 
         let target = python_interpreter
@@ -267,16 +271,84 @@ impl BuildContext {
                     "Error checking for manylinux/musllinux compliance".to_string()
                 }
             })?;
-        if should_repair {
-            repair(&artifact).with_context(|| {
+        let external_libs = if should_repair && !self.editable {
+            get_external_libs(&artifact, &policy).with_context(|| {
                 if let Some(platform_tag) = platform_tag {
                     format!("Error repairing wheel for {} compliance", platform_tag)
                 } else {
                     "Error repairing wheel for manylinux/musllinux compliance".to_string()
                 }
-            })?;
+            })?
+        } else {
+            Vec::new()
+        };
+        Ok((policy, external_libs))
+    }
+
+    fn add_external_libs(
+        &self,
+        writer: &mut WheelWriter,
+        artifact: &Path,
+        ext_libs: &[Library],
+    ) -> Result<()> {
+        if ext_libs.is_empty() {
+            return Ok(());
         }
-        Ok(policy)
+        // Put external libs to ${module_name}.libs directory
+        // See https://github.com/pypa/auditwheel/issues/89
+        let libs_dir = PathBuf::from(format!("{}.libs", self.module_name));
+        writer.add_directory(&libs_dir)?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let mut soname_map = HashMap::new();
+        for lib in ext_libs {
+            let lib_path = lib.realpath.clone().with_context(|| {
+                format!(
+                    "Cannot repair wheel, because required library {} could not be located.",
+                    lib.path.display()
+                )
+            })?;
+            let short_hash = &hash_file(&lib_path)?[..8];
+            let (file_stem, file_ext) = lib.name.split_once('.').unwrap();
+            let new_soname = if !file_stem.ends_with(&format!("-{}", short_hash)) {
+                format!("{}-{}.{}", file_stem, short_hash, file_ext)
+            } else {
+                format!("{}.{}", file_stem, file_ext)
+            };
+            let dest_path = temp_dir.path().join(&new_soname);
+            fs::copy(&lib_path, &dest_path)?;
+            patchelf::set_soname(&dest_path, &new_soname)?;
+            if !lib.rpath.is_empty() || !lib.runpath.is_empty() {
+                patchelf::set_rpath(&dest_path, &libs_dir)?;
+            }
+            soname_map.insert(
+                lib.name.clone(),
+                (new_soname.clone(), dest_path.clone(), lib.needed.clone()),
+            );
+
+            patchelf::replace_needed(artifact, &lib.name, &new_soname)?;
+        }
+
+        // we grafted in a bunch of libraries and modified their sonames, but
+        // they may have internal dependencies (DT_NEEDED) on one another, so
+        // we need to update those records so each now knows about the new
+        // name of the other.
+        for (new_soname, path, needed) in soname_map.values() {
+            for n in needed {
+                if soname_map.contains_key(n) {
+                    patchelf::replace_needed(path, n, &soname_map[n].0)?;
+                }
+            }
+            writer.add_file_with_permissions(libs_dir.join(new_soname), path, 0o755)?;
+        }
+
+        // Currently artifact .so file always resides at ${module_name}/${module_name}.so
+        let artifact_dir = Path::new(&self.module_name);
+        let new_rpath = Path::new("$ORIGIN").join(relpath(&libs_dir, artifact_dir));
+        // FIXME: preserving existing rpath entries
+        // See https://github.com/pypa/auditwheel/blob/353c24250d66951d5ac7e60b97471a6da76c123f/src/auditwheel/repair.py#L160
+        patchelf::set_rpath(artifact, &new_rpath)?;
+        Ok(())
     }
 
     fn add_pth(&self, writer: &mut WheelWriter) -> Result<()> {
@@ -290,6 +362,7 @@ impl BuildContext {
         &self,
         artifact: &Path,
         platform_tag: PlatformTag,
+        ext_libs: &[Library],
         major: u8,
         min_minor: u8,
     ) -> Result<BuiltWheelMetadata> {
@@ -299,6 +372,7 @@ impl BuildContext {
         let tag = format!("cp{}{}-abi3-{}", major, min_minor, platform);
 
         let mut writer = WheelWriter::new(&tag, &self.out, &self.metadata21, &[tag.clone()])?;
+        self.add_external_libs(&mut writer, artifact, ext_libs)?;
 
         write_bindings_module(
             &mut writer,
@@ -333,9 +407,15 @@ impl BuildContext {
             python_interpreter,
             Some(self.project_layout.extension_name()),
         )?;
-        let policy = self.auditwheel(python_interpreter, &artifact, self.platform_tag)?;
-        let (wheel_path, tag) =
-            self.write_binding_wheel_abi3(&artifact, policy.platform_tag(), major, min_minor)?;
+        let (policy, external_libs) =
+            self.auditwheel(python_interpreter, &artifact, self.platform_tag)?;
+        let (wheel_path, tag) = self.write_binding_wheel_abi3(
+            &artifact,
+            policy.platform_tag(),
+            &external_libs,
+            major,
+            min_minor,
+        )?;
 
         println!(
             "📦 Built wheel for abi3 Python ≥ {}.{} to {}",
@@ -353,10 +433,12 @@ impl BuildContext {
         python_interpreter: &PythonInterpreter,
         artifact: &Path,
         platform_tag: PlatformTag,
+        ext_libs: &[Library],
     ) -> Result<BuiltWheelMetadata> {
         let tag = python_interpreter.get_tag(platform_tag, self.universal2)?;
 
         let mut writer = WheelWriter::new(&tag, &self.out, &self.metadata21, &[tag.clone()])?;
+        self.add_external_libs(&mut writer, artifact, ext_libs)?;
 
         write_bindings_module(
             &mut writer,
@@ -395,9 +477,14 @@ impl BuildContext {
                 Some(python_interpreter),
                 Some(self.project_layout.extension_name()),
             )?;
-            let policy = self.auditwheel(Some(python_interpreter), &artifact, self.platform_tag)?;
-            let (wheel_path, tag) =
-                self.write_binding_wheel(python_interpreter, &artifact, policy.platform_tag())?;
+            let (policy, external_libs) =
+                self.auditwheel(Some(python_interpreter), &artifact, self.platform_tag)?;
+            let (wheel_path, tag) = self.write_binding_wheel(
+                python_interpreter,
+                &artifact,
+                policy.platform_tag(),
+                &external_libs,
+            )?;
             println!(
                 "📦 Built wheel for {} {}.{}{} to {}",
                 python_interpreter.interpreter_kind,
@@ -413,8 +500,7 @@ impl BuildContext {
         Ok(wheels)
     }
 
-    /// Runs cargo build, extracts the cdylib from the output, runs auditwheel and returns the
-    /// artifact
+    /// Runs cargo build, extracts the cdylib from the output and returns the path to it
     ///
     /// The module name is used to warn about missing a `PyInit_<module name>` function for
     /// bindings modules.
@@ -438,19 +524,29 @@ impl BuildContext {
                 .context("Failed to parse the native library")?;
         }
 
-        Ok(artifact)
+        if self.editable || self.skip_auditwheel {
+            return Ok(artifact);
+        }
+        // auditwheel repair will edit the file, so we need to copy it to avoid errors in reruns
+        let maturin_build = artifact.parent().unwrap().join("maturin");
+        fs::create_dir_all(&maturin_build)?;
+        let new_artifact = maturin_build.join(artifact.file_name().unwrap());
+        fs::copy(&artifact, &new_artifact)?;
+        Ok(new_artifact)
     }
 
     fn write_cffi_wheel(
         &self,
         artifact: &Path,
         platform_tag: PlatformTag,
+        ext_libs: &[Library],
     ) -> Result<BuiltWheelMetadata> {
         let (tag, tags) = self
             .target
             .get_universal_tags(platform_tag, self.universal2)?;
 
         let mut writer = WheelWriter::new(&tag, &self.out, &self.metadata21, &tags)?;
+        self.add_external_libs(&mut writer, artifact, ext_libs)?;
 
         write_cffi_module(
             &mut writer,
@@ -472,8 +568,9 @@ impl BuildContext {
     pub fn build_cffi_wheel(&self) -> Result<Vec<BuiltWheelMetadata>> {
         let mut wheels = Vec::new();
         let artifact = self.compile_cdylib(None, None)?;
-        let policy = self.auditwheel(None, &artifact, self.platform_tag)?;
-        let (wheel_path, tag) = self.write_cffi_wheel(&artifact, policy.platform_tag())?;
+        let (policy, external_libs) = self.auditwheel(None, &artifact, self.platform_tag)?;
+        let (wheel_path, tag) =
+            self.write_cffi_wheel(&artifact, policy.platform_tag(), &external_libs)?;
 
         // Warn if cffi isn't specified in the requirements
         if !self
@@ -498,6 +595,7 @@ impl BuildContext {
         &self,
         artifact: &Path,
         platform_tag: PlatformTag,
+        ext_libs: &[Library],
     ) -> Result<BuiltWheelMetadata> {
         let (tag, tags) = self
             .target
@@ -528,6 +626,8 @@ impl BuildContext {
         let bin_name = artifact
             .file_name()
             .expect("Couldn't get the filename from the binary produced by cargo");
+        self.add_external_libs(&mut writer, artifact, ext_libs)?;
+
         write_bin(&mut writer, artifact, &self.metadata21, bin_name)?;
 
         self.add_pth(&mut writer)?;
@@ -549,12 +649,55 @@ impl BuildContext {
             .cloned()
             .ok_or_else(|| anyhow!("Cargo didn't build a binary"))?;
 
-        let policy = self.auditwheel(None, &artifact, self.platform_tag)?;
+        let (policy, external_libs) = self.auditwheel(None, &artifact, self.platform_tag)?;
 
-        let (wheel_path, tag) = self.write_bin_wheel(&artifact, policy.platform_tag())?;
+        let (wheel_path, tag) =
+            self.write_bin_wheel(&artifact, policy.platform_tag(), &external_libs)?;
         println!("📦 Built wheel to {}", wheel_path.display());
         wheels.push((wheel_path, tag));
 
         Ok(wheels)
+    }
+}
+
+fn relpath(to: &Path, from: &Path) -> PathBuf {
+    let mut suffix_pos = 0;
+    for (f, t) in from.components().zip(to.components()) {
+        if f == t {
+            suffix_pos += 1;
+        } else {
+            break;
+        }
+    }
+    let mut result = PathBuf::new();
+    from.components()
+        .skip(suffix_pos)
+        .map(|_| result.push(".."))
+        .last();
+    to.components()
+        .skip(suffix_pos)
+        .map(|x| result.push(x.as_os_str()))
+        .last();
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::relpath;
+    use std::path::Path;
+
+    #[test]
+    fn test_relpath() {
+        let cases = [
+            ("", "", ""),
+            ("/", "/usr", ".."),
+            ("/", "/usr/lib", "../.."),
+        ];
+        for (from, to, expected) in cases {
+            let from = Path::new(from);
+            let to = Path::new(to);
+            let result = relpath(from, to);
+            assert_eq!(result, Path::new(expected));
+        }
     }
 }

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -264,7 +264,7 @@ impl BuildContext {
             .unwrap_or(&self.target);
 
         let (policy, should_repair) =
-            auditwheel_rs(&artifact, target, platform_tag).with_context(|| {
+            auditwheel_rs(artifact, target, platform_tag).with_context(|| {
                 if let Some(platform_tag) = platform_tag {
                     format!("Error ensuring {} compliance", platform_tag)
                 } else {


### PR DESCRIPTION
Linux dylib dependency resolution built with [lddtree-rs](https://github.com/messense/lddtree-rs), patch dylib's `soname` and `rpath` is done with [patchelf](https://github.com/NixOS/patchelf) which means user needs to install it beforehand. Would be great if there is a pure Rust version but unfortunately I don't have the expertise to do that.

The code isn't well organized yet, but hey it works™.

Closes #649 