### PR TITLE
cli: add --profile option and MATURIN_PROFILE var

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for using [`zig cc`](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html) as linker for easier cross compiling and manylinux compliance in [#756](https://github.com/PyO3/maturin/pull/756)
 * Switch from reqwest to ureq to reduce dependencies in [#767](https://github.com/PyO3/maturin/pull/767)
 * Fix missing Python submodule in wheel in [#772](https://github.com/PyO3/maturin/pull/772)
+* Add `--profile` argument to match Cargo's `--profile`, and `MATURIN_PROFILE` env var in [#774](https://github.com/PyO3/maturin/pull/774)
 
 ## [0.12.6] - 2021-12-31
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -154,8 +154,8 @@ pub struct BuildContext {
     /// The directory to store the built wheels in. Defaults to a new "wheels"
     /// directory in the project's target directory
     pub out: PathBuf,
-    /// Pass --release to cargo
-    pub release: bool,
+    /// The `--profile` to pass to cargo.
+    pub profile: Option<String>,
     /// Strip the library for minimum file size
     pub strip: bool,
     /// Skip checking the linked libraries for manylinux/musllinux compliance

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -154,7 +154,8 @@ pub struct BuildContext {
     /// The directory to store the built wheels in. Defaults to a new "wheels"
     /// directory in the project's target directory
     pub out: PathBuf,
-    /// The `--profile` to pass to cargo.
+    /// The `--profile` to pass to cargo. Can also be set by the `MATURIN_PROFILE` environment
+    /// variable.
     pub profile: Option<String>,
     /// Strip the library for minimum file size
     pub strip: bool,

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -318,7 +318,12 @@ impl BuildOptions {
         let profile = if self.profile.is_some() {
             self.profile
         } else if let Some(env_var) = std::env::var_os("MATURIN_PROFILE") {
-            Some(env_var.to_str().context("expected MATURIN_PROFILE to be utf-8")?.to_owned())
+            Some(
+                env_var
+                    .to_str()
+                    .context("expected MATURIN_PROFILE to be utf-8")?
+                    .to_owned(),
+            )
         } else {
             default_profile.map(ToOwned::to_owned)
         };

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -91,7 +91,8 @@ pub struct BuildOptions {
     /// Only applies to macOS targets, do nothing otherwise.
     #[clap(long)]
     pub universal2: bool,
-    /// The `--profile` to pass to `cargo`.
+    /// The `--profile` to pass to cargo. Can also be set by the `MATURIN_PROFILE` environment
+    /// variable.
     #[clap(long)]
     pub profile: Option<String>,
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -118,8 +118,8 @@ fn compile_target(
 
     shared_args.extend(context.cargo_extra_args.iter().map(String::as_str));
 
-    if context.release {
-        shared_args.push("--release");
+    if let Some(profile) = &context.profile {
+        shared_args.extend(&["--profile", profile]);
     }
     let mut rustc_args: Vec<&str> = context
         .rustc_extra_args

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -19,9 +19,9 @@ pub fn develop(
     cargo_extra_args: Vec<String>,
     rustc_extra_args: Vec<String>,
     venv_dir: &Path,
-    release: bool,
     strip: bool,
     extras: Vec<String>,
+    profile: Option<String>,
 ) -> Result<()> {
     let target = Target::from_target_triple(None)?;
     let python = target.get_venv_python(&venv_dir);
@@ -40,9 +40,10 @@ pub fn develop(
         cargo_extra_args,
         rustc_extra_args,
         universal2: false,
+        profile,
     };
 
-    let build_context = build_options.into_build_context(release, strip, true)?;
+    let build_context = build_options.into_build_context(None, strip, true)?;
 
     let interpreter = PythonInterpreter::check_executable(&python, &target, &build_context.bridge)?
         .ok_or_else(|| {

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -43,7 +43,7 @@ pub fn develop(
         profile,
     };
 
-    let build_context = build_options.into_build_context(None, strip, true)?;
+    let build_context = build_options.into_build_context(strip, true)?;
 
     let interpreter = PythonInterpreter::check_executable(&python, &target, &build_context.bridge)?
         .ok_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,8 @@ enum Opt {
             multiple_occurrences = false
         )]
         extras: Vec<String>,
-        /// The `--profile` to pass to `cargo`.
+        /// The `--profile` to pass to cargo. Can also be set by the `MATURIN_PROFILE` environment
+        /// variable.
         #[clap(long)]
         profile: Option<String>,
     },

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -42,9 +42,9 @@ pub fn test_develop(
         ],
         vec![],
         &venv_dir,
-        false,
         cfg!(feature = "faster-tests"),
         vec![],
+        None,
     )?;
 
     check_installed(package.as_ref(), &python)?;

--- a/tests/common/editable.rs
+++ b/tests/common/editable.rs
@@ -47,7 +47,7 @@ pub fn test_editable(
 
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
 
-    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), true)?;
+    let build_context = options.into_build_context(cfg!(feature = "faster-tests"), true)?;
     let wheels = build_context.build_wheels()?;
 
     for (filename, _supported_version) in wheels.iter() {

--- a/tests/common/editable.rs
+++ b/tests/common/editable.rs
@@ -47,7 +47,7 @@ pub fn test_editable(
 
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
 
-    let build_context = options.into_build_context(false, cfg!(feature = "faster-tests"), true)?;
+    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), true)?;
     let wheels = build_context.build_wheels()?;
 
     for (filename, _supported_version) in wheels.iter() {

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -13,7 +13,7 @@ pub fn abi3_without_version() -> Result<()> {
     ];
 
     let options = BuildOptions::try_parse_from(cli)?;
-    let result = options.into_build_context(false, cfg!(feature = "faster-tests"), false);
+    let result = options.into_build_context(None, cfg!(feature = "faster-tests"), false);
     if let Err(err) = result {
         assert_eq!(err.to_string(),
             "You have selected the `abi3` feature but not a minimum version (e.g. the `abi3-py36` feature). \
@@ -42,7 +42,7 @@ pub fn pyo3_no_extension_module() -> Result<()> {
 
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
-        .into_build_context(false, cfg!(feature = "faster-tests"), false)?
+        .into_build_context(None, cfg!(feature = "faster-tests"), false)?
         .build_wheels();
     if let Err(err) = result {
         if !(err
@@ -74,7 +74,7 @@ pub fn locked_doesnt_build_without_cargo_lock() -> Result<()> {
         "--cargo-extra-args=--target-dir test-crates/targets/locked_doesnt_build_without_cargo_lock",
     ];
     let options = BuildOptions::try_parse_from(cli)?;
-    let result = options.into_build_context(false, cfg!(feature = "faster-tests"), false);
+    let result = options.into_build_context(None, cfg!(feature = "faster-tests"), false);
     if let Err(err) = result {
         let err_string = err
             .source()
@@ -113,7 +113,7 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
     ];
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
-        .into_build_context(false, cfg!(feature = "faster-tests"), false)?
+        .into_build_context(None, false, cfg!(feature = "faster-tests"))?
         .build_wheels();
     if let Err(err) = result {
         assert_eq!(err.to_string(), "Error ensuring manylinux_2_99 compliance");

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -13,7 +13,7 @@ pub fn abi3_without_version() -> Result<()> {
     ];
 
     let options = BuildOptions::try_parse_from(cli)?;
-    let result = options.into_build_context(None, cfg!(feature = "faster-tests"), false);
+    let result = options.into_build_context(cfg!(feature = "faster-tests"), false);
     if let Err(err) = result {
         assert_eq!(err.to_string(),
             "You have selected the `abi3` feature but not a minimum version (e.g. the `abi3-py36` feature). \
@@ -42,7 +42,7 @@ pub fn pyo3_no_extension_module() -> Result<()> {
 
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
-        .into_build_context(None, cfg!(feature = "faster-tests"), false)?
+        .into_build_context(cfg!(feature = "faster-tests"), false)?
         .build_wheels();
     if let Err(err) = result {
         if !(err
@@ -74,7 +74,7 @@ pub fn locked_doesnt_build_without_cargo_lock() -> Result<()> {
         "--cargo-extra-args=--target-dir test-crates/targets/locked_doesnt_build_without_cargo_lock",
     ];
     let options = BuildOptions::try_parse_from(cli)?;
-    let result = options.into_build_context(None, cfg!(feature = "faster-tests"), false);
+    let result = options.into_build_context(cfg!(feature = "faster-tests"), false);
     if let Err(err) = result {
         let err_string = err
             .source()
@@ -113,7 +113,7 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
     ];
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
-        .into_build_context(None, false, cfg!(feature = "faster-tests"))?
+        .into_build_context(false, cfg!(feature = "faster-tests"))?
         .build_wheels();
     if let Err(err) = result {
         assert_eq!(err.to_string(), "Error ensuring manylinux_2_99 compliance");

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -52,7 +52,7 @@ pub fn test_integration(
     }
 
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
-    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), false)?;
+    let build_context = options.into_build_context(cfg!(feature = "faster-tests"), false)?;
     let wheels = build_context.build_wheels()?;
 
     let test_name = package
@@ -171,7 +171,6 @@ fn create_conda_env(name: &str, major: usize, minor: usize) {
 
 #[cfg(target_os = "windows")]
 pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String>) -> Result<()> {
-    use std::env;
     use std::process::Stdio;
 
     let package_string = package.as_ref().join("Cargo.toml").display().to_string();

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -52,7 +52,7 @@ pub fn test_integration(
     }
 
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
-    let build_context = options.into_build_context(false, cfg!(feature = "faster-tests"), false)?;
+    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), false)?;
     let wheels = build_context.build_wheels()?;
 
     let test_name = package

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -63,7 +63,7 @@ pub fn test_musl() -> Result<bool> {
         "test-crates/wheels/test_musl",
     ])?;
 
-    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), false)?;
+    let build_context = options.into_build_context(cfg!(feature = "faster-tests"), false)?;
     let built_lib =
         PathBuf::from("test-crates/targets/test_musl/x86_64-unknown-linux-musl/debug/hello-world");
     if built_lib.is_file() {
@@ -100,7 +100,7 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
         "test-crates/wheels/test_workspace_cargo_lock",
     ])?;
 
-    let build_context = options.into_build_context(None, false, false)?;
+    let build_context = options.into_build_context(false, false)?;
     let source_distribution = build_context.build_source_distribution()?;
     assert!(source_distribution.is_some());
 
@@ -126,7 +126,7 @@ pub fn test_source_distribution(
         ..Default::default()
     };
 
-    let build_context = build_options.into_build_context(None, false, false)?;
+    let build_context = build_options.into_build_context(false, false)?;
     let (path, _) = build_context
         .build_source_distribution()?
         .context("Failed to build source distribution")?;

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -63,7 +63,7 @@ pub fn test_musl() -> Result<bool> {
         "test-crates/wheels/test_musl",
     ])?;
 
-    let build_context = options.into_build_context(false, cfg!(feature = "faster-tests"), false)?;
+    let build_context = options.into_build_context(None, cfg!(feature = "faster-tests"), false)?;
     let built_lib =
         PathBuf::from("test-crates/targets/test_musl/x86_64-unknown-linux-musl/debug/hello-world");
     if built_lib.is_file() {
@@ -100,7 +100,7 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
         "test-crates/wheels/test_workspace_cargo_lock",
     ])?;
 
-    let build_context = options.into_build_context(false, false, false)?;
+    let build_context = options.into_build_context(None, false, false)?;
     let source_distribution = build_context.build_source_distribution()?;
     assert!(source_distribution.is_some());
 
@@ -126,7 +126,7 @@ pub fn test_source_distribution(
         ..Default::default()
     };
 
-    let build_context = build_options.into_build_context(false, false, false)?;
+    let build_context = build_options.into_build_context(None, false, false)?;
     let (path, _) = build_context
         .build_source_distribution()?
         .context("Failed to build source distribution")?;


### PR DESCRIPTION
See https://github.com/PyO3/pyo3/pull/2105

This adds `--profile` option, which forwards to `cargo --profile`. In addition, the `MATURIN_PROFILE` environment variable is added which sets the same value from environment instead of cli. This is helpful when using `pip install` with the PEP 517 backend to override the default of `release` build.

The env var may not be necessary - it's possible that we can use the PEP 517 `config_settings` to take build arguments like `--profile`, which would be an alternative to passing with an env var. At the moment, however, this dict is unused.

Please let me know how you want this tested and / or documented, and I'll update this PR.