### PR TITLE
Defaults to musllinux_1_2 for musl target if it's not bin bindings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Add support for `pyo3-ffi` by ijl in [#804](https://github.com/PyO3/maturin/pull/804)
+* Defaults to `musllinux_1_2` for musl target if it's not bin bindings in [#808](https://github.com/PyO3/maturin/pull/808)
 
 ## [0.12.9] - 2022-02-09
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -325,7 +325,12 @@ impl BuildOptions {
                     Some(target.get_minimum_manylinux_tag())
                 }
             } else {
-                None
+                // Defaults to musllinux_1_2 for musl target if it's not bin bindings
+                if target.is_musl_target() && !matches!(bridge, BridgeModel::Bin) {
+                    Some(PlatformTag::Musllinux { x: 1, y: 2 })
+                } else {
+                    None
+                }
             });
         if platform_tag == Some(PlatformTag::manylinux1()) {
             eprintln!("⚠️  Warning: manylinux1 is unsupported by the Rust compiler.");


### PR DESCRIPTION
It's kinda odd that `maturin build --target xxx-musl` outputs manylinux wheels for python extension modules.