### PR TITLE
Add `--find-interpreter` option to `build` and `publish` commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **Breaking Change**: Drop support for python 3.6, which is end of life in [#945](https://github.com/PyO3/maturin/pull/945)
 * **Breaking Change**: Don't build source distribution by default in `maturin build` command in [#955](https://github.com/PyO3/maturin/pull/955), `--no-sdist` option is replaced by `--sdist`
+* **Breaking Change**: maturin no longer search for python interpreters by default and only build for current interpreter in `PATH` in [#964](https://github.com/PyO3/maturin/pull/964)
 * Add support for building with multiple binary targets in [#948](https://github.com/PyO3/maturin/pull/948)
 * Fix incompatibility with cibuildwheel for 32-bit Windows in [#951](https://github.com/PyO3/maturin/pull/951)
 * Don't require `pip` error messages to be utf-8 encoding in [#953](https://github.com/PyO3/maturin/pull/953)
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Set `PYO3_PYTHON` env var for PyPy when abi3 is enabled in [#960](https://github.com/PyO3/maturin/pull/960)
 * Add sysconfigs for x64 Windows PyPy in [#962](https://github.com/PyO3/maturin/pull/962)
 * Add support for cross compiling PyPy wheels when abi3 feature is enabled in [#963](https://github.com/PyO3/maturin/pull/963)
+* Add `--find-interpreter` option to `build` and `publish` commands to search for python interpreters in [#964](https://github.com/PyO3/maturin/pull/964)
 
 ## [0.12.19] - 2022-06-05
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -4,7 +4,6 @@ use crate::compile::warn_missing_py_init;
 use crate::module_writer::{
     add_data, write_bin, write_bindings_module, write_cffi_module, write_python_part, WheelWriter,
 };
-use crate::python_interpreter::InterpreterKind;
 use crate::source_distribution::source_distribution;
 use crate::{compile, Metadata21, ModuleWriter, PyProjectToml, PythonInterpreter, Target};
 use anyhow::{anyhow, bail, Context, Result};
@@ -229,13 +228,13 @@ impl BuildContext {
                 let cpythons: Vec<_> = self
                     .interpreter
                     .iter()
-                    .filter(|interp| interp.interpreter_kind == InterpreterKind::CPython)
+                    .filter(|interp| interp.interpreter_kind.is_cpython())
                     .cloned()
                     .collect();
                 let pypys: Vec<_> = self
                     .interpreter
                     .iter()
-                    .filter(|interp| interp.interpreter_kind == InterpreterKind::PyPy)
+                    .filter(|interp| interp.interpreter_kind.is_pypy())
                     .cloned()
                     .collect();
                 let mut built_wheels = Vec::new();

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,5 +1,4 @@
 use crate::build_context::BridgeModel;
-use crate::python_interpreter::InterpreterKind;
 use crate::{BuildContext, PlatformTag, PythonInterpreter};
 use anyhow::{anyhow, bail, Context, Result};
 use fat_macho::FatWriter;
@@ -285,7 +284,7 @@ fn compile_target(
 
     if let BridgeModel::BindingsAbi3(_, _) = bindings_crate {
         let is_pypy = python_interpreter
-            .map(|p| p.interpreter_kind == InterpreterKind::PyPy)
+            .map(|p| p.interpreter_kind.is_pypy())
             .unwrap_or(false);
         if !is_pypy && !target.is_windows() {
             let pyo3_ver = pyo3_version(&context.cargo_metadata)
@@ -305,7 +304,7 @@ fn compile_target(
             if bindings_crate.is_bindings("pyo3")
                 || bindings_crate.is_bindings("pyo3-ffi")
                 || (matches!(bindings_crate, BridgeModel::BindingsAbi3(_, _))
-                    && matches!(interpreter.interpreter_kind, InterpreterKind::PyPy))
+                    && interpreter.interpreter_kind.is_pypy())
             {
                 build_command.env("PYO3_PYTHON", &interpreter.executable);
             }
@@ -315,7 +314,7 @@ fn compile_target(
         } else if (bindings_crate.is_bindings("pyo3")
             || bindings_crate.is_bindings("pyo3-ffi")
             || (matches!(bindings_crate, BridgeModel::BindingsAbi3(_, _))
-                && matches!(interpreter.interpreter_kind, InterpreterKind::PyPy)))
+                && interpreter.interpreter_kind.is_pypy()))
             && env::var_os("PYO3_CONFIG_FILE").is_none()
         {
             let pyo3_config = interpreter.pyo3_config_file();

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -30,6 +30,7 @@ pub fn develop(
     let build_options = BuildOptions {
         platform_tag: vec![PlatformTag::Linux],
         interpreter: vec![python.clone()],
+        find_interpreter: false,
         bindings,
         manifest_path: Some(manifest_file.to_path_buf()),
         out: Some(wheel_dir.path().to_path_buf()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,7 @@ fn run() -> Result<()> {
         Opt::ListPython { target } => {
             let found = if target.is_some() {
                 let target = Target::from_target_triple(target)?;
-                PythonInterpreter::find_by_target(&target)
+                PythonInterpreter::find_by_target(&target, None)
             } else {
                 let target = Target::from_target_triple(None)?;
                 // We don't know the targeted bindings yet, so we use the most lenient


### PR DESCRIPTION
Some behaviors changed:

1. `maturin build` now implicitly translate to `maturin build -i python3`, meaning that we only build for the current python3 interpreter in `PATH`
2. `maturin build --find-interpreter` makes maturin search for interpreters on host, also search for bundled sysconfig when cross compiling
3. Mix `-i` and `--find-interpreter` is not allowed
4. `maturin publish` does the same as `maturin build`

Part of #796 