### PR TITLE
Use `MATURIN_REPOSITORY_URL` environment variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add wheel data support in [#906](https://github.com/PyO3/maturin/pull/906)
 * Allow use python interpreters from bundled sysconfig when not cross compiling in [#907](https://github.com/PyO3/maturin/pull/907)
 * Use setuptools-rust for bootstrapping in [#909](https://github.com/PyO3/maturin/pull/909)
+* Allow setting the publish repository URL via `MATURIN_REPOSITORY_URL` in [#913](https://github.com/PyO3/maturin/pull/913)
 
 ## [0.12.15] - 2022-05-07
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -20,9 +20,11 @@ pub struct PublishOpt {
     #[clap(
         short = 'r',
         long = "repository-url",
+        env = "MATURIN_REPOSITORY_URL",
         default_value = "https://upload.pypi.org/legacy/"
     )]
-    /// The url of registry where the wheels are uploaded to
+    /// The URL of the registry where the wheels are uploaded to. Note than you can also pass
+    /// the URL through MATURIN_REPOSITORY_URL variable
     registry: String,
     #[clap(short, long)]
     /// Username for pypi or your custom registry. Set MATURIN_PYPI_TOKEN variable


### PR DESCRIPTION
Include it for feature parity with twine's `TWINE_REPOSITORY_URL`.