### PR TITLE
Add aliases for maturin `build` and `develop` subcommands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `--repository` option to `maturin upload` command in [#987](https://github.com/PyO3/maturin/pull/987)
 * Only lookup bundled Python sysconfig when interpreters aren't specified as file path in [#988](https://github.com/PyO3/maturin/pull/988)
 * Find CPython upper to 3.12 and PyPy upper to 3.10 in [#993](https://github.com/PyO3/maturin/pull/993)
+* Add short alias `maturin b` for `maturin build` and `maturin dev` for `maturin develop` subcommands in [#994](https://github.com/PyO3/maturin/pull/994)
 
 ## [0.12.20] - 2022-06-15
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ enum Opt {
         #[clap(long)]
         target: Option<String>,
     },
-    #[clap(name = "develop")]
+    #[clap(name = "develop", alias = "dev")]
     /// Installs the crate as module in the current virtualenv
     ///
     /// Note that this command doesn't create entrypoints

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use std::str::FromStr;
 /// Build and publish crates with pyo3, rust-cpython and cffi bindings as well
 /// as rust binaries as python packages
 enum Opt {
-    #[clap(name = "build")]
+    #[clap(name = "build", alias = "b")]
     /// Build the crate into python packages
     Build {
         /// Build artifacts in release mode, with optimizations


### PR DESCRIPTION
Cargo use `cargo d` for `cargo doc`, to avoid possible confusion we use `dev`
instead