### PR TITLE
Only lookup bundled Python sysconfig when interpreters aren't specified as file path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow overriding platform release version using env var in [#975](https://github.com/PyO3/maturin/pull/975)
 * Fix `maturin develop` for arm64 Python on M1 Mac when default toolchain is x86_64 in [#980](https://github.com/PyO3/maturin/pull/980)
 * Add `--repository` option to `maturin upload` command in [#987](https://github.com/PyO3/maturin/pull/987)
+* Only lookup bundled Python sysconfig when interpreters aren't specified as file path in [#988](https://github.com/PyO3/maturin/pull/988)
 
 ## [0.12.20] - 2022-06-15
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1083,10 +1083,7 @@ fn find_interpreter_in_sysconfig(
     }
     let mut interpreters = Vec::new();
     for interp in interpreter {
-        let python = interp
-            .file_name()
-            .context("Invalid python interpreter")?
-            .to_string_lossy();
+        let python = interp.display().to_string();
         let (python_impl, python_ver) = if let Some(ver) = python.strip_prefix("pypy") {
             (InterpreterKind::PyPy, ver.strip_prefix('-').unwrap_or(ver))
         } else if let Some(ver) = python.strip_prefix("python") {


### PR DESCRIPTION
Rejects `-i /some/path/to/python3.x` when looking up sysconfig since the user intention is to find python in exact location.