### PR TITLE
Allow running tests without zig

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -78,7 +78,7 @@ impl Zig {
     /// Search for `python -m ziglang` first and for `zig` second.
     /// That way we use the zig from `maturin[ziglang]` first,
     /// but users or distributions can also insert their own zig
-    fn find_zig() -> Result<(String, Vec<String>)> {
+    pub fn find_zig() -> Result<(String, Vec<String>)> {
         Self::find_zig_python()
             .or_else(|_| Self::find_zig_bin())
             .context("Failed to find zig")

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -1,7 +1,7 @@
 use crate::common::{adjust_canonicalization, check_installed, maybe_mock_cargo};
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use maturin::{BuildOptions, PythonInterpreter, Target};
+use maturin::{BuildOptions, PythonInterpreter, Target, Zig};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
@@ -43,7 +43,7 @@ pub fn test_integration(
         cli.push(bindings);
     }
 
-    if zig {
+    if zig && Zig::find_zig().is_ok() {
         cli.push("--zig")
     } else {
         cli.push("--compatibility");


### PR DESCRIPTION
Some distros like Alpine Linux run full test suite when packaging maturin, we don't really want them to depend on zig for testing.