### PR TITLE
Allow stubs-only mixed project layout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow use python interpreters from bundled sysconfig when not cross compiling in [#907](https://github.com/PyO3/maturin/pull/907)
 * Use setuptools-rust for bootstrapping in [#909](https://github.com/PyO3/maturin/pull/909)
 * Allow setting the publish repository URL via `MATURIN_REPOSITORY_URL` in [#913](https://github.com/PyO3/maturin/pull/913)
+* Allow stubs-only mixed project layout in [#914](https://github.com/PyO3/maturin/pull/914)
 * Allow setting the publish user name via `MATURIN_USERNAME` in [#915](https://github.com/PyO3/maturin/pull/915)
 
 ## [0.12.15] - 2022-05-07

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -113,7 +113,9 @@ impl ProjectLayout {
         };
 
         if python_module.is_dir() {
-            if !python_module.join("__init__.py").is_file() {
+            if !python_module.join("__init__.py").is_file()
+                && !python_module.join("__init__.pyi").is_file()
+            {
                 bail!("Found a directory with the module name ({}) next to Cargo.toml, which indicates a mixed python/rust project, but the directory didn't contain an __init__.py file.", module_name)
             }
 


### PR DESCRIPTION
Fixes #792 

Note that this only allows it to build, it doesn't re-export the Rust module to top module level as in https://github.com/PyO3/maturin/blob/4f92d4d9eeb4110ac44bc977f155ef1c8cb3f0bd/src/module_writer.rs#L646-L658

@kevinheavey I'd love to know more about your requirements.