### PR TITLE
Enable `--crate-type cdylib` on Rust 1.64.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Allow user to override default Emscripten settings in [#1059](https://github.com/PyO3/maturin/pull/1059)
+* Enable `--crate-type cdylib` on Rust 1.64.0 in [#1060](https://github.com/PyO3/maturin/pull/1060)
 
 ## [0.13.2] - 2022-08-14
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,5 @@
 use crate::build_context::BridgeModel;
+use crate::target::RUST_1_64_0;
 use crate::{BuildContext, PlatformTag, PythonInterpreter, Target};
 use anyhow::{anyhow, bail, Context, Result};
 use fat_macho::FatWriter;
@@ -170,16 +171,10 @@ fn compile_target(
         .iter()
         .any(|k| LIB_CRATE_TYPES.contains(&k.as_str()))
     {
-        if let Ok(channel) = rustc_version::version_meta().map(|x| x.channel) {
-            if matches!(
-                channel,
-                rustc_version::Channel::Nightly | rustc_version::Channel::Dev
-            ) {
-                cargo_rustc
-                    .unstable_flags
-                    .push("unstable-options".to_string());
-                cargo_rustc.crate_type = vec!["cdylib".to_string()];
-            }
+        // `--crate-type` is stable since Rust 1.64.0
+        // See https://github.com/rust-lang/cargo/pull/10838
+        if target.rustc_version.semver >= RUST_1_64_0 {
+            cargo_rustc.crate_type = vec!["cdylib".to_string()];
         }
     }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 use std::str;
 use target_lexicon::{Environment, Triple};
 
+pub(crate) const RUST_1_64_0: semver::Version = semver::Version::new(1, 64, 0);
+
 /// All supported operating system
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -414,10 +416,9 @@ impl Target {
                 PlatformTag::manylinux2014()
             }
             Arch::X86 | Arch::X86_64 => {
-                let rust_1_64 = semver::Version::new(1, 64, 0);
                 // rustc 1.64.0 bumps glibc requirement to 2.17
                 // see https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
-                if self.rustc_version.semver >= rust_1_64 {
+                if self.rustc_version.semver >= RUST_1_64_0 {
                     PlatformTag::manylinux2014()
                 } else {
                     PlatformTag::manylinux2010()


### PR DESCRIPTION
Closes #881 