### PR TITLE
Fallback to `py -X.Y` when `pythonX.Y` cannot be found on Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Python 3.11 sysconfig for arm64 Windows in [#936](https://github.com/PyO3/maturin/pull/936)
 * Add network proxy support to upload command in [#939](https://github.com/PyO3/maturin/pull/939)
 * Fix python interpreter detection on arm64 Windows in [#940](https://github.com/PyO3/maturin/pull/940)
+* Fallback to `py -X.Y` when `pythonX.Y` cannot be found on Windows in [#943](https://github.com/PyO3/maturin/pull/943)
 
 ## [0.12.17] - 2022-05-18
 

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -20,6 +20,7 @@ else:
     ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 
 metadata = {
+    "executable": sys.executable or None,
     "major": sys.version_info.major,
     "minor": sys.version_info.minor,
     "abiflags": sysconfig.get_config_var("ABIFLAGS"),


### PR DESCRIPTION
Before

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/1556054/170647395-156021cb-a89f-4612-bca5-1e236bbd62f5.png">

After

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/1556054/170647458-776fd0bf-1508-4348-982c-36bbfe1e85e2.png">