### PR TITLE
Fix Windows Store install detection

### DIFF
--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -230,7 +230,7 @@ fn find_all_windows(target: &Target, min_python_minor: usize) -> Result<Vec<Stri
     // Fallback to pythonX.Y for Microsoft Store versions
     for minor in min_python_minor..MAXIMUM_PYTHON_MINOR {
         if !versions_found.contains(&(3, minor)) {
-            interpreter.push(format!("python3.{}", minor));
+            interpreter.push(format!("python3.{}.exe", minor));
             versions_found.insert((3, minor));
         }
     }

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -144,7 +144,11 @@ fn find_all_windows(target: &Target, min_python_minor: usize) -> Result<Vec<Stri
                         .unwrap();
                     let path = str::from_utf8(&output.stdout).unwrap().trim();
                     if !output.status.success() || path.trim().is_empty() {
-                        bail!("Couldn't determine the path to python for `py {}`", version);
+                        eprintln!(
+                            "⚠️  Warning: couldn't determine the path to python for `py {}`",
+                            version
+                        );
+                        continue;
                     }
                     interpreter.push(path.to_string());
                     versions_found.insert((major, minor));


### PR DESCRIPTION
This includes two fixes:
- At least for me, `maturin` was unable to run `python` executables for auto-detection without the `.exe` extension explicitly added, so this adds the extension.
- I have an old version of `py.exe` that can pick up all of my Windows Store installs. My Python 3.7 install is unable to be run through `py.exe` for whatever reason, however. There is no reason that I can see to completely bail when we can't execute the test command through `py.exe` for a particular install, so I changed it to just a warning.

Prior work #944 

Completely fixes #788 