### PR TITLE
Re-export `__all__` in `__init__.py` for pure Rust project

### DIFF
--- a/guide/src/project_layout.md
+++ b/guide/src/project_layout.md
@@ -22,7 +22,8 @@ wheel. For convenience, this file includes the following:
 ```python
 from .my_project import *
 
-__doc__ = .my_project.__doc__
+__doc__ = my_project.__doc__
+__all__ = my_project.__all__
 ```
 
 such that the module functions may be called directly with:

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -656,7 +656,7 @@ pub fn write_bindings_module(
             writer.add_bytes(
                 &module.join("__init__.py"),
                 format!(
-                    "from .{module_name} import *\n\n__doc__ = {module_name}.__doc__\n",
+                    "from .{module_name} import *\n\n__doc__ = {module_name}.__doc__\n__all__ = {module_name}.__all__\n",
                     module_name = module_name
                 )
                 .as_bytes(),

--- a/src/templates/__init__.py.j2
+++ b/src/templates/__init__.py.j2
@@ -2,3 +2,4 @@ from .{{ crate_name }} import *
 
 
 __doc__ = {{ crate_name }}.__doc__
+__all__ = {{ crate_name }}.__all__


### PR DESCRIPTION
maturin already re-exports `__doc__`, but `__all__` is also useful to be reexported. There are a bunch of Python documentation generators which make use of this. In our case (I work on [pdoc](https://pdoc.dev)), re-exporting `__all__` means we correctly detect that it's `my_project` and not `my_project.my_project`. 😃 

On that note, thank you folks for the fantastic work you are doing with PyO3/maturin! 🍰 
We're working on some Rust extensions for @mitmproxy and PyO3 has just been super wonderful. ❤️ 