### PR TITLE
Filter cargo targets by `kind` instead of `crate_types`

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -28,8 +28,8 @@ pub fn compile(
         .targets
         .iter()
         .filter(|target| match bindings_crate {
-            BridgeModel::Bin(_) => target.crate_types.contains(&"bin".to_string()),
-            _ => target.crate_types.contains(&"cdylib".to_string()),
+            BridgeModel::Bin(_) => target.kind.contains(&"bin".to_string()),
+            _ => target.kind.contains(&"cdylib".to_string()),
         })
         .collect();
     if context.target.is_macos() && context.universal2 {


### PR DESCRIPTION
```
[
    Target {
        name: "maturin",
        kind: [
            "bin",
        ],
        crate_types: [
            "bin",
        ],
        required_features: [],
        src_path: "/Users/messense/Projects/maturin/src/main.rs",
        edition: "2018",
        doctest: false,
        test: true,
        doc: true,
    },
    Target {
        name: "run",
        kind: [
            "test",
        ],
        crate_types: [
            "bin",
        ],
        required_features: [],
        src_path: "/Users/messense/Projects/maturin/tests/run.rs",
        edition: "2018",
        doctest: false,
        test: true,
        doc: false,
    },
]
```

Filter by `crate_types` may pull in `test` binaries.