### PR TITLE
Re-introduce rustls feature and add a native-tls feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1037,7 @@ dependencies = [
  "lddtree",
  "minijinja",
  "multipart",
+ "native-tls",
  "once_cell",
  "platform-info",
  "pretty_env_logger",
@@ -1095,6 +1111,24 @@ dependencies = [
  "mime",
  "mime_guess",
  "rand",
+ "tempfile",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -1217,6 +1251,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1560,6 +1627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -1983,6 +2060,7 @@ dependencies = [
  "chunked_transfer",
  "flate2",
  "log",
+ "native-tls",
  "once_cell",
  "rustls",
  "url",
@@ -2010,6 +2088,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,16 +63,19 @@ semver = "1.0.4"
 configparser = { version = "3.0.0", optional = true }
 multipart = { version = "0.18.0", features = ["client"], default-features = false, optional = true }
 rpassword = { version = "5.0.1", optional = true }
-ureq = { version = "2.3.1", optional = true }
+ureq = { version = "2.3.1", features = ["gzip"], default-features = false, optional = true }
+native-tls-crate = { package = "native-tls", version = "0.2.8", optional = true }
 
 [dev-dependencies]
 indoc = "1.0.3"
 
 [features]
-default = ["log", "upload", "human-panic"]
+default = ["log", "upload", "rustls", "human-panic"]
 upload = ["ureq", "multipart", "rpassword", "configparser"]
 password-storage = ["upload", "keyring"]
 log = ["pretty_env_logger"]
+rustls = ["ureq/tls"]
+native-tls = ["ureq/native-tls", "native-tls-crate"]
 # Internal feature to speed up the tests significantly
 faster-tests = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,16 @@
 //!
 //! # Cargo features
 //!
-//! Default features: log, upload, human-panic
+//! Default features: log, upload, rustls, human-panic
 //!
 //! - log: Configures pretty-env-logger, even though maturin doesn't use logging itself.
 //!
 //! - upload: Uses ureq to add the upload command.
+//!
+//! - rustls: Makes ureq use the rustls stack so that we can build maturin in a CentOS 6
+//! docker container and which maturin itself manylinux compliant.
+//!
+//! - native-tls: Makes ureq use the platform native tls stack
 //!
 //! - human-panic: Adds https://github.com/rust-clique/human-panic
 //!


### PR DESCRIPTION
Fixes https://github.com/PyO3/maturin/pull/767#issuecomment-1008235362

Here is an example of the release workflow: https://github.com/PyO3/maturin/actions/runs/1673233092

`native-tls` feature isn't used by us now, but end users can use it if rustls doesn't support their platforms yet.