### PR TITLE
Don't consider compile to i686 on x86_64 Windows cross compiling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Don't consider compile to i686 on x86_64 Windows cross compiling in [#923](https://github.com/PyO3/maturin/pull/923)
+
 ## [0.12.16] - 2022-05-16
 
 * Add Linux armv7l python sysconfig in [#901](https://github.com/PyO3/maturin/pull/901)

--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -23,6 +23,11 @@ pub fn is_cross_compiling(target: &Target) -> Result<bool> {
         return Ok(false);
     }
 
+    if target_triple.starts_with("i686-pc-windows") && host.starts_with("x86_64-pc-windows") {
+        // Not cross-compiling to compile for 32-bit Python from windows 64-bit
+        return Ok(false);
+    }
+
     if let Some(target_without_env) = target_triple
         .rfind('-')
         .map(|index| &target_triple[0..index])


### PR DESCRIPTION
Same as https://github.com/PyO3/pyo3/blob/23a3069d53ff97a53b1e381ebb919d9c9cc52c5c/pyo3-build-config/src/impl_.rs#L794-L796