### PR TITLE
Zig for manylinux compliance without docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,13 @@ jobs:
           pypy3 -m pip install --force-reinstall --no-index --find-links test-crates/pyo3-pure/target/wheels pyo3-pure
           pypy3 -m pip install pytest
           pypy3 -m pytest test-crates/pyo3-pure/test_pyo3_pure.py
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10.0"
+      - name: test cross compiling with zig
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+          cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
 
   test-auditwheel:
     name: Test Auditwheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           python-version: "3.10.0"
       - name: test cross compiling with zig
+        if: matrix.os != 'windows-latest'
         run: |
           rustup target add aarch64-unknown-linux-gnu
           cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.10.0"
       - name: Install cffi and virtualenv
-        run: pip install cffi virtualenv
+        run: pip install cffi virtualenv ziglang~=0.9.0
       - uses: actions-rs/toolchain@v1
         id: rustup
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ classifiers = [
 ]
 dependencies = ["toml~=0.10.2"]
 
+[project.optional-dependencies]
+zig = [
+    "ziglang~=0.9.0",
+]
+
 [project.urls]
 "Source Code" = "https://github.com/PyO3/maturin"
 Issues = "https://github.com/PyO3/maturin/issues"

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -320,7 +320,8 @@ pub fn auditwheel_rs(
         policy.fixup_musl_libc_so_name(target.target_arch());
 
         if let Some(highest_policy) = highest_policy {
-            if policy.priority < highest_policy.priority {
+            // Don't recommend manylinux1 because rust doesn't support it anymore
+            if policy.priority < highest_policy.priority && highest_policy.name != "manylinux_2_5" {
                 println!(
                     "📦 Wheel is eligible for a higher priority tag. \
                     You requested {} but this wheel is eligible for {}",

--- a/src/auditwheel/policy.rs
+++ b/src/auditwheel/policy.rs
@@ -59,7 +59,7 @@ impl Display for Policy {
             f.write_str(&self.name)
         } else {
             f.write_fmt(format_args!(
-                "{}(aka {})",
+                "{} (aka {})",
                 &self.name,
                 self.aliases.join(",")
             ))

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -158,8 +158,10 @@ pub struct BuildContext {
     pub release: bool,
     /// Strip the library for minimum file size
     pub strip: bool,
-    /// Whether to skip checking the linked libraries for manylinux/musllinux compliance
+    /// Skip checking the linked libraries for manylinux/musllinux compliance
     pub skip_auditwheel: bool,
+    /// When compiling for manylinux, use zig as linker to ensure glibc version compliance
+    pub zig: bool,
     /// Whether to use the the manylinux/musllinux or use the native linux tag (off)
     pub platform_tag: Option<PlatformTag>,
     /// Extra arguments that will be passed to cargo as `cargo rustc [...] [arg1] [arg2] --`

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -293,7 +293,7 @@ impl BuildOptions {
                 // With zig we can compile to any glibc version that we want, so we pick the lowest
                 // one supported by the rust compiler
                 if self.zig && !target.is_musl_target() {
-                    Some(PlatformTag::manylinux2010())
+                    Some(target.get_default_manylinux_tag())
                 } else {
                     None
                 },

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -292,7 +292,7 @@ impl BuildOptions {
             .or(
                 // With zig we can compile to any glibc version that we want, so we pick the lowest
                 // one supported by the rust compiler
-                if self.zig {
+                if self.zig && !target.is_musl_target() {
                     Some(PlatformTag::manylinux2010())
                 } else {
                     None

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -293,7 +293,7 @@ impl BuildOptions {
                 // With zig we can compile to any glibc version that we want, so we pick the lowest
                 // one supported by the rust compiler
                 if self.zig && !target.is_musl_target() {
-                    Some(target.get_default_manylinux_tag())
+                    Some(target.get_minimum_manylinux_tag())
                 } else {
                     None
                 },

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -64,6 +64,13 @@ pub struct BuildOptions {
     /// Don't check for manylinux compliance
     #[structopt(long = "skip-auditwheel")]
     pub skip_auditwheel: bool,
+    /// For manylinux targets, use zig to ensure compliance for the chosen manylinux version
+    ///
+    /// Default to manylinux2010/manylinux_2_12 if you do not specify an `--compatibility`
+    ///
+    /// Make sure you installed zig with `pip install maturin[zig]`
+    #[structopt(long)]
+    pub zig: bool,
     /// The --target option for cargo
     #[structopt(long, name = "TRIPLE", env = "CARGO_BUILD_TARGET")]
     pub target: Option<String>,
@@ -96,6 +103,7 @@ impl Default for BuildOptions {
             manifest_path: PathBuf::from("Cargo.toml"),
             out: None,
             skip_auditwheel: false,
+            zig: false,
             target: None,
             cargo_extra_args: Vec::new(),
             rustc_extra_args: Vec::new(),
@@ -271,14 +279,25 @@ impl BuildOptions {
         let strip = pyproject.map(|x| x.strip()).unwrap_or_default() || strip;
         let skip_auditwheel =
             pyproject.map(|x| x.skip_auditwheel()).unwrap_or_default() || self.skip_auditwheel;
-        let platform_tag = self.platform_tag.or_else(|| {
-            pyproject.and_then(|x| {
-                if x.compatibility().is_some() {
-                    args_from_pyproject.push("compatibility");
-                }
-                x.compatibility()
+        let platform_tag = self
+            .platform_tag
+            .or_else(|| {
+                pyproject.and_then(|x| {
+                    if x.compatibility().is_some() {
+                        args_from_pyproject.push("compatibility");
+                    }
+                    x.compatibility()
+                })
             })
-        });
+            .or(
+                // With zig we can compile to any glibc version that we want, so we pick the lowest
+                // one supported by the rust compiler
+                if self.zig {
+                    Some(PlatformTag::manylinux2010())
+                } else {
+                    None
+                },
+            );
         if platform_tag == Some(PlatformTag::manylinux1()) {
             eprintln!("⚠️  Warning: manylinux1 is unsupported by the Rust compiler.");
         }
@@ -302,6 +321,7 @@ impl BuildOptions {
             release,
             strip,
             skip_auditwheel,
+            zig: self.zig,
             platform_tag,
             cargo_extra_args,
             rustc_extra_args,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -183,7 +183,7 @@ fn create_linker_script(path: &Path) -> Result<std::fs::File> {
 
 #[cfg(not(target_family = "unix"))]
 fn create_linker_script(path: &Path) -> Result<File> {
-    File::create(path)
+    Ok(File::create(path)?)
 }
 
 fn compile_target(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -278,6 +278,7 @@ fn compile_target(
             .to_uppercase()
             .replace("-", "_");
         build_command.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_linker);
+        build_command.env("TARGET_CC", &zig_linker);
     }
 
     if let BridgeModel::BindingsAbi3(_, _) = bindings_crate {

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -35,6 +35,7 @@ pub fn develop(
         manifest_path: manifest_file.to_path_buf(),
         out: Some(wheel_dir.path().to_path_buf()),
         skip_auditwheel: false,
+        zig: false,
         target: None,
         cargo_extra_args,
         rustc_extra_args,
@@ -113,7 +114,7 @@ pub fn develop(
 // Y U NO accept windows path prefix, pip?
 // Anyways, here's shepmasters stack overflow solution
 // https://stackoverflow.com/a/50323079/3549270
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 fn adjust_canonicalization(p: impl AsRef<Path>) -> String {
     p.as_ref().display().to_string()
 }

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -12,11 +12,11 @@ use fs_err::File;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::ffi::OsStr;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 use std::fs::OpenOptions;
 use std::io;
 use std::io::{Read, Write};
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -164,7 +164,7 @@ impl ModuleWriter for PathWriter {
 
         // We only need to set the executable bit on unix
         let mut file = {
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(target_family = "unix")]
             {
                 OpenOptions::new()
                     .create(true)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,7 +15,7 @@ pub mod other;
 // Y U NO accept windows path prefix, pip?
 // Anyways, here's shepmasters stack overflow solution
 // https://stackoverflow.com/a/50323079/3549270
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_family = "unix")]
 pub fn adjust_canonicalization(p: impl AsRef<Path>) -> String {
     p.as_ref().display().to_string()
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -100,6 +100,7 @@ fn integration_pyo3_pure() {
         "test-crates/pyo3-pure",
         None,
         "integration_pyo3_pure",
+        false,
     ));
 }
 
@@ -109,6 +110,7 @@ fn integration_pyo3_mixed() {
         "test-crates/pyo3-mixed",
         None,
         "integration_pyo3_mixed",
+        false,
     ));
 }
 
@@ -118,6 +120,7 @@ fn integration_pyo3_mixed_submodule() {
         "test-crates/pyo3-mixed-submodule",
         None,
         "integration_pyo3_mixed_submodule",
+        false,
     ));
 }
 
@@ -127,6 +130,7 @@ fn integration_pyo3_mixed_py_subdir() {
         "test-crates/pyo3-mixed-py-subdir",
         None,
         "integration_pyo3_mixed_py_subdir",
+        true,
     ));
 }
 
@@ -146,6 +150,7 @@ fn integration_cffi_pure() {
         "test-crates/cffi-pure",
         None,
         "integration_cffi_pure",
+        false,
     ));
 }
 
@@ -155,6 +160,7 @@ fn integration_cffi_mixed() {
         "test-crates/cffi-mixed",
         None,
         "integration_cffi_mixed",
+        false,
     ));
 }
 
@@ -164,6 +170,7 @@ fn integration_hello_world() {
         "test-crates/hello-world",
         None,
         "integration_hello_world",
+        false,
     ));
 }
 


### PR DESCRIPTION
If this actually works as I imaging it to be, we won't need the manylinux docker anymore!

---

This allows compiling for a specified manylinux version by using `zig cc`s custom glibc targeting (https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html). You just add `--zig`, and it will target the policy you want, defaulting to manylinux2010. Example from ubuntu 20.04:

```
$ cargo run -- build -m test-crates/pyo3-pure/Cargo.toml -i python --no-sdist 2> /dev/null
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.6
🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
📖 Found type stub file at pyo3_pure.pyi
📦 Built wheel for abi3 Python ≥ 3.6 to /home/konsti/maturin/test-crates/pyo3-pure/target/wheels/pyo3_pure-2.1.2-cp36-abi3-manylinux_2_24_x86_64.whl
$ cargo run -- build -m test-crates/pyo3-pure/Cargo.toml -i python --no-sdist --zig 2> /dev/null
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.6
🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
📖 Found type stub file at pyo3_pure.pyi
📦 Built wheel for abi3 Python ≥ 3.6 to /home/konsti/maturin/test-crates/pyo3-pure/target/wheels/pyo3_pure-2.1.2-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
```

Maturin has to be installed with `maturin[zig]` to get a compatible zig version.

Still missing:
 * musl (code is there, but untested)
 * pyproject.toml integration (do we want/need that?)
 * Documentation in the user guide