### PR TITLE
Accept `-i x.y` and `-i python-x.y` in `maturin build` command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Don't consider compile to i686 on x86_64 Windows cross compiling in [#923](https://github.com/PyO3/maturin/pull/923)
+* Accept `-i x.y` and `-i python-x.y` in `maturin build` command in [#925](https://github.com/PyO3/maturin/pull/925)
 
 ## [0.12.16] - 2022-05-16
 


### PR DESCRIPTION
This makes it easier to write CI configuration, for example
`setup-python` action use `pypy-3.9` as version, accepting `pypy-3.9`
as `pypy3.9` is much nicer than writing another `pypy3.9` option.