### PR TITLE
Pass arguments to pep517 command via `MATURIN_PEP517_ARGS` env var

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Switch from reqwest to ureq to reduce dependencies in [#767](https://github.com/PyO3/maturin/pull/767)
 * Fix missing Python submodule in wheel in [#772](https://github.com/PyO3/maturin/pull/772)
 * Add support for specifying cargo manifest path in pyproject.toml in [#781](https://github.com/PyO3/maturin/pull/781)
+* Add support for passing arguments to pep517 command via `MATURIN_PEP517_ARGS` env var in [#786](https://github.com/PyO3/maturin/pull/786)
 
 ## [0.12.6] - 2021-12-31
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -10,6 +10,7 @@ maturin's emojis.
 """
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -25,6 +26,11 @@ def get_config() -> Dict[str, str]:
     return pyproject_toml.get("tool", {}).get("maturin", {})
 
 
+def get_maturin_pep517_args():
+    args = shlex.split(os.getenv("MATURIN_PEP517_ARGS", ""))
+    return args
+
+
 # noinspection PyUnusedLocal
 def _build_wheel(
     wheel_directory, config_settings=None, metadata_directory=None, editable=False
@@ -34,6 +40,9 @@ def _build_wheel(
     command = ["maturin", "pep517", "build-wheel", "-i", sys.executable]
     if editable:
         command.append("--editable")
+    pep517_args = get_maturin_pep517_args()
+    if pep517_args:
+        command.extend(pep517_args)
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()
@@ -131,6 +140,9 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
         "--interpreter",
         sys.executable,
     ]
+    pep517_args = get_maturin_pep517_args()
+    if pep517_args:
+        command.extend(pep517_args)
 
     print("Running `{}`".format(" ".join(command)))
     try:


### PR DESCRIPTION
> Do you know if there currently is any way to actually use config_settings? Last time I checked it wasn't usable with pip and the general from the python packaging discourse consensus was that it's effectively unspecified so we're not doing anything with it.

Yes, this is what I've found out too from further reading. It sounds like `config_settings` doesn't work, so in general we currently don't have a way to pass options to maturin during PEP 517 build. If you don't like having a `MATURIN_PROFILE` env var an alternative could be a `MATURIN_PEP517_ARGS` environment variable which adds arguments to the `maturin pep517` Rust internal command.

_Originally posted by @davidhewitt in https://github.com/PyO3/maturin/issues/774#issuecomment-1016202143_

cc @ionenwks