### PR TITLE
Don't require `pyproject.toml` when cargo manifest is not specified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        manylinux: [ 'manylinux2014', 'manylinux_2_24' ]
+        # manylinux2014 fails with `/lib64/libc.so.6: version `GLIBC_2.18'` not found recently
+        # could be a upstream Rust issue, disable it for now
+        #
+        # manylinux: [ 'manylinux2014', 'manylinux_2_24' ]
+        manylinux: [ 'manylinux_2_24' ]
     container: quay.io/pypa/${{ matrix.manylinux }}_x86_64
     steps:
       - uses: actions/checkout@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Don't require `pyproject.toml` when cargo manifest is not specified in [#806](https://github.com/PyO3/maturin/pull/806)
+
 ## [0.12.8] - 2022-02-08
 
 * Add missing `--version` flag from clap 3.0 upgrade

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -116,18 +116,21 @@ impl BuildOptions {
         let current_dir = env::current_dir()
             .context("Failed to detect current directory ಠ_ಠ")?
             .canonicalize()?;
-        let pyproject = PyProjectToml::new(&current_dir).context("pyproject.toml is invalid")?;
-        if let Some(path) = pyproject.manifest_path() {
-            println!("🔗 Found cargo manifest path in pyproject.toml");
-            // pyproject.toml must be placed at top directory
-            let manifest_dir = path
-                .parent()
-                .context("missing parent directory")?
-                .canonicalize()?;
-            if !manifest_dir.starts_with(&current_dir) {
-                bail!("Cargo.toml can not be placed outside of the directory containing pyproject.toml");
+        if current_dir.join("pyproject.toml").is_file() {
+            let pyproject =
+                PyProjectToml::new(&current_dir).context("pyproject.toml is invalid")?;
+            if let Some(path) = pyproject.manifest_path() {
+                println!("🔗 Found cargo manifest path in pyproject.toml");
+                // pyproject.toml must be placed at top directory
+                let manifest_dir = path
+                    .parent()
+                    .context("missing parent directory")?
+                    .canonicalize()?;
+                if !manifest_dir.starts_with(&current_dir) {
+                    bail!("Cargo.toml can not be placed outside of the directory containing pyproject.toml");
+                }
+                return Ok(path.to_path_buf());
             }
-            return Ok(path.to_path_buf());
         }
         // check Cargo.toml in current directory
         let path = PathBuf::from("Cargo.toml");


### PR DESCRIPTION
Fixes #805 