### PR TITLE
Run default CI workflow on main/master push only

### DIFF
--- a/src/templates/CI.yml.j2
+++ b/src/templates/CI.yml.j2
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
As suggested by @messense in https://github.com/PyO3/maturin/issues/1040#issuecomment-1207180707.

Fixes #1040.