### PR TITLE
Fix abi3 wheel build when no Python interpreters found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow user to override default Emscripten settings in [#1059](https://github.com/PyO3/maturin/pull/1059)
 * Enable `--crate-type cdylib` on Rust 1.64.0 in [#1060](https://github.com/PyO3/maturin/pull/1060)
 * Update MSRV to 1.59.0 in [#1071](https://github.com/PyO3/maturin/pull/1071)
+* Fix abi3 wheel build when no Python interpreters found in [#1072](https://github.com/PyO3/maturin/pull/1072)
 
 ## [0.13.2] - 2022-08-14
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -292,3 +292,8 @@ fn workspace_with_path_dep_sdist() {
         "workspace_with_path_dep_sdist",
     ))
 }
+
+#[test]
+fn abi3_python_interpreter_args() {
+    handle_result(other::abi3_python_interpreter_args());
+}


### PR DESCRIPTION
Now for abi3 wheels,

* `maturin build` without `-i` should work
* `maturin build -i python` when python is 2.7 or not found will print an error
* `maturin build -i python3` when python3 is not found will print an error
* `maturin build -i python3.10` python3.10 is in our bundled sysconfig, it should work regardless of whether python3.10 exists on host or not

Fixes https://github.com/messense/maturin-action/issues/71