### PR TITLE
Support pyo3 abi3-py310 feature

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -356,11 +356,11 @@ fn has_abi3(cargo_metadata: &Metadata) -> Result<Option<(u8, u8)>> {
             let min_abi3_version = pyo3_crate
                 .features
                 .iter()
-                .filter(|x| x.starts_with("abi3-py") && x.len() == "abi3-pyxx".len())
+                .filter(|x| x.starts_with("abi3-py") && x.len() >= "abi3-pyxx".len())
                 .map(|x| {
                     Ok((
                         (x.as_bytes()[7] as char).to_string().parse::<u8>()?,
-                        (x.as_bytes()[8] as char).to_string().parse::<u8>()?,
+                        x[8..].parse::<u8>()?,
                     ))
                 })
                 .collect::<Result<Vec<(u8, u8)>>>()


### PR DESCRIPTION
When trying to build a pyo3 project with the `abi3-py310` feature enabled, maturin fails with the following error message.
```
💥 maturin failed
  Caused by: You have selected the `abi3` feature but not a minimum version (e.g. the `abi3-py36` feature). maturin needs a minimum version feature to build abi3 wheels.
```
Fix this by allowing more than one character as minor version.