### PR TITLE
Migrate Python dependency `uiri/toml` to `tomllib` / `hukkin/tomli`

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -17,12 +17,15 @@ import sys
 from subprocess import SubprocessError
 from typing import Dict
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 def get_config() -> Dict[str, str]:
-    with open("pyproject.toml", encoding="utf-8") as fp:
-        pyproject_toml = toml.load(fp)
+    with open("pyproject.toml", "rb") as fp:
+        pyproject_toml = tomllib.load(fp)
     return pyproject_toml.get("tool", {}).get("maturin", {})
 
 

--- a/maturin/import_hook.py
+++ b/maturin/import_hook.py
@@ -10,7 +10,10 @@ import sys
 import subprocess
 from typing import Optional
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 class Importer(abc.MetaPathFinder):
@@ -64,8 +67,8 @@ class Loader(abc.Loader):
 
 def _is_cargo_project(cargo_toml: pathlib.Path, module_name: str) -> bool:
     with contextlib.suppress(FileNotFoundError):
-        with open(cargo_toml) as f:
-            cargo = toml.load(f)
+        with open(cargo_toml, "rb") as f:
+            cargo = tomllib.load(f)
             package_name = cargo.get("package", {}).get("name")
             if (
                 package_name == module_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Workaround to bootstrap maturin on non-manylinux platforms
 [build-system]
-requires = ["setuptools~=53.0.0", "wheel~=0.36.2", "toml~=0.10.2"]
+requires = ["setuptools~=53.0.0", "wheel~=0.36.2", "tomli>=1.1.0 ; python_version<'3.11'"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["toml~=0.10.2"]
+dependencies = ["tomli>=1.1.0 ; python_version<'3.11'"]
 
 [project.optional-dependencies]
 zig = [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ import shutil
 import subprocess
 import sys
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from setuptools import setup
 from setuptools.command.install import install
 
@@ -109,8 +112,8 @@ class PostInstallCommand(install):
 with open("Readme.md", encoding="utf-8", errors="ignore") as fp:
     long_description = fp.read()
 
-with open("Cargo.toml") as fp:
-    version = toml.load(fp)["package"]["version"]
+with open("Cargo.toml", "rb") as fp:
+    version = tomllib.load(fp)["package"]["version"]
 
 setup(
     name="maturin",
@@ -131,6 +134,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["toml~=0.10.0"],
+    install_requires=["tomli>=1.1.0 ; python_version<'3.11'"],
     zip_safe=False,
 )


### PR DESCRIPTION
Reasons for the migration:

1. [`hukkin/tomli`](https://github.com/hukkin/tomli) has been accepted as part of the Python standard library (see [PEP680](https://www.python.org/dev/peps/pep-0680/) and python/cpython#31498), named as `tomllib`, and will be released along with Python 3.11.
2. [`uiri/toml`](https://github.com/uiri/toml) is unmaintained since Oct 2020, while `hukkin/tomli` is an actively maintained implementation of TOML 1.0 spec, with 100% test coverage.
