### PR TITLE
Consider pyproject.toml features when detecting pyo3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add 64-bit RISC-V support by felixonmars in [#1001](https://github.com/PyO3/maturin/pull/1001)
 * Add support for invoking with `python3 -m maturin` in [#1008](https://github.com/PyO3/maturin/pull/1008)
+* Fix detection of optional dependencies when declaring `features` in `pyproject.toml` in [#1014](https://github.com/PyO3/maturin/pull/1014)
 
 ## [0.13.0] - 2022-07-09
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -580,7 +580,7 @@ impl BuildOptions {
             Vec::new()
         };
 
-        let cargo_metadata_extra_args = extract_cargo_metadata_args(&self.cargo)?;
+        let cargo_metadata_extra_args = extract_cargo_metadata_args(&cargo_options)?;
 
         let result = MetadataCommand::new()
             .manifest_path(&manifest_file)


### PR DESCRIPTION
We have a mixed python/Rust project which uses PyO3. PyO3 is declared as an optional dependency of our crate, which gets enabled with a feature  `python`. This allows us to build the crate as a Rust-only library as well.

Starting with maturin 0.13.0 (and also in the master branch), we have noticed that maturin does no longer detect pyo3, so it tries to use CFFI bindings rather than pyo3 bindings. With maturin <0.13 we were using `cargo-extra-args` in `pyproject.toml`, and with maturin >=0.13 we have switched this to `features` (also in `pyproject.toml`).

[This repository](https://github.com/diddlum/maturin_build) demonstrates this.

Looking at the code, we think that the problem is that the features enabled in `pyproject.toml` are not merged when obtaining the cargo metadata to produce the dependency graph.