### PR TITLE
Use setuptools-rust for bootstrapping

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include Cargo.toml Cargo.lock
+include Readme.md
+include license-apache license-mit
+recursive-include src *.rs
+recursive-include src/auditwheel *.json
+recursive-include src/python_interpreter *.py *.json
+recursive-include src/templates *.j2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Workaround to bootstrap maturin on non-manylinux platforms
 [build-system]
-requires = ["setuptools~=53.0.0", "wheel~=0.36.2", "tomli>=1.1.0 ; python_version<'3.11'"]
+requires = ["setuptools~=53.0.0", "wheel~=0.36.2", "tomli>=1.1.0 ; python_version<'3.11'", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This seems like a better approach for bootstrapping and fixes things so that the extensions are built during the build phase instead of the install phase.
