### PR TITLE
Fix incompatibility with cibuildwheel for 32-bit Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * **Breaking Change**: Drop support for python 3.6, which is end of life
+* Fix incompatibility with cibuildwheel for 32-bit Windows in [#951](https://github.com/PyO3/maturin/pull/951)
 
 ## [0.12.19] - 2022-06-05
 


### PR DESCRIPTION
`maturin pep517` commands use Rust host target triple by default, thus when building for 32-bit Python on x64 Windows with `cibuildwheel` it incorrectly uses `x86_64-pc-windows-msvc` target.