### PR TITLE
Package license files in `.dist-info`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Package license files in `.dist-info/license_files` following PEP 639 in [#837](https://github.com/PyO3/maturin/pull/837)
+* Stop testing Python 3.6 on CI since it's already EOL in [#840](https://github.com/PyO3/maturin/pull/840)
+
 ## [0.12.10] - 2022-03-09
 
 * Add support for `pyo3-ffi` by ijl in [#804](https://github.com/PyO3/maturin/pull/804)

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -833,5 +833,16 @@ pub fn write_dist_info(
         )?;
     }
 
+    if !metadata21.license_files.is_empty() {
+        let license_files_dir = dist_info_dir.join("license_files");
+        writer.add_directory(&license_files_dir)?;
+        for path in &metadata21.license_files {
+            let filename = path.file_name().with_context(|| {
+                format!("missing file name for license file {}", path.display())
+            })?;
+            writer.add_file(license_files_dir.join(filename), path)?;
+        }
+    }
+
     Ok(())
 }

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -4,6 +4,7 @@ name = "pyo3-pure"
 version = "2.1.2"
 edition = "2018"
 description = "Implements a dummy function (get_fortytwo.DummyClass.get_42()) in rust"
+license = "MIT"
 
 [dependencies]
 pyo3 = { version = "0.15.1", features = ["abi3-py36", "extension-module"] }


### PR DESCRIPTION
1. https://peps.python.org/pep-0639/#license-file-multiple-use
2. https://github.com/pypa/setuptools/pull/2645

Fixes #829 