### PR TITLE
Add hardcoded well-known sysconfigs for effortless cross compiling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,9 @@ jobs:
 
           # non-abi3
           cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
+          cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-apple-darwin --zig
+          # Check wheels with twine
+          twine check --strict test-crates/pyo3-mixed/target/wheels/*.whl
       - name: test cross compiling windows abi3 wheel
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,11 +105,16 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
           rustup target add aarch64-unknown-linux-musl
           rustup target add aarch64-apple-darwin
+
+          # abi3
           cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
           cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-musl --zig
           cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-apple-darwin --zig
           # Check wheels with twine
           twine check --strict test-crates/pyo3-pure/target/wheels/*.whl
+
+          # non-abi3
+          cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
       - name: test cross compiling windows abi3 wheel
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Re-export `__all__` for pure Rust projects in [#886](https://github.com/PyO3/maturin/pull/886)
-* Stop setting `RUSTFLAGS` environment variable to an empty string [#887](https://github.com/PyO3/maturin/pull/887)
+* Stop setting `RUSTFLAGS` environment variable to an empty string in [#887](https://github.com/PyO3/maturin/pull/887)
+* Add hardcoded well-known sysconfigs for effortless cross compiling in [#896](https://github.com/PyO3/maturin/pull/896)
 
 ## [0.12.14] - 2022-04-25
 

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -1,0 +1,100 @@
+use super::InterpreterKind;
+use crate::target::{Arch, Os};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Wellknown Python interpreter sysconfig values
+static WELLKNOWN_SYSCONFIG: Lazy<HashMap<Os, HashMap<Arch, Vec<InterpreterConfig>>>> =
+    Lazy::new(|| {
+        let mut sysconfig = HashMap::new();
+        let sysconfig_linux = serde_json::from_slice(include_bytes!("sysconfig-linux.json"))
+            .expect("invalid sysconfig.json");
+        sysconfig.insert(Os::Linux, sysconfig_linux);
+        sysconfig
+    });
+
+/// Some of the sysconfigdata of Python interpreter we care about
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
+pub struct InterpreterConfig {
+    /// Python's major version
+    pub major: usize,
+    /// Python's minor version
+    pub minor: usize,
+    /// cpython or pypy
+    #[serde(rename = "interpreter")]
+    pub interpreter_kind: InterpreterKind,
+    /// For linux and mac, this contains the value of the abiflags, e.g. "m"
+    /// for python3.7m or "dm" for python3.6dm. Since python3.8, the value is
+    /// empty. On windows, the value was always None.
+    ///
+    /// See PEP 261 and PEP 393 for details
+    pub abiflags: String,
+    /// Suffix to use for extension modules as given by sysconfig.
+    pub ext_suffix: String,
+    /// Part of sysconfig's SOABI specifying {major}{minor}{abiflags}
+    ///
+    /// Note that this always `None` on windows
+    pub abi_tag: Option<String>,
+    /// Pointer width
+    pub calcsize_pointer: Option<usize>,
+}
+
+impl InterpreterConfig {
+    /// Lookup a wellknown sysconfig for a given Python interpreter
+    pub fn lookup(
+        os: Os,
+        arch: Arch,
+        python_impl: InterpreterKind,
+        python_version: (usize, usize),
+    ) -> Option<&'static Self> {
+        let (major, minor) = python_version;
+        if let Some(os_sysconfigs) = WELLKNOWN_SYSCONFIG.get(&os) {
+            if let Some(sysconfigs) = os_sysconfigs.get(&arch) {
+                return sysconfigs.iter().find(|s| {
+                    s.interpreter_kind == python_impl && s.major == major && s.minor == minor
+                });
+            }
+        }
+        None
+    }
+
+    /// Generate pyo3 config file content
+    pub fn pyo3_config_file(&self) -> String {
+        let mut content = format!(
+            r#"implementation={implementation}
+version={major}.{minor}
+shared=true
+abi3=false
+build_flags=WITH_THREAD
+suppress_build_script_link_lines=false"#,
+            implementation = self.interpreter_kind,
+            major = self.major,
+            minor = self.minor,
+        );
+        if let Some(pointer_width) = self.calcsize_pointer {
+            content.push_str(&format!("\npointer_width={}", pointer_width * 8));
+        }
+        content
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_load_sysconfig() {
+        let linux_sysconfig = WELLKNOWN_SYSCONFIG.get(&Os::Linux).unwrap();
+        assert!(linux_sysconfig.contains_key(&Arch::X86_64));
+    }
+
+    #[test]
+    fn test_pyo3_config_file() {
+        let sysconfig =
+            InterpreterConfig::lookup(Os::Linux, Arch::X86_64, InterpreterKind::CPython, (3, 10))
+                .unwrap();
+        let config_file = sysconfig.pyo3_config_file();
+        assert_eq!(config_file, "implementation=CPython\nversion=3.10\nshared=true\nabi3=false\nbuild_flags=WITH_THREAD\nsuppress_build_script_link_lines=false\npointer_width=64");
+    }
+}

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -9,8 +9,11 @@ static WELLKNOWN_SYSCONFIG: Lazy<HashMap<Os, HashMap<Arch, Vec<InterpreterConfig
     Lazy::new(|| {
         let mut sysconfig = HashMap::new();
         let sysconfig_linux = serde_json::from_slice(include_bytes!("sysconfig-linux.json"))
-            .expect("invalid sysconfig.json");
+            .expect("invalid sysconfig-linux.json");
         sysconfig.insert(Os::Linux, sysconfig_linux);
+        let sysconfig_macos = serde_json::from_slice(include_bytes!("sysconfig-macos.json"))
+            .expect("invalid sysconfig-macos.json");
+        sysconfig.insert(Os::Macos, sysconfig_macos);
         sysconfig
     });
 

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -2,6 +2,7 @@ import json
 import platform
 import sys
 import sysconfig
+import struct
 
 if platform.python_implementation() == "PyPy":
     # Workaround for PyPy 3.6 on windows:
@@ -28,6 +29,8 @@ metadata = {
     "platform": sysconfig.get_platform(),
     # This one isn't technically necessary, but still very useful for sanity checks
     "system": platform.system().lower(),
+    # This one is for generating a config file for pyo3
+    "calcsize_pointer": struct.calcsize("P"),
 }
 
 print(json.dumps(metadata))

--- a/src/python_interpreter/sysconfig-linux.json
+++ b/src/python_interpreter/sysconfig-linux.json
@@ -1,0 +1,318 @@
+{
+  "x86_64": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-x86_64-linux-gnu.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-x86_64-linux-gnu.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-x86_64-linux-gnu.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-x86_64-linux-gnu.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-x86_64-linux-gnu.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy37-pp73-x86_64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy38-pp73-x86_64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy39-pp73-x86_64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    }
+  ],
+  "i686": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-i386-linux-gnu.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-i386-linux-gnu.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-i386-linux-gnu.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-i386-linux-gnu.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-i386-linux-gnu.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy37-pp73-x86-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy38-pp73-x86-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 4
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy39-pp73-x86-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 4
+    }
+  ],
+  "aarch64": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-aarch64-linux-gnu.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-aarch64-linux-gnu.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-aarch64-linux-gnu.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-aarch64-linux-gnu.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-aarch64-linux-gnu.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy37-pp73-aarch64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy38-pp73-aarch64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy39-pp73-aarch64-linux-gnu.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    }
+  ],
+  "ppc64le": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-powerpc64le-linux-gnu.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-powerpc64le-linux-gnu.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-powerpc64le-linux-gnu.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-powerpc64le-linux-gnu.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-powerpc64le-linux-gnu.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    }
+  ],
+  "s390x": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-s390x-linux-gnu.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-s390x-linux-gnu.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-s390x-linux-gnu.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-s390x-linux-gnu.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-s390x-linux-gnu.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    }
+  ]
+}

--- a/src/python_interpreter/sysconfig-macos.json
+++ b/src/python_interpreter/sysconfig-macos.json
@@ -1,0 +1,123 @@
+{
+  "x86_64": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-darwin.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-darwin.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-darwin.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-darwin.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-darwin.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy37-pp73-darwin.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy38-pp73-darwin.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "pypy",
+      "ext_suffix": ".pypy39-pp73-darwin.so",
+      "abi_tag": "pp73",
+      "calcsize_pointer": 8
+    }
+  ],
+  "aarch64": [
+    {
+      "major": 3,
+      "minor": 6,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-36m-darwin.so",
+      "abi_tag": "36m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 7,
+      "abiflags": "m",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-37m-darwin.so",
+      "abi_tag": "37m",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 8,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-38-darwin.so",
+      "abi_tag": "38",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 9,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-39-darwin.so",
+      "abi_tag": "39",
+      "calcsize_pointer": 8
+    },
+    {
+      "major": 3,
+      "minor": 10,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cpython-310-darwin.so",
+      "abi_tag": "310",
+      "calcsize_pointer": 8
+    }
+  ]
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -3,6 +3,7 @@ use crate::python_interpreter::InterpreterKind;
 use crate::{PlatformTag, PythonInterpreter};
 use anyhow::{anyhow, bail, format_err, Context, Result};
 use platform_info::*;
+use serde::Deserialize;
 use std::env;
 use std::fmt;
 use std::path::Path;
@@ -11,8 +12,9 @@ use std::str;
 use target_lexicon::{Environment, Triple};
 
 /// All supported operating system
-#[derive(Debug, Clone, Eq, PartialEq)]
-enum Os {
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Os {
     Linux,
     Windows,
     Macos,
@@ -41,12 +43,16 @@ impl fmt::Display for Os {
 }
 
 /// All supported CPU architectures
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Arch {
     Aarch64,
     Armv7L,
+    #[serde(alias = "ppc64le")]
     Powerpc64Le,
+    #[serde(alias = "ppc64")]
     Powerpc64,
+    #[serde(alias = "i686")]
     X86,
     X86_64,
     S390X,
@@ -346,6 +352,11 @@ impl Target {
             | Os::Illumos
             | Os::Haiku => true,
         }
+    }
+
+    /// Returns target operating system
+    pub fn target_os(&self) -> Os {
+        self.os
     }
 
     /// Returns target architecture

--- a/sysconfig/generate_manylinux.py
+++ b/sysconfig/generate_manylinux.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import json
+from collections import defaultdict
+import subprocess
+
+
+ARCHES = ["x86_64", "i686", "aarch64", "ppc64le", "s390x"]
+PY_VERS = [
+    "cp36-cp36m",
+    "cp37-cp37m",
+    "cp38-cp38",
+    "cp39-cp39",
+    "cp310-cp310",
+    "pp37-pypy37_pp73",
+    "pp38-pypy38_pp73",
+    "pp39-pypy39_pp73",
+]
+
+
+def main():
+    well_known = defaultdict(list)
+    cwd = os.getcwd()
+    for arch in ARCHES:
+        docker_image = f"quay.io/pypa/manylinux2014_{arch}"
+        for ver in PY_VERS:
+            # PyPy is not available on ppc64le & s390x
+            if arch in ["ppc64le", "s390x"] and ver.startswith("pp"):
+                continue
+            command = [
+                "docker",
+                "run",
+                "--rm",
+                "-it",
+                "-v",
+                f"{cwd}:/io",
+                "-w",
+                "/io",
+                docker_image,
+                f"/opt/python/{ver}/bin/python",
+                "/io/src/python_interpreter/get_interpreter_metadata.py",
+            ]
+            try:
+                metadata = subprocess.check_output(command).decode().strip()
+            except subprocess.CalledProcessError as exc:
+                print(exc.output, file=sys.stderr)
+                raise
+            metadata = json.loads(metadata.splitlines()[-1])
+            for key in ["system", "platform"]:
+                metadata.pop(key, None)
+            well_known[arch].append(metadata)
+
+    with open("src/python_interpreter/sysconfig-linux.json", "w") as f:
+        f.write(json.dumps(well_known, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements https://github.com/PyO3/maturin/pull/756#discussion_r775961992

With this when cross compiling for non-abi3 Linux wheels, there is no need to supply `PYO3_CROSS_LIB_DIR` anymore and `-i pythonX.Y` will just work™️. Internally maturin generates a pyo3 config file based on collected sysconfigs and set `PYO3_CONFIG_FILE` env var for pyo3's build script.

In theory we can extend the support to most Unix systems, ~~for example macOS~~(added macOS in this PR), but that can be done in its dedicated PRs.