### PR TITLE
Add support for building bin bindings wheels with multiple platform tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,7 @@ jobs:
       - name: Build wheel (with sdist)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
-          # manylinux
-          cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage"
-          # musllinux
-          cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage" --no-sdist --compatibility musllinux_1_1
+          cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage" --no-sdist --compatibility manylinux2010 musllinux_1_1
 
       # ring doesn't support aarch64 windows yet
       - name: Build wheel (windows aarch64)
@@ -184,7 +181,7 @@ jobs:
           # musllinux
           maturin build --release -b bin -o dist --no-sdist \
             --target ${{ matrix.platform.target }} \
-            --compatibility musllinux_1_1 \
+            --compatibility  musllinux_1_1 \
             --cargo-extra-args="--features password-storage"
       - name: Archive binary
         run: tar czvf target/release/maturin-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release maturin

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add support for building bin bindings wheels with multiple platform tags in [#928](https://github.com/PyO3/maturin/pull/928)
+
 ## [0.12.17] - 2022-05-18
 
 * Don't consider compile to i686 on x86_64 Windows cross compiling in [#923](https://github.com/PyO3/maturin/pull/923)

--- a/src/auditwheel/platform_tag.rs
+++ b/src/auditwheel/platform_tag.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Decides how to handle manylinux and musllinux compliance
-#[derive(Serialize, Debug, Clone, Eq, PartialEq, Copy)]
+#[derive(Serialize, Debug, Clone, Eq, PartialEq, Copy, Ord, PartialOrd)]
 pub enum PlatformTag {
     /// Use the manylinux_x_y tag
     Manylinux {
@@ -60,6 +60,16 @@ impl PlatformTag {
     /// Only manylinux and musllinux are portable
     pub fn is_portable(&self) -> bool {
         !matches!(self, PlatformTag::Linux)
+    }
+
+    /// Is this a manylinux platform tag
+    pub fn is_manylinux(&self) -> bool {
+        matches!(self, PlatformTag::Manylinux { .. })
+    }
+
+    /// Is this a musllinux platform tag
+    pub fn is_musllinux(&self) -> bool {
+        matches!(self, PlatformTag::Musllinux { .. })
     }
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -206,8 +206,8 @@ fn compile_target(
                 build.target = vec![target_triple.to_string()];
             }
         } else {
-            let zig_triple = if target.is_linux() {
-                match context.platform_tag {
+            let zig_triple = if target.is_linux() && !target.is_musl_target() {
+                match context.platform_tag.iter().find(|tag| tag.is_manylinux()) {
                     Some(PlatformTag::Manylinux { x, y }) => {
                         format!("{}.{}.{}", target_triple, x, y)
                     }

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -29,7 +29,7 @@ pub fn develop(
     let wheel_dir = TempDir::new().context("Failed to create temporary directory")?;
 
     let build_options = BuildOptions {
-        platform_tag: Some(PlatformTag::Linux),
+        platform_tag: vec![PlatformTag::Linux],
         interpreter: vec![python.clone()],
         bindings,
         manifest_path: Some(manifest_file.to_path_buf()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,20 +264,20 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
                 BridgeModel::Bindings(..) => {
                     vec![context.interpreter[0].get_tag(
                         &context.target,
-                        PlatformTag::Linux,
+                        &[PlatformTag::Linux],
                         context.universal2,
                     )?]
                 }
                 BridgeModel::BindingsAbi3(major, minor) => {
                     let platform = context
                         .target
-                        .get_platform_tag(PlatformTag::Linux, context.universal2)?;
+                        .get_platform_tag(&[PlatformTag::Linux], context.universal2)?;
                     vec![format!("cp{}{}-abi3-{}", major, minor, platform)]
                 }
                 BridgeModel::Bin | BridgeModel::Cffi => {
                     context
                         .target
-                        .get_universal_tags(PlatformTag::Linux, context.universal2)?
+                        .get_universal_tags(&[PlatformTag::Linux], context.universal2)?
                         .1
                 }
             };

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -367,22 +367,22 @@ impl PythonInterpreter {
     pub fn get_tag(
         &self,
         target: &Target,
-        platform_tag: PlatformTag,
+        platform_tags: &[PlatformTag],
         universal2: bool,
     ) -> Result<String> {
         // Restrict `sysconfig.get_platform()` usage to Windows and non-portable Linux only for now
         // so we don't need to deal with macOS deployment target
         let use_sysconfig_platform = target.is_windows()
-            || (target.is_linux() && !platform_tag.is_portable())
+            || (target.is_linux() && platform_tags.iter().any(|tag| !tag.is_portable()))
             || target.is_illumos();
         let platform = if use_sysconfig_platform {
             if let Some(platform) = self.platform.clone() {
                 platform
             } else {
-                target.get_platform_tag(platform_tag, universal2)?
+                target.get_platform_tag(platform_tags, universal2)?
             }
         } else {
-            target.get_platform_tag(platform_tag, universal2)?
+            target.get_platform_tag(platform_tags, universal2)?
         };
         let tag = match self.interpreter_kind {
             InterpreterKind::CPython => {


### PR DESCRIPTION
This allows `maturin build --manylinux manylinux_x_y musllinux_x_y -b bin` while disallows any other forms of multiple platform tags. (Which is the old behavior before this change).

Closes #927 