### PR TITLE
Update the default edition for new projects

### DIFF
--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -1,7 +1,7 @@
 [package]
 name = "{{ name }}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Changing the edition in `src/templates/Cargo.toml.j2` from 2018 to 2021 since it's newer.