### PR TITLE
Refactor get host target using the `rustc_version` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ dependencies = [
  "python-pkginfo",
  "regex",
  "rpassword",
- "semver",
+ "rustc_version",
  "serde",
  "serde_json",
  "sha2 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ dirs = "4.0.0"
 fs-err = "2.5.0"
 fat-macho = { version = "0.4.5", default-features = false }
 once_cell = "1.7.2"
+rustc_version = "0.4.0"
 target-lexicon = "0.12.0"
 pyproject-toml = "0.3.0"
 python-pkginfo = "0.5.1"
@@ -59,7 +60,6 @@ cc = "1.0.72"
 clap = { version = "3.1.0", features = ["derive", "env", "wrap_help"] }
 clap_complete = "3.1.0"
 clap_complete_fig = "3.1.0"
-semver = "1.0.5"
 # upload
 configparser = { version = "3.0.0", optional = true }
 multipart = { version = "0.18.0", features = ["client"], default-features = false, optional = true }


### PR DESCRIPTION
We already depend on it indirectly via `cargo-zigbuild`