### PR TITLE
Filter Python interpreters by target pointer width on Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * **Breaking Change**: Drop support for python 3.6, which is end of life
+* Fix Windows Store install detection in [#949](https://github.com/PyO3/maturin/pull/949)
+* Filter Python interpreters by target pointer width on Windows in [#950](https://github.com/PyO3/maturin/pull/950)
 
 ## [0.12.18] - 2022-05-29
 


### PR DESCRIPTION
Fixes an oversight from #943 and #944.