### PR TITLE
Compare minimum python version requirement between `requires-python` and bindings crate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Drop support for python 3.6, which is end of life
 * Fix incompatibility with cibuildwheel for 32-bit Windows in [#951](https://github.com/PyO3/maturin/pull/951)
 * Don't require `pip` error messages to be utf-8 encoding in [#953](https://github.com/PyO3/maturin/pull/953)
+* Compare minimum python version requirement between `requires-python` and bindings crate in [#954](https://github.com/PyO3/maturin/pull/954)
 
 ## [0.12.19] - 2022-06-05
 

--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {%- if bindings == "pyo3" -%}
-pyo3 = { version = "0.16.3", features = ["extension-module"] }
+pyo3 = { version = "0.16.5", features = ["extension-module"] }
 {%- elif bindings == "rust-cpython" -%}
 cpython = { version = "0.7.0", features = ["extension-module"] }
 {%- endif -%}

--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "{{ name }}"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Fixes [this issue](https://gitter.im/PyO3/Lobby?at=629d97aada330517ffb121a9) reported in Gitter.

<img width="978" alt="image" src="https://user-images.githubusercontent.com/1556054/172204662-f62f13b1-fad2-45ee-a57e-891e82e41439.png">
