### PR TITLE
Add support for Linux armv6l

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add sysconfigs for x64 Windows PyPy in [#962](https://github.com/PyO3/maturin/pull/962)
 * Add support for cross compiling PyPy wheels when abi3 feature is enabled in [#963](https://github.com/PyO3/maturin/pull/963)
 * Add `--find-interpreter` option to `build` and `publish` commands to search for python interpreters in [#964](https://github.com/PyO3/maturin/pull/964)
+* Add support for Linux armv6l in [#966](https://github.com/PyO3/maturin/pull/966)
 
 ## [0.12.19] - 2022-06-05
 

--- a/src/auditwheel/policy.rs
+++ b/src/auditwheel/policy.rs
@@ -97,6 +97,7 @@ impl Policy {
         if self.name.starts_with("musllinux") && self.lib_whitelist.remove("libc.so") {
             let new_soname = match target_arch {
                 Arch::Aarch64 => "libc.musl-aarch64.so.1",
+                Arch::Armv6L => "libc.musl-armhf.so.1",
                 Arch::Armv7L => "libc.musl-armv7.so.1",
                 Arch::Powerpc64Le => "libc.musl-ppc64le.so.1",
                 Arch::Powerpc64 => "", // musllinux doesn't support ppc64


### PR DESCRIPTION
Old Raspberry Pi uses `linux_armv6l`, some projects want to support them, for example https://github.com/eclipse-zenoh/zenoh-python/issues/64.

armv6l doesn't not support manylinux/musllinux, so it will only produce `linux_armv6l` tag.