### PR TITLE
Don't build sdist by default in `maturin build` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,16 @@ jobs:
       - name: Build wheel (with sdist)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
-          cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage" --compatibility manylinux2010 musllinux_1_1
+          cargo run -- build --release -b bin --sdist -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage" --compatibility manylinux2010 musllinux_1_1
 
       # ring doesn't support aarch64 windows yet
       - name: Build wheel (windows aarch64)
         if: matrix.target == 'aarch64-pc-windows-msvc'
-        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --no-sdist --cargo-extra-args="--no-default-features" --cargo-extra-args="--features log,upload,human-panic"
+        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--no-default-features" --cargo-extra-args="--features log,upload,human-panic"
 
       - name: Build wheel (without sdist)
         if: ${{ matrix.target != 'x86_64-unknown-linux-musl' && matrix.target != 'aarch64-pc-windows-msvc' }}
-        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --no-sdist --cargo-extra-args="--features password-storage"
+        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage"
 
       - name: Build wheel (macOS universal2)
         if: matrix.target == 'x86_64-apple-darwin'
@@ -106,7 +106,7 @@ jobs:
           # set SDKROOT for C dependencies like ring and bzip2
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           rustup target add aarch64-apple-darwin
-          cargo run -- build --release -b bin -o dist --no-sdist --universal2 --cargo-extra-args="--features password-storage"
+          cargo run -- build --release -b bin -o dist --universal2 --cargo-extra-args="--features password-storage"
 
       - name: Archive binary (windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,13 +85,13 @@ jobs:
           python-version: "pypy-3.7"
       - name: test build pypy wheel
         run: |
-          cargo run -- build --no-sdist -i pypy3 -m test-crates/pyo3-mixed-submodule/Cargo.toml
+          cargo run -- build -i pypy3 -m test-crates/pyo3-mixed-submodule/Cargo.toml
           pypy3 -m pip install --force-reinstall --no-index --find-links test-crates/pyo3-mixed-submodule/target/wheels pyo3-mixed-submodule
           pypy3 -m pip install pytest
           pypy3 -m pytest test-crates/pyo3-mixed-submodule/tests/
       - name: test build pypy wheel with abi3
         run: |
-          cargo run -- build --no-sdist -i pypy3 -m test-crates/pyo3-pure/Cargo.toml --cargo-extra-args="-vv"
+          cargo run -- build -i pypy3 -m test-crates/pyo3-pure/Cargo.toml --cargo-extra-args="-vv"
           pypy3 -m pip install --force-reinstall --no-index --find-links test-crates/pyo3-pure/target/wheels pyo3-pure
           pypy3 -m pip install pytest
           pypy3 -m pytest test-crates/pyo3-pure/test_pyo3_pure.py
@@ -107,15 +107,15 @@ jobs:
           rustup target add aarch64-apple-darwin
 
           # abi3
-          cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
-          cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-musl --zig
-          cargo run -- build --no-sdist -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-apple-darwin --zig
+          cargo run -- build -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
+          cargo run -- build -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-musl --zig
+          cargo run -- build -i python -m test-crates/pyo3-pure/Cargo.toml --target aarch64-apple-darwin --zig
           # Check wheels with twine
           twine check --strict test-crates/pyo3-pure/target/wheels/*.whl
 
           # non-abi3
-          cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
-          cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-apple-darwin --zig
+          cargo run -- build -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
+          cargo run -- build -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-apple-darwin --zig
           # Check wheels with twine
           twine check --strict test-crates/pyo3-mixed/target/wheels/*.whl
       - name: test cross compiling windows wheel
@@ -127,17 +127,17 @@ jobs:
           rustup target add x86_64-pc-windows-msvc
 
           # abi3
-          cargo run -- build --no-sdist -m test-crates/pyo3-pure/Cargo.toml --target x86_64-pc-windows-gnu
-          cargo run -- build --no-sdist -m test-crates/pyo3-pure/Cargo.toml --target x86_64-pc-windows-msvc
+          cargo run -- build -m test-crates/pyo3-pure/Cargo.toml --target x86_64-pc-windows-gnu
+          cargo run -- build -m test-crates/pyo3-pure/Cargo.toml --target x86_64-pc-windows-msvc
 
           # no-abi3
-          cargo run -- build --no-sdist -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target x86_64-pc-windows-msvc
+          cargo run -- build -i python3.9 -m test-crates/pyo3-mixed/Cargo.toml --target x86_64-pc-windows-msvc
       - name: test compiling with PYO3_CONFIG_FILE
         shell: bash
         run: |
           rustup target add x86_64-unknown-linux-gnu
           export PYO3_CONFIG_FILE=$(pwd)/test-crates/pyo3-mixed/pyo3-config.txt
-          cargo run -- build --no-sdist -m test-crates/pyo3-mixed/Cargo.toml --target x86_64-unknown-linux-gnu --zig
+          cargo run -- build -m test-crates/pyo3-mixed/Cargo.toml --target x86_64-unknown-linux-gnu --zig
 
   test-alpine:
     name: Test Alpine Linux
@@ -281,10 +281,10 @@ jobs:
           rustup target add ${{ matrix.platform.target }}
 
           # Use bundled sysconfig
-          cargo run --target x86_64-unknown-linux-gnu -- build -i ${{ matrix.platform.python }} --release --out dist --no-sdist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
+          cargo run --target x86_64-unknown-linux-gnu -- build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
 
           # Use PYO3_CROSS_LIB_DIR
           export PYO3_CROSS_LIB_DIR=/opt/python/${{ matrix.platform.abi }}
-          cargo run --target x86_64-unknown-linux-gnu -- build -i python3.9 --release --out dist --no-sdist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
+          cargo run --target x86_64-unknown-linux-gnu -- build -i python3.9 --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
           ' > build-wheel.sh
           docker run --rm -v "$PWD":/io -w /io messense/manylinux2014-cross:${{ matrix.platform.arch }} bash build-wheel.sh

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* **Breaking Change**: Drop support for python 3.6, which is end of life
+* **Breaking Change**: Drop support for python 3.6, which is end of life in [#945](https://github.com/PyO3/maturin/pull/945)
+* **Breaking Change**: Don't build source distribution by default in `maturin build` command in [#955](https://github.com/PyO3/maturin/pull/955), `--no-sdist` option is replaced by `--sdist`
 * Add support for building with multiple binary targets in [#948](https://github.com/PyO3/maturin/pull/948)
 * Fix incompatibility with cibuildwheel for 32-bit Windows in [#951](https://github.com/PyO3/maturin/pull/951)
 * Don't require `pip` error messages to be utf-8 encoding in [#953](https://github.com/PyO3/maturin/pull/953)

--- a/Readme.md
+++ b/Readme.md
@@ -187,7 +187,7 @@ requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"
 ```
 
-If a `pyproject.toml` with a `[build-system]` entry is present, maturin will build a source distribution of your package, unless `--no-sdist` is specified.
+If a `pyproject.toml` with a `[build-system]` entry is present, maturin can build a source distribution of your package when `--sdist` is specified.
 The source distribution will contain the same files as `cargo package`. To only build a source distribution, pass `--interpreter` without any values.
 
 You can then e.g. install your package with `pip install .`. With `pip install . -v` you can see the output of cargo and maturin.

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -10,7 +10,7 @@ requires = ["maturin>=0.13,<0.14"]
 build-backend = "maturin"
 ```
 
-If a `pyproject.toml` with a `[build-system]` entry is present, maturin will build a source distribution of your package, unless `--no-sdist` is specified.
+If a `pyproject.toml` with a `[build-system]` entry is present, maturin can build a source distribution of your package when `--sdist` is specified.
 The source distribution will contain the same files as `cargo package`. To only build a source distribution, use the `maturin sdist` command.
 
 You can then e.g. install your package with `pip install .`. With `pip install . -v` you can see the output of cargo and maturin.
@@ -112,8 +112,8 @@ OPTIONS:
     -m, --manifest-path <PATH>
             The path to the Cargo.toml
 
-        --no-sdist
-            Don't build a source distribution
+        --sdist
+            Build a source distribution
 
     -o, --out <OUT>
             The directory to store the built wheels in. Defaults to a new "wheels" directory in the

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,9 @@ enum Opt {
         /// Strip the library for minimum file size
         #[clap(long)]
         strip: bool,
-        /// Don't build a source distribution
-        #[clap(long = "no-sdist")]
-        no_sdist: bool,
+        /// Build a source distribution
+        #[clap(long)]
+        sdist: bool,
     },
     #[cfg(feature = "upload")]
     #[clap(name = "publish")]
@@ -330,10 +330,10 @@ fn run() -> Result<()> {
             build,
             release,
             strip,
-            no_sdist,
+            sdist,
         } => {
             let build_context = build.into_build_context(release, strip, false)?;
-            if !no_sdist {
+            if sdist {
                 build_context.build_source_distribution()?;
             }
             let wheels = build_context.build_wheels()?;

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -179,7 +179,7 @@ fn add_crate_to_source_distribution(
     {
         bail!(
             "pyproject.toml was not included by `cargo package`. \
-                 Please make sure pyproject.toml is not excluded or build with `--no-sdist`"
+                 Please make sure pyproject.toml is not excluded or build without `--sdist`"
         )
     }
 

--- a/src/templates/CI.yml.j2
+++ b/src/templates/CI.yml.j2
@@ -13,7 +13,7 @@ jobs:
       with:
         manylinux: auto
         command: build
-        args: --release -o dist
+        args: --release --sdist -o dist
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -27,7 +27,7 @@ jobs:
     - uses: messense/maturin-action@v1
       with:
         command: build
-        args: --release --no-sdist -o dist
+        args: --release -o dist
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -41,7 +41,7 @@ jobs:
     - uses: messense/maturin-action@v1
       with:
         command: build
-        args: --release --no-sdist -o dist --universal2
+        args: --release -o dist --universal2
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/test-dockerfile.sh
+++ b/test-dockerfile.sh
@@ -14,7 +14,7 @@ source venv-docker/bin/activate
 for test_crate in hello-world cffi-pure cffi-mixed pyo3-pure pyo3-mixed pyo3-mixed-submodule
 do
   echo "Testing $test_crate"
-  docker run -e RUST_BACKTRACE=1 --rm -v "$(pwd):/io" -w /io/test-crates/$test_crate maturin build --no-sdist -i python3.8
+  docker run -e RUST_BACKTRACE=1 --rm -v "$(pwd):/io" -w /io/test-crates/$test_crate maturin build -i python3.8
   # --only-binary=:all: stops pip from picking a local already compiled sdist
   venv-docker/bin/pip install $test_crate --only-binary=:all: --find-links test-crates/$test_crate/target/wheels/
   if [[ $(venv-docker/bin/python test-crates/$test_crate/check_installed/check_installed.py) != 'SUCCESS' ]]; then

--- a/tests/manylinux_compliant.sh
+++ b/tests/manylinux_compliant.sh
@@ -4,5 +4,5 @@ set -e
 which cargo > /dev/null 2>&1 || curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
 for PYBIN in /opt/python/cp3[789]*/bin; do
-  cargo run -- build --no-sdist -m test-crates/pyo3-mixed/Cargo.toml -i "${PYBIN}/python" --manylinux $1 -o dist
+  cargo run -- build -m test-crates/pyo3-mixed/Cargo.toml -i "${PYBIN}/python" --manylinux $1 -o dist
 done

--- a/tests/manylinux_incompliant.sh
+++ b/tests/manylinux_incompliant.sh
@@ -5,7 +5,7 @@ which cargo > /dev/null || curl -sSf https://sh.rustup.rs | sh -s -- -y --profil
 
 # Fail because we're running in manylinux2014, which can't build for manylinux 2010
 for PYBIN in /opt/python/cp3[9]*/bin; do
-  if cargo run -- build --no-sdist -m test-crates/pyo3-mixed/Cargo.toml -i "${PYBIN}/python" --manylinux 2010 -o dist; then
+  if cargo run -- build -m test-crates/pyo3-mixed/Cargo.toml -i "${PYBIN}/python" --manylinux 2010 -o dist; then
     echo "maturin build unexpectedly succeeded"
     exit 1
   else
@@ -17,7 +17,7 @@ done
 apt-get -v &> /dev/null && apt-get install -y zlib1g-dev || yum install -y zlib-devel
 
 for PYBIN in /opt/python/cp3[9]*/bin; do
-  if cargo run -- build --no-sdist -m test-crates/lib_with_disallowed_lib/Cargo.toml -i "${PYBIN}/python" --manylinux 2014 -o dist; then
+  if cargo run -- build -m test-crates/lib_with_disallowed_lib/Cargo.toml -i "${PYBIN}/python" --manylinux 2014 -o dist; then
     echo "maturin build unexpectedly succeeded"
     exit 1
   else


### PR DESCRIPTION
This replaces `--no-sdist` with `--sdist` option to only build sdist
when `--sdist` is specified.

Part of #796 