### PR TITLE
Switch back to toml_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b9b16bdfa76cf072c650a0244dd7bf91882d3501d8beba8ec82d160124eaea"
+checksum = "9e50ef07fc35bc21bd1e3381581e5d06d331a9e4e42cc9ff4c31d0a10114fa65"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -373,6 +379,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -533,6 +549,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -955,6 +977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1010,15 @@ dependencies = [
  "secret-service",
  "security-framework",
  "winapi",
+]
+
+[[package]]
+name = "kstring"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1078,7 +1118,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror",
- "toml",
+ "toml_edit",
  "ureq",
  "zip",
 ]
@@ -2006,6 +2046,19 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.10.0"
 shlex = "1.0.0"
 tar = "0.4.33"
 tempfile = "3.2.0"
-toml = "0.5.8"
+toml_edit = { version = "0.13.4", features = ["easy"] }
 zip = "0.5.5"
 thiserror = "1.0.24"
 dirs = "4.0.0"

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -49,7 +49,7 @@ impl CargoToml {
             "Can't read Cargo.toml at {}",
             manifest_file.as_ref().display(),
         ))?;
-        let cargo_toml = toml::from_str(&contents).context(format!(
+        let cargo_toml = toml_edit::easy::from_str(&contents).context(format!(
             "Failed to parse Cargo.toml at {}",
             manifest_file.as_ref().display()
         ))?;
@@ -156,7 +156,7 @@ mod test {
         "#
         );
 
-        let cargo_toml: CargoToml = toml::from_str(cargo_toml).unwrap();
+        let cargo_toml: CargoToml = toml_edit::easy::from_str(cargo_toml).unwrap();
 
         let mut scripts = HashMap::new();
         scripts.insert("ph".to_string(), "maturin:print_hello".to_string());
@@ -195,7 +195,7 @@ mod test {
         "#
         );
 
-        let cargo_toml: CargoToml = toml::from_str(cargo_toml).unwrap();
+        let cargo_toml: CargoToml = toml_edit::easy::from_str(cargo_toml).unwrap();
 
         let classifiers = vec!["Programming Language :: Python".to_string()];
 
@@ -226,7 +226,7 @@ mod test {
         "#
         );
 
-        let cargo_toml: Result<CargoToml, _> = toml::from_str(cargo_toml);
+        let cargo_toml: Result<CargoToml, _> = toml_edit::easy::from_str(cargo_toml);
         assert!(cargo_toml.is_ok());
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -532,7 +532,7 @@ mod test {
 
         let toml_with_path = cargo_toml.replace("REPLACE_README_PATH", &readme_path);
 
-        let cargo_toml_struct: CargoToml = toml::from_str(&toml_with_path).unwrap();
+        let cargo_toml_struct: CargoToml = toml_edit::easy::from_str(&toml_with_path).unwrap();
 
         let metadata =
             Metadata21::from_cargo_toml(&cargo_toml_struct, &readme_md.path().parent().unwrap())
@@ -718,7 +718,7 @@ mod test {
         "#
         );
 
-        let cargo_toml_struct: CargoToml = toml::from_str(cargo_toml).unwrap();
+        let cargo_toml_struct: CargoToml = toml_edit::easy::from_str(cargo_toml).unwrap();
         let metadata =
             Metadata21::from_cargo_toml(&cargo_toml_struct, "/not/exist/manifest/path").unwrap();
         let actual = metadata.to_file_contents();
@@ -763,7 +763,7 @@ mod test {
     #[test]
     fn test_merge_metadata_from_pyproject_toml() {
         let cargo_toml_str = fs_err::read_to_string("test-crates/pyo3-pure/Cargo.toml").unwrap();
-        let cargo_toml: CargoToml = toml::from_str(&cargo_toml_str).unwrap();
+        let cargo_toml: CargoToml = toml_edit::easy::from_str(&cargo_toml_str).unwrap();
         let metadata = Metadata21::from_cargo_toml(&cargo_toml, "test-crates/pyo3-pure").unwrap();
         assert_eq!(
             metadata.summary,
@@ -824,7 +824,7 @@ mod test {
     fn test_merge_metadata_from_pyproject_toml_with_customized_python_source_dir() {
         let cargo_toml_str =
             fs_err::read_to_string("test-crates/pyo3-mixed-py-subdir/Cargo.toml").unwrap();
-        let cargo_toml: CargoToml = toml::from_str(&cargo_toml_str).unwrap();
+        let cargo_toml: CargoToml = toml_edit::easy::from_str(&cargo_toml_str).unwrap();
         let metadata =
             Metadata21::from_cargo_toml(&cargo_toml, "test-crates/pyo3-mixed-py-subdir").unwrap();
         // defined in Cargo.toml
@@ -839,7 +839,7 @@ mod test {
     #[test]
     fn test_implicit_readme() {
         let cargo_toml_str = fs_err::read_to_string("test-crates/pyo3-mixed/Cargo.toml").unwrap();
-        let cargo_toml = toml::from_str(&cargo_toml_str).unwrap();
+        let cargo_toml = toml_edit::easy::from_str(&cargo_toml_str).unwrap();
         let metadata = Metadata21::from_cargo_toml(&cargo_toml, "test-crates/pyo3-mixed").unwrap();
         assert!(metadata.description.unwrap().starts_with("# pyo3-mixed"));
         assert_eq!(

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -62,7 +62,7 @@ impl PyProjectToml {
             "Couldn't find pyproject.toml at {}",
             path.display()
         ))?;
-        let pyproject: PyProjectToml = toml::from_str(&contents)
+        let pyproject: PyProjectToml = toml_edit::easy::from_str(&contents)
             .map_err(|err| format_err!("pyproject.toml is not PEP 517 compliant: {}", err))?;
         Ok(pyproject)
     }

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -32,7 +32,7 @@ fn rewrite_cargo_toml(
         "Can't read Cargo.toml at {}",
         manifest_path.as_ref().display(),
     ))?;
-    let mut data = toml::from_str::<toml::value::Table>(&text).context(format!(
+    let mut data = text.parse::<toml_edit::Document>().context(format!(
         "Failed to parse Cargo.toml at {}",
         manifest_path.as_ref().display()
     ))?;
@@ -60,10 +60,10 @@ fn rewrite_cargo_toml(
                 }
                 // This is the location of the targeted crate in the source distribution
                 table[&dep_name]["path"] = if root_crate {
-                    format!("{}/{}", LOCAL_DEPENDENCIES_FOLDER, dep_name).into()
+                    toml_edit::value(format!("{}/{}", LOCAL_DEPENDENCIES_FOLDER, dep_name))
                 } else {
                     // Cargo.toml contains relative paths, and we're already in LOCAL_DEPENDENCIES_FOLDER
-                    format!("../{}", dep_name).into()
+                    toml_edit::value(format!("../{}", dep_name))
                 };
                 rewritten = true;
                 if !known_path_deps.contains_key(&dep_name) {
@@ -79,7 +79,7 @@ fn rewrite_cargo_toml(
         }
     }
     if rewritten {
-        Ok(toml::to_string(&data)?)
+        Ok(data.to_string())
     } else {
         Ok(text)
     }


### PR DESCRIPTION
Cargo already switched from `toml-rs` to `toml_edit`: https://github.com/rust-lang/cargo/pull/10086