### PR TITLE
Add support for repairing cross compiled linux wheels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,9 +1022,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lddtree"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5d1501bcbb2572cd5aaec64307faf409b52f25c0d8adbaeaa8afe01387f467"
+checksum = "c530d2918615bf5a01051451a5cd07be67d076fc8242c99e877cf9abc90fdf07"
 dependencies = [
  "fs-err",
  "glob",
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
+checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
 dependencies = [
  "base64",
  "bytes",
@@ -1666,7 +1666,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -2093,7 +2093,7 @@ checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
  "rustls",
  "tokio",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -2370,16 +2370,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -2390,11 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
 dependencies = [
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "bytesize",
  "cargo_metadata",
  "cbindgen",
+ "cc",
  "configparser",
  "console",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ignore = "0.4.18"
 dialoguer = "0.9.0"
 console = "0.15.0"
 minijinja = "0.8.2"
-lddtree = "0.1.4"
+lddtree = "0.2.0"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ dialoguer = "0.9.0"
 console = "0.15.0"
 minijinja = "0.8.2"
 lddtree = "0.2.0"
+cc = "1.0.72"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add support for repairing cross compiled linux wheels in [#754](https://github.com/PyO3/maturin/pull/754)
+
 ## [0.12.5] - 2021-12-20
 
 * Fix docs for `new` and `init` commands in `maturin --help` in [#734](https://github.com/PyO3/maturin/pull/734)

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -8,4 +8,4 @@ mod repair;
 pub use audit::*;
 pub use platform_tag::PlatformTag;
 pub use policy::{Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
-pub use repair::{get_external_libs, hash_file};
+pub use repair::{find_external_libs, hash_file};

--- a/src/auditwheel/repair.rs
+++ b/src/auditwheel/repair.rs
@@ -5,13 +5,14 @@ use fs_err as fs;
 use lddtree::DependencyAnalyzer;
 use sha2::{Digest, Sha256};
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn get_external_libs(
     artifact: impl AsRef<Path>,
     policy: &Policy,
 ) -> Result<Vec<lddtree::Library>, AuditWheelError> {
-    let dep_analyzer = DependencyAnalyzer::new();
+    let root = PathBuf::from("/");
+    let dep_analyzer = DependencyAnalyzer::new(root);
     let deps = dep_analyzer.analyze(artifact).unwrap();
     let mut ext_libs = Vec::new();
     for (name, lib) in deps.libraries {

--- a/src/auditwheel/repair.rs
+++ b/src/auditwheel/repair.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use std::io;
 use std::path::{Path, PathBuf};
 
-pub fn get_external_libs(
+pub fn find_external_libs(
     artifact: impl AsRef<Path>,
     policy: &Policy,
     sysroot: PathBuf,

--- a/src/auditwheel/repair.rs
+++ b/src/auditwheel/repair.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 pub fn get_external_libs(
     artifact: impl AsRef<Path>,
     policy: &Policy,
+    sysroot: PathBuf,
 ) -> Result<Vec<lddtree::Library>, AuditWheelError> {
-    let root = PathBuf::from("/");
-    let dep_analyzer = DependencyAnalyzer::new(root);
+    let dep_analyzer = DependencyAnalyzer::new(sysroot);
     let deps = dep_analyzer.analyze(artifact).unwrap();
     let mut ext_libs = Vec::new();
     for (name, lib) in deps.libraries {

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1,5 +1,5 @@
 use crate::auditwheel::{
-    auditwheel_rs, get_external_libs, hash_file, patchelf, PlatformTag, Policy,
+    auditwheel_rs, find_external_libs, hash_file, patchelf, PlatformTag, Policy,
 };
 use crate::compile::warn_missing_py_init;
 use crate::module_writer::{
@@ -274,7 +274,7 @@ impl BuildContext {
             })?;
         let external_libs = if should_repair && !self.editable {
             let sysroot = get_sysroot_path(&self.target)?;
-            get_external_libs(&artifact, &policy, sysroot).with_context(|| {
+            find_external_libs(&artifact, &policy, sysroot).with_context(|| {
                 if let Some(platform_tag) = platform_tag {
                     format!("Error repairing wheel for {} compliance", platform_tag)
                 } else {

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -15,6 +15,7 @@ use lddtree::Library;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// The way the rust code is used in the wheel
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -272,7 +273,8 @@ impl BuildContext {
                 }
             })?;
         let external_libs = if should_repair && !self.editable {
-            get_external_libs(&artifact, &policy).with_context(|| {
+            let sysroot = get_sysroot_path(&self.target)?;
+            get_external_libs(&artifact, &policy, sysroot).with_context(|| {
                 if let Some(platform_tag) = platform_tag {
                     format!("Error repairing wheel for {} compliance", platform_tag)
                 } else {
@@ -683,6 +685,50 @@ fn relpath(to: &Path, from: &Path) -> PathBuf {
         .map(|x| result.push(x.as_os_str()))
         .last();
     result
+}
+
+/// Get sysroot path from target C compiler
+///
+/// Currently only gcc is supported, clang doesn't have a `--print-sysroot` option
+/// TODO: allow specify sysroot from environment variable?
+fn get_sysroot_path(target: &Target) -> Result<PathBuf> {
+    use crate::target::get_host_target;
+
+    let host_triple = get_host_target()?;
+    let target_triple = target.target_triple();
+    if host_triple != target_triple {
+        let mut build = cc::Build::new();
+        build
+            // Suppress cargo metadata for example env vars printing
+            .cargo_metadata(false)
+            // opt_level, host and target are required
+            .opt_level(0)
+            .host(&host_triple)
+            .target(target_triple);
+        let compiler = build
+            .try_get_compiler()
+            .with_context(|| format!("Failed to get compiler for {}", target_triple))?;
+        let path = compiler.path();
+        let out = Command::new(path)
+            .arg("--print-sysroot")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .with_context(|| format!("Failed to run `{} --print-sysroot`", path.display()))?;
+        if out.status.success() {
+            let sysroot = String::from_utf8(out.stdout)
+                .context("Failed to read the sysroot path")?
+                .trim()
+                .to_owned();
+            return Ok(PathBuf::from(sysroot));
+        } else {
+            bail!(
+                "Failed to get the sysroot path: {}",
+                String::from_utf8(out.stderr)?
+            );
+        }
+    }
+    Ok(PathBuf::from("/"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Below is an example demonstrating cross compile and cross repair a musllinux wheel on macOS then run it in a Alpine Linux container:

![2021-12-21 23 25 02](https://user-images.githubusercontent.com/1556054/146955399-7ab32c9e-5b52-4dff-836c-3c6121f7a915.gif)
