### PR TITLE
Don't add `--release` to cargo if `--profile` present

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -119,7 +119,13 @@ fn compile_target(
     shared_args.extend(context.cargo_extra_args.iter().map(String::as_str));
 
     if context.release {
-        shared_args.push("--release");
+        let has_cargo_profile = shared_args
+            .iter()
+            .any(|arg| *arg == "--profile" || arg.starts_with("--profile="));
+        // --release and --profile are conflicting options
+        if !has_cargo_profile {
+            shared_args.push("--release");
+        }
     }
     let mut rustc_args: Vec<&str> = context
         .rustc_extra_args


### PR DESCRIPTION
> I wonder if a separate `--profile` make sense vs. just using `--cargo-extra-args`

This is a fair point. Note that because maturin passes `--release` automatically in some contexts, the user cannot override the `--profile` without also figuring out how to invoke maturin to not pass the flag:

```bash
$ cargo build --release --profile dev
error: conflicting usage of --profile=dev and --release
The `--release` flag is the same as `--profile=release`.
Remove one flag or the other to continue.
```

_Originally posted by @davidhewitt in https://github.com/PyO3/maturin/issues/774#issuecomment-1016202143_