### PR TITLE
Find python module next to `pyproject.toml` if `pyproject.toml` exists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Linux sparc64 architecture support in [#1027](https://github.com/PyO3/maturin/pull/1027)
 * Add PEP 440 local version identifier support in [#1037](https://github.com/PyO3/maturin/pull/1037)
 * Fix inconsistent `Cargo.toml` and `pyproject.toml` path handling in [#1043](https://github.com/PyO3/maturin/pull/1043)
+* Find python module next to `pyproject.toml` if `pyproject.toml` exists in [#1044](https://github.com/PyO3/maturin/pull/1044).
+  It's technically a **breaking change**, but previously it doesn't work properly
+  if the directory containing `pyproject.toml` isn't recognized as project root.
 
 ## [0.13.1] - 2022-07-26
 

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -52,7 +52,7 @@ impl ProjectResolver {
         let manifest_dir = manifest_file.parent().unwrap();
         let pyproject_toml: Option<PyProjectToml> = if pyproject_file.is_file() {
             let pyproject =
-                PyProjectToml::new(pyproject_file).context("pyproject.toml is invalid")?;
+                PyProjectToml::new(&pyproject_file).context("pyproject.toml is invalid")?;
             pyproject.warn_missing_maturin_version();
             pyproject.warn_missing_build_backend();
             Some(pyproject)
@@ -89,8 +89,13 @@ impl ProjectResolver {
         let data = pyproject
             .and_then(|x| x.data())
             .or_else(|| extra_metadata.data.as_ref().map(Path::new));
+        let project_root = if pyproject_file.is_file() {
+            pyproject_file.parent().unwrap_or(manifest_dir)
+        } else {
+            manifest_dir
+        };
         let project_layout = ProjectLayout::determine(
-            manifest_dir,
+            project_root,
             extension_name,
             extra_metadata.python_source.as_deref(),
             data,


### PR DESCRIPTION
Based on #1043.

The primary motivation for this is to make [pyxel](https://github.com/kitao/pyxel) buildable with maturin.

```bash
$ tree -L 2
.
├── CHANGELOG.md
├── LICENSE
├── Makefile
├── README.md
├── lib
│   ├── Cargo.lock
│   ├── Cargo.toml
│   ├── Makefile
│   ├── engine
│   ├── pyoxidizer.bzl
│   ├── pyxel.vbs
│   ├── rustfmt.toml
│   ├── setup.iss
│   ├── target
│   ├── update_version
│   └── wrapper
├── pyproject.toml
├── pyxel
│   ├── __init__.py
│   ├── __init__.pyi
│   ├── __main__.py
│   ├── cli.py
│   ├── editor
│   ├── examples
│   ├── lib
│   └── py.typed
├── setup.cfg
└── setup.py
```