### PR TITLE
Make PEP 517 build wheel defaults to linux compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove support for building only sdist via `maturin build -i` in [#813](https://github.com/PyO3/maturin/pull/813), use `maturin sdist` instead.
 * Add macOS target support for `--zig` in [#817](https://github.com/PyO3/maturin/pull/817)
 * Migrate Python dependency `toml` to `tomllib` / `tomli` by Contextualist in [#821](https://github.com/PyO3/maturin/pull/821)
+* Disable auditwheel for PEP 517 build wheel process in [#823](https://github.com/PyO3/maturin/pull/823)
 
 ## [0.12.9] - 2022-02-09
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -40,7 +40,15 @@ def _build_wheel(
 ):
     # PEP 517 specifies that only `sys.executable` points to the correct
     # python interpreter
-    command = ["maturin", "pep517", "build-wheel", "-i", sys.executable]
+    command = [
+        "maturin",
+        "pep517",
+        "build-wheel",
+        "-i",
+        sys.executable,
+        "--compatibility",
+        "off",
+    ]
     if editable:
         command.append("--editable")
     pep517_args = get_maturin_pep517_args()


### PR DESCRIPTION
I don't think pep517 build process needs to ensure manylinux/musllinux compatibility, correct me if I'm wrong.