### PR TITLE
Remove default manifest path for `maturin sdist` command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix sdist build for optional path dependencies in [#1084](https://github.com/PyO3/maturin/pull/1084)
 * auditwheel: find dylibs in Cargo target directory in [#1092](https://github.com/PyO3/maturin/pull/1092)
 * Add library search paths in Cargo target directory to rpath in editable mode on Linux in [#1094](https://github.com/PyO3/maturin/pull/1094)
+* Remove default manifest path for `maturin sdist` command in [#1097](https://github.com/PyO3/maturin/pull/1097)
 
 ## [0.13.2] - 2022-08-14
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,14 +102,9 @@ enum Opt {
     /// This command is a workaround for [pypa/pip#6041](https://github.com/pypa/pip/issues/6041)
     #[clap(name = "sdist")]
     SDist {
-        #[clap(
-            short = 'm',
-            long = "manifest-path",
-            parse(from_os_str),
-            default_value = "Cargo.toml"
-        )]
+        #[clap(short = 'm', long = "manifest-path", parse(from_os_str))]
         /// The path to the Cargo.toml
-        manifest_path: PathBuf,
+        manifest_path: Option<PathBuf>,
         /// The directory to store the built wheels in. Defaults to a new "wheels"
         /// directory in the project's target directory
         #[clap(short, long, parse(from_os_str))]
@@ -413,7 +408,7 @@ fn run() -> Result<()> {
             let build_options = BuildOptions {
                 out,
                 cargo: CargoOptions {
-                    manifest_path: Some(manifest_path),
+                    manifest_path,
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
It's inferred from project layout after #1043 