### PR TITLE
Expose commonly used Cargo CLI options in `maturin build` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,16 @@ jobs:
       - name: Build wheel (with sdist)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
-          cargo run -- build --release -b bin --sdist -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage" --compatibility manylinux2010 musllinux_1_1
+          cargo run -- build --release -b bin --sdist -o dist --target ${{ matrix.target }} --features password-storage --compatibility manylinux2010 musllinux_1_1
 
       # ring doesn't support aarch64 windows yet
       - name: Build wheel (windows aarch64)
         if: matrix.target == 'aarch64-pc-windows-msvc'
-        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--no-default-features" --cargo-extra-args="--features log,upload,human-panic"
+        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --no-default-features --features log,upload,human-panic
 
       - name: Build wheel (without sdist)
         if: ${{ matrix.target != 'x86_64-unknown-linux-musl' && matrix.target != 'aarch64-pc-windows-msvc' }}
-        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --cargo-extra-args="--features password-storage"
+        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --features password-storage
 
       - name: Build wheel (macOS universal2)
         if: matrix.target == 'x86_64-apple-darwin'
@@ -106,7 +106,7 @@ jobs:
           # set SDKROOT for C dependencies like ring and bzip2
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           rustup target add aarch64-apple-darwin
-          cargo run -- build --release -b bin -o dist --universal2 --cargo-extra-args="--features password-storage"
+          cargo run -- build --release -b bin -o dist --universal2 --features password-storage
 
       - name: Archive binary (windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,12 +96,12 @@ jobs:
         shell: bash
         run: |
           set -ex
-          cargo run -- build -i pypy3 -m test-crates/pyo3-pure/Cargo.toml --cargo-extra-args="-vv"
+          cargo run -- build -i pypy3 -m test-crates/pyo3-pure/Cargo.toml -vv
           pypy3 -m pip install --force-reinstall --no-index --find-links test-crates/pyo3-pure/target/wheels pyo3-pure
           pypy3 -m pip install pytest
           pypy3 -m pytest test-crates/pyo3-pure/test_pyo3_pure.py
 
-          cargo run -- pep517 build-wheel -i pypy3 -m test-crates/pyo3-pure/Cargo.toml --cargo-extra-args="-vv"
+          cargo run -- pep517 build-wheel -i pypy3 -m test-crates/pyo3-pure/Cargo.toml -vv
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -547,26 +547,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytesize",
+ "cargo-options",
  "cargo-xwin",
  "cargo-zigbuild",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-options"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dacdf12b405b432ddcb94aa5edef0766daf8cb781f484e56b518305afd45ba"
+checksum = "23ce158e74c4b485a51101125ce308f69a62c13310f4c6e9a082acd862f38995"
 dependencies = [
  "clap",
 ]
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-xwin"
-version = "0.8.7"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb40f2f01bc8ff52fbb570b4b7f8ec823ba21ce1a64352492868eab29f39b9fc"
+checksum = "ef75f26606f9e2fa5e3ebf73e5a4518dfe97e9f034bae9d1147c04ccaba656b3"
 dependencies = [
  "anyhow",
  "cargo-options",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed951e06c76e4580db0fec84aad5a0266f876f82c3190e323b4c09875edf5750"
+checksum = "3f82d567aa085050598e94d2326132630715fc97506544eef56eea3c1ff7b28f"
 dependencies = [
  "anyhow",
  "cargo-options",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ base64 = "0.13.0"
 bytesize = "1.0.1"
 glob = "0.3.0"
 cargo_metadata = "0.14.0"
-cargo-zigbuild = "0.9.0"
-cargo-xwin = { version = "0.8.6", default-features = false }
+cargo-zigbuild = "0.10.1"
+cargo-xwin = { version = "0.9.1", default-features = false }
 cbindgen = { version = "0.24.2", default-features = false }
 flate2 = "1.0.18"
 goblin = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ base64 = "0.13.0"
 bytesize = "1.0.1"
 glob = "0.3.0"
 cargo_metadata = "0.14.0"
+cargo-options = "0.2.0"
 cargo-zigbuild = "0.10.1"
 cargo-xwin = { version = "0.9.1", default-features = false }
 cbindgen = { version = "0.24.2", default-features = false }

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Drop support for python 3.6, which is end of life in [#945](https://github.com/PyO3/maturin/pull/945)
 * **Breaking Change**: Don't build source distribution by default in `maturin build` command in [#955](https://github.com/PyO3/maturin/pull/955), `--no-sdist` option is replaced by `--sdist`
 * **Breaking Change**: maturin no longer search for python interpreters by default and only build for current interpreter in `PATH` in [#964](https://github.com/PyO3/maturin/pull/964)
+* **Breaking Change**: Removed `--cargo-extra-args` and `--rustc-extra-args` options in [#972](https://github.com/PyO3/maturin/pull/972)
 * Add support for building with multiple binary targets in [#948](https://github.com/PyO3/maturin/pull/948)
 * Add a `--target` option to `maturin list-python` command in [#957](https://github.com/PyO3/maturin/pull/957)
 * Add support for using bundled python sysconfigs for PyPy when abi3 feature is enabled in [#958](https://github.com/PyO3/maturin/pull/958)
 * Add support for cross compiling PyPy wheels when abi3 feature is enabled in [#963](https://github.com/PyO3/maturin/pull/963)
 * Add `--find-interpreter` option to `build` and `publish` commands to search for python interpreters in [#964](https://github.com/PyO3/maturin/pull/964)
 * Infer target triple from `ARCHFLAGS` for macOS to be compatible with `cibuildwheel` in [#967](https://github.com/PyO3/maturin/pull/967)
+* Expose commonly used Cargo CLI options in `maturin build` command in [#972](https://github.com/PyO3/maturin/pull/972)
 
 ## [0.12.20] - 2022-06-15
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Drop support for python 3.6, which is end of life in [#945](https://github.com/PyO3/maturin/pull/945)
 * **Breaking Change**: Don't build source distribution by default in `maturin build` command in [#955](https://github.com/PyO3/maturin/pull/955), `--no-sdist` option is replaced by `--sdist`
 * **Breaking Change**: maturin no longer search for python interpreters by default and only build for current interpreter in `PATH` in [#964](https://github.com/PyO3/maturin/pull/964)
-* **Breaking Change**: Removed `--cargo-extra-args` and `--rustc-extra-args` options in [#972](https://github.com/PyO3/maturin/pull/972)
+* **Breaking Change**: Removed `--cargo-extra-args` and `--rustc-extra-args` options in [#972](https://github.com/PyO3/maturin/pull/972). You can now pass all common `cargo build` arguments directly to `maturin build`
 * Add support for building with multiple binary targets in [#948](https://github.com/PyO3/maturin/pull/948)
 * Add a `--target` option to `maturin list-python` command in [#957](https://github.com/PyO3/maturin/pull/957)
 * Add support for using bundled python sysconfigs for PyPy when abi3 feature is enabled in [#958](https://github.com/PyO3/maturin/pull/958)

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1174,6 +1174,40 @@ fn extract_cargo_metadata_args(cargo_options: &CargoOptions) -> Result<Vec<Strin
     Ok(cargo_metadata_extra_args)
 }
 
+impl From<CargoOptions> for cargo_options::Rustc {
+    fn from(cargo: CargoOptions) -> Self {
+        cargo_options::Rustc {
+            common: cargo_options::CommonOptions {
+                quiet: cargo.quiet,
+                jobs: cargo.jobs,
+                profile: cargo.profile,
+                features: cargo.features,
+                all_features: cargo.all_features,
+                no_default_features: cargo.no_default_features,
+                target: match cargo.target {
+                    Some(target) => vec![target],
+                    None => Vec::new(),
+                },
+                target_dir: cargo.target_dir,
+                manifest_path: cargo.manifest_path,
+                ignore_rust_version: cargo.ignore_rust_version,
+                verbose: cargo.verbose,
+                color: cargo.color,
+                frozen: cargo.frozen,
+                locked: cargo.locked,
+                offline: cargo.offline,
+                config: cargo.config,
+                unstable_flags: cargo.unstable_flags,
+                timings: cargo.timings,
+                ..Default::default()
+            },
+            future_incompat_report: cargo.future_incompat_report,
+            args: cargo.args,
+            ..Default::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::path::Path;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -212,12 +212,12 @@ fn compile_target(
 
     let target_triple = target.target_triple();
     let mut build_command = if target.is_msvc() && target.cross_compiling() {
-        let mut build = cargo_xwin::Build::new(Some(context.manifest_path.clone()));
+        let mut build = cargo_xwin::Rustc::new(Some(context.manifest_path.clone()));
 
         build.target = vec![target_triple.to_string()];
-        build.build_command("rustc")?
+        build.build_command()?
     } else {
-        let mut build = cargo_zigbuild::Build::new(Some(context.manifest_path.clone()));
+        let mut build = cargo_zigbuild::Rustc::new(Some(context.manifest_path.clone()));
         if !context.zig {
             build.disable_zig_linker = true;
             if target.user_specified {
@@ -236,7 +236,7 @@ fn compile_target(
             };
             build.target = vec![zig_triple];
         }
-        build.build_command("rustc")?
+        build.build_command()?
     };
 
     if context.zig {

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -1,3 +1,4 @@
+use crate::build_options::CargoOptions;
 use crate::BuildOptions;
 use crate::PlatformTag;
 use crate::PythonInterpreter;
@@ -32,14 +33,15 @@ pub fn develop(
         interpreter: vec![python.clone()],
         find_interpreter: false,
         bindings,
-        manifest_path: Some(manifest_file.to_path_buf()),
         out: Some(wheel_dir.path().to_path_buf()),
         skip_auditwheel: false,
         zig: false,
-        target: None,
-        cargo_extra_args,
-        rustc_extra_args,
         universal2: false,
+        cargo: CargoOptions {
+            target: None,
+            manifest_path: Some(manifest_file.to_path_buf()),
+            ..Default::default()
+        },
     };
 
     let build_context = build_options.into_build_context(release, strip, true)?;

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -15,9 +15,7 @@ use tempfile::TempDir;
 #[allow(clippy::too_many_arguments)]
 pub fn develop(
     bindings: Option<String>,
-    manifest_file: &Path,
-    cargo_extra_args: Vec<String>,
-    rustc_extra_args: Vec<String>,
+    cargo_options: CargoOptions,
     venv_dir: &Path,
     release: bool,
     strip: bool,
@@ -37,11 +35,7 @@ pub fn develop(
         skip_auditwheel: false,
         zig: false,
         universal2: false,
-        cargo: CargoOptions {
-            target: None,
-            manifest_path: Some(manifest_file.to_path_buf()),
-            ..Default::default()
-        },
+        cargo: cargo_options,
     };
 
     let build_context = build_options.into_build_context(release, strip, true)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 #![deny(missing_docs)]
 
 pub use crate::build_context::{BridgeModel, BuildContext, BuiltWheelMetadata};
-pub use crate::build_options::BuildOptions;
+pub use crate::build_options::{BuildOptions, CargoOptions};
 pub use crate::cargo_toml::CargoToml;
 pub use crate::compile::compile;
 pub use crate::develop::develop;

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -1,7 +1,7 @@
 use crate::common::{check_installed, create_virtualenv, maybe_mock_cargo};
 use anyhow::Result;
-use maturin::develop;
-use std::path::Path;
+use maturin::{develop, CargoOptions};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
@@ -34,13 +34,15 @@ pub fn test_develop(
     let manifest_file = package.as_ref().join("Cargo.toml");
     develop(
         bindings,
-        &manifest_file,
-        vec![
-            "--quiet".to_string(),
-            "--target-dir".to_string(),
-            format!("test-crates/targets/{}", unique_name),
-        ],
-        vec![],
+        CargoOptions {
+            manifest_path: Some(manifest_file),
+            quiet: true,
+            target_dir: Some(PathBuf::from(format!(
+                "test-crates/targets/{}",
+                unique_name
+            ))),
+            ..Default::default()
+        },
         &venv_dir,
         false,
         cfg!(feature = "faster-tests"),

--- a/tests/common/editable.rs
+++ b/tests/common/editable.rs
@@ -18,22 +18,21 @@ pub fn test_editable(
 
     let (venv_dir, python) = create_virtualenv(&package, "editable", None)?;
     let interpreter = python.to_str().expect("invalid interpreter path");
-    let cargo_extra_args = format!(
-        "--cargo-extra-args=--quiet --target-dir test-crates/targets/{}",
-        unique_name
-    );
+    let target_dir = format!("test-crates/targets/{}", unique_name);
     let wheel_dir = format!("test-crates/wheels/{}", unique_name);
 
     // The first argument is ignored by clap
     let mut cli = vec![
         "build",
+        "--quiet",
         "--interpreter",
         interpreter,
         "--manifest-path",
         &package_string,
         "--compatibility",
         "linux",
-        &cargo_extra_args,
+        "--target-dir",
+        &target_dir,
         "--out",
         &wheel_dir,
     ];

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -9,7 +9,9 @@ pub fn abi3_without_version() -> Result<()> {
         "build",
         "--manifest-path",
         "test-crates/pyo3-abi3-without-version/Cargo.toml",
-        "--cargo-extra-args=--quiet --target-dir test-targets/wheels/abi3_without_version",
+        "--quiet",
+        "--target-dir",
+        "test-targets/wheels/abi3_without_version",
     ];
 
     let options = BuildOptions::try_parse_from(cli)?;
@@ -34,7 +36,9 @@ pub fn pyo3_no_extension_module() -> Result<()> {
         "build",
         "--manifest-path",
         "test-crates/pyo3-no-extension-module/Cargo.toml",
-        "--cargo-extra-args=--quiet --target-dir test-crates/targets/pyo3_no_extension_module",
+        "--quiet",
+        "--target-dir",
+        "test-crates/targets/pyo3_no_extension_module",
         "-i=python",
         "--out",
         "test-crates/targets/pyo3_no_extension_module",
@@ -69,9 +73,10 @@ pub fn locked_doesnt_build_without_cargo_lock() -> Result<()> {
         "build",
         "--manifest-path",
         "test-crates/lib_with_path_dep/Cargo.toml",
-        "--cargo-extra-args=--locked",
+        "--locked",
         "-itargetspython",
-        "--cargo-extra-args=--target-dir test-crates/targets/locked_doesnt_build_without_cargo_lock",
+        "--target-dir",
+        "test-crates/targets/locked_doesnt_build_without_cargo_lock",
     ];
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options.into_build_context(false, cfg!(feature = "faster-tests"), false);
@@ -107,7 +112,8 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
         "-i=python",
         "--compatibility",
         "manylinux_2_99",
-        "--cargo-extra-args=--target-dir test-crates/targets/invalid_manylinux_does_not_panic",
+        "--target-dir",
+        "test-crates/targets/invalid_manylinux_does_not_panic",
         "--out",
         "test-crates/targets/invalid_manylinux_does_not_panic",
     ];

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -28,15 +28,14 @@ pub fn test_integration(
 
     // The first argument is ignored by clap
     let shed = format!("test-crates/wheels/{}", unique_name);
-    let cargo_extra_args = format!(
-        "--cargo-extra-args=--quiet --target-dir test-crates/targets/{}",
-        unique_name
-    );
+    let target_dir = format!("test-crates/targets/{}", unique_name);
     let mut cli = vec![
         "build",
+        "--quiet",
         "--manifest-path",
         &package_string,
-        &cargo_extra_args,
+        "--target-dir",
+        &target_dir,
         "--out",
         &shed,
     ];
@@ -170,12 +169,7 @@ pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String
     create_conda_env("A-pyo3-build-env-310", 3, 10);
 
     // The first argument is ignored by clap
-    let mut cli = vec![
-        "build",
-        "--manifest-path",
-        &package_string,
-        "--cargo-extra-args=--quiet",
-    ];
+    let mut cli = vec!["build", "--manifest-path", &package_string, "--quiet"];
 
     if let Some(ref bindings) = bindings {
         cli.push("--bindings");

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -57,7 +57,9 @@ pub fn test_musl() -> Result<bool> {
         "x86_64-unknown-linux-musl",
         "--compatibility",
         "linux",
-        "--cargo-extra-args=--quiet --target-dir test-crates/targets/test_musl",
+        "--quiet",
+        "--target-dir",
+        "test-crates/targets/test_musl",
         "--out",
         "test-crates/wheels/test_musl",
     ])?;
@@ -94,7 +96,9 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
         "test-crates/workspace/py/Cargo.toml",
         "--compatibility",
         "linux",
-        "--cargo-extra-args=--quiet --target-dir test-crates/targets/test_workspace_cargo_lock",
+        "--quiet",
+        "--target-dir",
+        "test-crates/targets/test_workspace_cargo_lock",
         "--out",
         "test-crates/wheels/test_workspace_cargo_lock",
     ])?;

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use flate2::read::GzDecoder;
-use maturin::BuildOptions;
+use maturin::{BuildOptions, CargoOptions};
 use std::collections::HashSet;
 use std::iter::FromIterator;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tar::Archive;
 
 /// Tries to compile a sample crate (pyo3-pure) for musl,
@@ -116,13 +116,15 @@ pub fn test_source_distribution(
     let sdist_directory = Path::new("test-crates").join("wheels").join(unique_name);
 
     let build_options = BuildOptions {
-        manifest_path: Some(manifest_path),
         out: Some(sdist_directory),
-        cargo_extra_args: vec![
-            "--quiet".to_string(),
-            "--target-dir".to_string(),
-            "test-crates/targets/test_workspace_cargo_lock".to_string(),
-        ],
+        cargo: CargoOptions {
+            manifest_path: Some(manifest_path),
+            quiet: true,
+            target_dir: Some(PathBuf::from(
+                "test-crates/targets/test_workspace_cargo_lock",
+            )),
+            ..Default::default()
+        },
         ..Default::default()
     };
 

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -19,7 +19,6 @@ pub fn test_musl() -> Result<bool> {
     use std::fs;
     use std::io::ErrorKind;
     use std::io::Read;
-    use std::path::PathBuf;
     use std::process::Command;
 
     let get_target_list = Command::new("rustup")


### PR DESCRIPTION
New `maturin build` cli example:

```bash
$ maturin build --help
maturin-build 
Build the crate into python packages

USAGE:
    maturin build [OPTIONS] [--] [ARGS]...

ARGS:
    <ARGS>...
            Rustc flags

OPTIONS:
    -r, --release
            Build artifacts in release mode, with optimizations

        --strip
            Strip the library for minimum file size

        --sdist
            Build a source distribution

        --compatibility <compatibility>...
            Control the platform tag on linux.
            
            Options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or
            `musllinux` tags (for example `musllinux_1_2`) and `linux` for the native linux tag.
            
            Note that `manylinux1` is unsupported by the rust compiler. Wheels with the native
            `linux` tag will be rejected by pypi, unless they are separately validated by
            `auditwheel`.
            
            The default is the lowest compatible `manylinux` tag, or plain `linux` if nothing
            matched
            
            This option is ignored on all non-linux platforms

    -i, --interpreter <INTERPRETER>...
            The python versions to build wheels for, given as the names of the interpreters. Uses
            autodiscovery if not explicitly set

    -f, --find-interpreter
            Find interpreters from the host machine

    -b, --bindings <BINDINGS>
            Which kind of bindings to use. Possible values are pyo3, rust-cpython, cffi and bin

    -o, --out <OUT>
            The directory to store the built wheels in. Defaults to a new "wheels" directory in the
            project's target directory

        --skip-auditwheel
            Don't check for manylinux compliance

        --zig
            For manylinux targets, use zig to ensure compliance for the chosen manylinux version
            
            Default to manylinux2010/manylinux_2_12 if you do not specify an `--compatibility`
            
            Make sure you installed zig with `pip install maturin[zig]`

        --universal2
            Control whether to build universal2 wheel for macOS or not. Only applies to macOS
            targets, do nothing otherwise

    -q, --quiet
            Do not print cargo log messages

    -j, --jobs <N>
            Number of parallel jobs, defaults to # of CPUs

        --profile <PROFILE-NAME>
            Build artifacts with the specified Cargo profile

        --features <FEATURES>...
            Space or comma separated list of features to activate

        --all-features
            Activate all available features

        --no-default-features
            Do not activate the `default` feature

        --target <TRIPLE>
            Build for the target triple
            
            [env: CARGO_BUILD_TARGET=]

        --target-dir <DIRECTORY>
            Directory for all generated artifacts

    -m, --manifest-path <PATH>
            Path to Cargo.toml

        --ignore-rust-version
            Ignore `rust-version` specification in packages

    -v, --verbose
            Use verbose output (-vv very verbose/build.rs output)

        --color <WHEN>
            Coloring: auto, always, never

        --frozen
            Require Cargo.lock and cache are up to date

        --locked
            Require Cargo.lock is up to date

        --offline
            Run without accessing the network

        --config <KEY=VALUE>...
            Override a configuration value (unstable)

    -Z <FLAG>...
            Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

        --timings[=<FMTS>...]
            Timing output formats (unstable) (comma separated): html, json

        --future-incompat-report
            Outputs a future incompatibility report at the end of the build (unstable)

    -h, --help
            Print help information

```

TODO:
- [x] Apply cargo options in `cargo metadata` and `cargo rustc` command
- [x] Read cargo options from `pyproject.toml`
- [x] Change `maturin develop`

Part of #796 