### PR TITLE
Find `pyproject.toml` in parent directories of `Cargo.toml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      RUST_BACKTRACE: '1'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -187,6 +189,8 @@ jobs:
   test-alpine:
     name: Test Alpine Linux
     runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: '1'
     container: alpine:edge
     steps:
       - uses: actions/checkout@v3

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Change `python-source` to be relative to the file specifies it in [#1049](https://github.com/PyO3/maturin/pull/1049)
 * Change `data` to be relative to the file specifies it in [#1051](https://github.com/PyO3/maturin/pull/1051)
 * Don't reinstall dependencies in `maturin develop` in [#1052](https://github.com/PyO3/maturin/pull/1052)
+* Find `pyproject.toml` in parent directories of `Cargo.toml` in [#1054](https://github.com/PyO3/maturin/pull/1054)
 
 ## [0.13.1] - 2022-07-26
 


### PR DESCRIPTION
When `--manifest-path` is supplied via cli, lookup `pyproject.toml`
in its parent directories until workspace root.

Fixes #1053