### PR TITLE
Fix auditwheel bundled shared libs directory name

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `--find-interpreter` option to `build` and `publish` commands to search for python interpreters in [#964](https://github.com/PyO3/maturin/pull/964)
 * Add support for Linux armv6l in [#966](https://github.com/PyO3/maturin/pull/966)
 * Infer target triple from `ARCHFLAGS` for macOS to be compatible with `cibuildwheel` in [#967](https://github.com/PyO3/maturin/pull/967)
+* Fix auditwheel bundled shared libs directory name in [#969](https://github.com/PyO3/maturin/pull/969)
 
 ## [0.12.19] - 2022-06-05
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -101,7 +101,7 @@ impl ProjectLayout {
             Cow::Owned(project_root.join(py_src))
         });
         let (python_module, rust_module, extension_name) = if parts.len() > 1 {
-            let mut rust_module = project_root.to_path_buf();
+            let mut rust_module = python_root.to_path_buf();
             rust_module.extend(&parts[0..parts.len() - 1]);
             (
                 python_root.join(parts[0]),
@@ -337,7 +337,14 @@ impl BuildContext {
         }
         // Put external libs to ${module_name}.libs directory
         // See https://github.com/pypa/auditwheel/issues/89
-        let libs_dir = PathBuf::from(format!("{}.libs", self.module_name));
+        let mut libs_dir = self
+            .project_layout
+            .python_module
+            .as_ref()
+            .and_then(|py| py.file_name().map(|s| s.to_os_string()))
+            .unwrap_or_else(|| self.module_name.clone().into());
+        libs_dir.push(".libs");
+        let libs_dir = PathBuf::from(libs_dir);
         writer.add_directory(&libs_dir)?;
 
         let temp_dir = tempfile::tempdir()?;

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -15,3 +15,4 @@ crate-type = ["cdylib"]
 
 [package.metadata.maturin]
 python-source = "python"
+name = "pyo3_mixed_py_subdir._pyo3_mixed"

--- a/test-crates/pyo3-mixed-py-subdir/python/pyo3_mixed_py_subdir/__init__.py
+++ b/test-crates/pyo3-mixed-py-subdir/python/pyo3_mixed_py_subdir/__init__.py
@@ -1,5 +1,5 @@
 from .python_module.double import double
-from .pyo3_mixed_py_subdir import get_21
+from ._pyo3_mixed import get_21
 
 
 def get_42() -> int:

--- a/test-crates/pyo3-mixed-py-subdir/src/lib.rs
+++ b/test-crates/pyo3-mixed-py-subdir/src/lib.rs
@@ -6,7 +6,7 @@ fn get_21() -> usize {
 }
 
 #[pymodule]
-fn pyo3_mixed_py_subdir(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _pyo3_mixed(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_21))?;
 
     Ok(())


### PR DESCRIPTION
Previous the `pyo3-mixed-py-subdir` crate would produce
`_pyo3_mixed.libs`, now it produces `pyo3_mixed_py_subdir.libs`.