### PR TITLE
Don't require `pip` error messages to be utf-8 encoding

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Breaking Change**: Drop support for python 3.6, which is end of life
 * Fix incompatibility with cibuildwheel for 32-bit Windows in [#951](https://github.com/PyO3/maturin/pull/951)
+* Don't require `pip` error messages to be utf-8 encoding in [#953](https://github.com/PyO3/maturin/pull/953)
 
 ## [0.12.19] - 2022-06-05
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -5,7 +5,6 @@ use crate::Target;
 use anyhow::{anyhow, bail, Context, Result};
 use std::path::Path;
 use std::process::Command;
-use std::str;
 use tempfile::TempDir;
 
 /// Installs a crate by compiling it and copying the shared library to site-packages.
@@ -91,15 +90,15 @@ pub fn develop(
                 venv_dir.display(),
                 &command,
                 output.status,
-                str::from_utf8(&output.stdout)?.trim(),
-                str::from_utf8(&output.stderr)?.trim(),
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
             );
         }
         if !output.stderr.is_empty() {
             eprintln!(
                 "⚠️  Warning: pip raised a warning running {:?}:\n{}",
                 &command,
-                str::from_utf8(&output.stderr)?.trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
             );
         }
         println!(


### PR DESCRIPTION
Fixes #952 