### PR TITLE
Fix path search upon `python3 -m  maturin`

### DIFF
--- a/maturin/__main__.py
+++ b/maturin/__main__.py
@@ -2,8 +2,37 @@ import os
 import sys
 from pathlib import Path
 import sysconfig
+from typing import Optional
+
+def get_maturin_path() -> Optional[Path]:
+    SCRIPT_NAME = "maturin"
+
+    def script_dir(scheme: str) -> Path:
+        return sysconfig.get_path("scripts", scheme)
+    
+    def script_exists(dir: Path) -> bool:
+        for _, _, files in os.walk(dir):
+            for f in files:
+                name, *_ = os.path.splitext(f)
+                if name == SCRIPT_NAME:
+                    return True
+        
+        return False
+                
+    
+    paths = list(filter(script_exists,
+                        filter(os.path.exists,
+                               map(script_dir, sysconfig.get_scheme_names()))))
+
+    if paths:
+        return Path(paths[0]) / SCRIPT_NAME
+    
+    return None
 
 if __name__ == "__main__":
-    scripts_dir = sysconfig.get_path("scripts")
-    maturin = Path(scripts_dir) / "maturin"
+    maturin = get_maturin_path()
+    if maturin is None:
+        print('Unable to find `maturin` script')
+        exit(1)
+
     os.execv(maturin, [str(maturin)] + sys.argv[1:])

--- a/maturin/__main__.py
+++ b/maturin/__main__.py
@@ -4,35 +4,39 @@ from pathlib import Path
 import sysconfig
 from typing import Optional
 
+
 def get_maturin_path() -> Optional[Path]:
     SCRIPT_NAME = "maturin"
 
     def script_dir(scheme: str) -> Path:
         return sysconfig.get_path("scripts", scheme)
-    
+
     def script_exists(dir: Path) -> bool:
         for _, _, files in os.walk(dir):
             for f in files:
                 name, *_ = os.path.splitext(f)
                 if name == SCRIPT_NAME:
                     return True
-        
+
         return False
-                
-    
-    paths = list(filter(script_exists,
-                        filter(os.path.exists,
-                               map(script_dir, sysconfig.get_scheme_names()))))
+
+    paths = list(
+        filter(
+            script_exists,
+            filter(os.path.exists, map(script_dir, sysconfig.get_scheme_names())),
+        )
+    )
 
     if paths:
         return Path(paths[0]) / SCRIPT_NAME
-    
+
     return None
+
 
 if __name__ == "__main__":
     maturin = get_maturin_path()
     if maturin is None:
-        print('Unable to find `maturin` script')
+        print("Unable to find `maturin` script")
         exit(1)
 
     os.execv(maturin, [str(maturin)] + sys.argv[1:])


### PR DESCRIPTION
`sysconfig.get_path` was insufficient on my machine as it was unable to resolve my `scripts` directory without an explicit `scheme="nt_user"` invocation (Windows 11 running Python 3.10.6). Intention here was to implement a more generic method of resolving `scripts` directories. There may be more idiomatic ways to achieve this behavior, as well as more useful error messages than what are provided in this solution.