### PR TITLE
Fix invalid pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = ["tomli>=1.1.0 ; python_version<'3.11'"]
+dynamic = [
+    "authors",
+    "description",
+    "license",
+    "readme",
+    "version"
+]
 
 [project.optional-dependencies]
 zig = [


### PR DESCRIPTION
These attributes should be marked dynamic.

Fixes:
```
configuration error: `project` must contain ['version'] properties
```

Fixes:
```
The following seems to be defined outside of `pyproject.toml`:

`description = 'Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages'`

According to the spec (see the link bellow), however, setuptools CANNOT
consider this value unless 'description' is listed as `dynamic`.
```

Fixes:
```
The following seems to be defined outside of `pyproject.toml`:

`license = 'MIT OR Apache-2.0'`

According to the spec (see the link bellow), however, setuptools CANNOT
consider this value unless 'license' is listed as `dynamic`.
```

Fixes:
```
The following seems to be defined outside of `pyproject.toml`:

`authors = 'konstin'`

According to the spec (see the link bellow), however, setuptools CANNOT
consider this value unless 'authors' is listed as `dynamic`.
```