### PR TITLE
Update new template to use maturin for upload

### DIFF
--- a/src/templates/CI.yml.j2
+++ b/src/templates/CI.yml.j2
@@ -57,13 +57,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: wheels
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
       - name: Publish to PyPI
+        uses: messense/maturin-action@v1
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: {{ '${{ secrets.PYPI_PASSWORD }}' }}
-        run: |
-          pip install --upgrade twine
-          twine upload --skip-existing *
+          MATURIN_PYPI_TOKEN: {{ '${{ secrets.PYPI_API_TOKEN }}' }}
+        with:
+          command: upload
+          args: --skip-existing *

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -345,7 +345,9 @@ pub fn upload_ui(items: &[PathBuf], publish: &PublishOpt) -> Result<()> {
                         Ok(()) => {
                             println!("🔑 Removed wrong password from keyring")
                         }
-                        Err(keyring::Error::NoEntry) | Err(keyring::Error::NoStorageAccess(_)) => {}
+                        Err(keyring::Error::NoEntry)
+                        | Err(keyring::Error::NoStorageAccess(_))
+                        | Err(keyring::Error::PlatformFailure(_)) => {}
                         Err(err) => {
                             eprintln!("⚠️ Warning: Failed to remove password from keyring: {}", err)
                         }
@@ -383,7 +385,9 @@ pub fn upload_ui(items: &[PathBuf], publish: &PublishOpt) -> Result<()> {
         let keyring = keyring::Entry::new(env!("CARGO_PKG_NAME"), &username);
         let password = registry.password;
         match keyring.set_password(&password) {
-            Ok(()) => {}
+            Ok(())
+            | Err(keyring::Error::NoStorageAccess(_))
+            | Err(keyring::Error::PlatformFailure(_)) => {}
             Err(err) => {
                 eprintln!(
                     "⚠️ Warning: Failed to store the password in the keyring: {:?}",


### PR DESCRIPTION
The second commit resolves the following warning on CI:

```
🚀 Uploading 12 packages
✨ Packages uploaded successfully
⚠️ Warning: Failed to store the password in the keyring: PlatformFailure(Zbus(Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })))
```

Closes https://github.com/messense/maturin-action/issues/21