### PR TITLE
Fix `maturin sdist --manifest-path` for workspace project

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Package license files in `.dist-info/license_files` following PEP 639 in [#837](https://github.com/PyO3/maturin/pull/837)
 * Stop testing Python 3.6 on CI since it's already EOL in [#840](https://github.com/PyO3/maturin/pull/840)
+* Fix `maturin sdist --manifest-path <PATH>` for workspace project in [#843](https://github.com/PyO3/maturin/pull/843)
 
 ## [0.12.10] - 2022-03-09
 

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -96,9 +96,15 @@ fn add_crate_to_source_distribution(
     known_path_deps: &HashMap<String, PathDependency>,
     root_crate: bool,
 ) -> Result<()> {
+    let crate_dir = manifest_path.as_ref().parent().with_context(|| {
+        format!(
+            "Can't get parent directory of {}",
+            manifest_path.as_ref().display()
+        )
+    })?;
     let output = Command::new("cargo")
-        .args(&["package", "--list", "--allow-dirty", "--manifest-path"])
-        .arg(manifest_path.as_ref())
+        .args(&["package", "--list", "--allow-dirty"])
+        .current_dir(crate_dir)
         .output()
         .context("Failed to run cargo")?;
     if !output.status.success() {


### PR DESCRIPTION
Found this bug when reproducing #838

```bash
❯ pwd
/tmp/resvg
❯ cargo package --list
.cargo_vcs_info.json
.github/chart-svg2.svg
.github/chart.svg
.github/pull_request_template.md
.github/workflows/main.yml
.github/workflows/tagged-release.yml
.gitignore
CHANGELOG.md
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE.txt
README.md
README.python.rst
docs/rendering.adoc
docs/svg2-changelog.md
docs/unsupported.md
docs/usvg_spec.adoc
examples/bboxes.svg
examples/custom_href_resolver.rs
examples/custom_href_resolver.svg
examples/custom_rtree.rs
examples/draw_bboxes.rs
examples/ferris.png
examples/minimal.rs
pyproject.toml
src/clip.rs
src/filter.rs
src/image.rs
src/lib.rs
src/main.rs
src/mask.rs
src/paint_server.rs
src/path.rs
src/render.rs
tools/kde-dolphin-thumbnailer/CMakeLists.txt
tools/kde-dolphin-thumbnailer/README.md
tools/kde-dolphin-thumbnailer/resvgthumbnailer.cpp
tools/kde-dolphin-thumbnailer/resvgthumbnailer.desktop
tools/kde-dolphin-thumbnailer/resvgthumbnailer.h
tools/viewsvg/.gitignore
tools/viewsvg/README.md
tools/viewsvg/main.cpp
tools/viewsvg/mainwindow.cpp
tools/viewsvg/mainwindow.h
tools/viewsvg/mainwindow.ui
tools/viewsvg/svgview.cpp
tools/viewsvg/svgview.h
tools/viewsvg/viewsvg.pro
version-bump.md
❯ cargo package --list --manifest-path /tmp/resvg/Cargo.toml
Cargo.lock
```

`cargo package --list --manifest-path /tmp/resvg/Cargo.toml` only gives `Cargo.lock`, which results in `maturin sdist` error:

```
🔗 Found bin bindings
📡 Using build options bindings from pyproject.toml
💥 maturin failed
  Caused by: Failed to build source distribution
  Caused by: pyproject.toml was not included by `cargo package`. Please make sure pyproject.toml is not excluded or build with `--no-sdist`
```
