### PR TITLE
Add Python 3.11 sysconfig for arm64 Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Skip auditwheel for non-compliant linux environment automatically in [#931](https://github.com/PyO3/maturin/pull/931)
 * Fix abi3 wheel build issue when no Python interpreters found on host in [#933](https://github.com/PyO3/maturin/pull/933)
 * Add Python 3.11 sysconfigs for Linux, macOS and Windows in [#934](https://github.com/PyO3/maturin/pull/934)
+* Add Python 3.11 sysconfig for arm64 Windows in [#936](https://github.com/PyO3/maturin/pull/936)
 
 ## [0.12.17] - 2022-05-18
 

--- a/src/python_interpreter/sysconfig-windows.json
+++ b/src/python_interpreter/sysconfig-windows.json
@@ -92,5 +92,16 @@
       "abi_tag": null,
       "pointer_width": 32
     }
+  ],
+  "aarch64": [
+    {
+      "major": 3,
+      "minor": 11,
+      "abiflags": "",
+      "interpreter": "cpython",
+      "ext_suffix": ".cp311-win_arm64.pyd",
+      "abi_tag": null,
+      "pointer_width": 64
+    }
   ]
 }


### PR DESCRIPTION
Only Python 3.11 and later versions have official arm64 Windows installer.