### PR TITLE
Remove support for building only sdist via `maturin build -i`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add support for `pyo3-ffi` by ijl in [#804](https://github.com/PyO3/maturin/pull/804)
 * Defaults to `musllinux_1_2` for musl target if it's not bin bindings in [#808](https://github.com/PyO3/maturin/pull/808)
+* Remove support for building only sdist via `maturin build -i` in [#813](https://github.com/PyO3/maturin/pull/813), use `maturin sdist` instead.
 
 ## [0.12.9] - 2022-02-09
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -30,7 +30,7 @@ pub fn develop(
 
     let build_options = BuildOptions {
         platform_tag: Some(PlatformTag::Linux),
-        interpreter: Some(vec![python.clone()]),
+        interpreter: vec![python.clone()],
         bindings,
         manifest_path: Some(manifest_file.to_path_buf()),
         out: Some(wheel_dir.path().to_path_buf()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,10 +255,7 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
             metadata_directory,
             strip,
         } => {
-            assert!(matches!(
-                build_options.interpreter.as_ref(),
-                Some(version) if version.len() == 1
-            ));
+            assert!(build_options.interpreter.len() == 1);
             let context = build_options.into_build_context(true, strip, false)?;
 
             // Since afaik all other PEP 517 backends also return linux tagged wheels, we do so too


### PR DESCRIPTION
Use `maturin sdist` command instead.

Fixes #810 