### PR TITLE
Fix abi3 wheel build issue when no Python interpreters found on host

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -949,7 +949,26 @@ pub fn find_interpreter(
                 }
             } else {
                 println!("🐍 Not using a specific python interpreter");
-                Ok(interpreter)
+                if interpreter.is_empty() {
+                    // Fake one to make `BuildContext::build_wheels` happy for abi3 when no cpython/pypy found on host
+                    // The python interpreter config doesn't matter, as it's not used for anything
+                    Ok(vec![PythonInterpreter {
+                        config: InterpreterConfig {
+                            major: *major as usize,
+                            minor: *minor as usize,
+                            interpreter_kind: InterpreterKind::CPython,
+                            abiflags: "".to_string(),
+                            ext_suffix: "".to_string(),
+                            abi_tag: None,
+                            pointer_width: None,
+                        },
+                        executable: PathBuf::new(),
+                        platform: None,
+                        runnable: false,
+                    }])
+                } else {
+                    Ok(interpreter)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes the following issue.

```
maturin.exe build -m maturin/test-crates/pyo3-pure/Cargo.toml --zig --target aarch64-unknown-linux-gnu
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
📡 Using build options bindings from pyproject.toml
📦 Built source distribution to D:\a\maturin-action\maturin-action\maturin\test-crates\pyo3-pure\target\wheels\pyo3_pure-2.1.2.tar.gz
thread 'main' panicked at 'assertion failed: !wheels.is_empty()', src\main.rs:337:13
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

for https://github.com/PyO3/maturin/blob/d39ab1a4c33f4a9835ddb0f85acf9d41d91d8ba4/src/build_context.rs#L232-L234

We should refactor the whole python interpreters detection logic later, we have used several faking interpreters for similar purposes now.