### PR TITLE
Pass C/C++ build variables through to cargo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add a `--target` option to `maturin list-python` command in [#957](https://github.com/PyO3/maturin/pull/957)
 * Add support for using bundled python sysconfigs for PyPy when abi3 feature is enabled in [#958](https://github.com/PyO3/maturin/pull/958)
 * Set `PYO3_PYTHON` env var for PyPy when abi3 is enabled in [#960](https://github.com/PyO3/maturin/pull/960)
+* Pass C/C++ build-related environmental variables such as `CC` and `CFLAGS` through to `cargo`.
 
 ## [0.12.19] - 2022-06-05
 

--- a/Readme.md
+++ b/Readme.md
@@ -244,6 +244,42 @@ See [konstin/complex-manylinux-maturin-docker](https://github.com/konstin/comple
 
 maturin itself is manylinux compliant when compiled for the musl target.
 
+## Depending on C/C++ libraries
+
+maturin supports the compilation of C/C++ dependencies through Cargo. To build the library, use
+the `cc` crate. To configure its build, maturin passes common environmental variables
+such as `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`, `CARCH`, and `CHOST`.
+
+
+```rust
+// build.rs
+
+fn main() {
+    pyo3_build_config::use_pyo3_cfgs();
+
+    cc::Build::new()
+        .file("include/library.c")
+        .include("include")
+        .compile("library");
+}
+```
+
+For example, to build a C library with `clang` and include it into the pyo3 project's shared object:
+
+```bash
+% export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=lld"
+% export CC="clang" CFLAGS="-O2 -flto=thin" LDFLAGS="-O2 -flto=thin -fuse-ld=lld"
+% maturin build --release
+📦 Including license file "LICENSE-APACHE"
+🔗 Found pyo3 bindings
+🐍 Found CPython 3.10 at ...
+➕ Passing RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=lld
+➕ Passing CC=clang
+➕ Passing CFLAGS=-O2 -flto=thin
+➕ Passing LDFLAGS=-O2 -flto=thin -fuse-ld=lld
+   Compiling ...
+```
+
 ## Code
 
 The main part is the maturin library, which is completely documented and should be well integrable. The accompanying `main.rs` takes care username and password for the pypi upload and otherwise calls into the library.


### PR DESCRIPTION
This allows the configuration of cc::Build to compile a C/C++
dependency.