### PR TITLE
Change readme and license paths in `pyproject.toml` to be relative to `pyproject.toml`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add library search paths in Cargo target directory to rpath in editable mode on Linux in [#1094](https://github.com/PyO3/maturin/pull/1094)
 * Remove default manifest path for `maturin sdist` command in [#1097](https://github.com/PyO3/maturin/pull/1097)
 * Fix sdist when `pyproject.toml` isn't in the same dir of `Cargo.toml` in [#1099](https://github.com/PyO3/maturin/pull/1099)
+* Change readme and license paths in `pyproject.toml` to be relative to `pyproject.toml` in [#1100](https://github.com/PyO3/maturin/pull/1100)
+  It's technically a **breaking change**, but previously it doesn't work properly.
 
 ## [0.13.2] - 2022-08-14
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -146,7 +146,6 @@ impl Metadata21 {
                 }
                 if let Some(license_path) = file {
                     let license_path = pyproject_dir.join(license_path);
-                    println!("license: {:?}", license_path);
                     self.license_files.push(license_path);
                 }
                 if let Some(license_text) = text {

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -89,7 +89,8 @@ impl ProjectResolver {
         let mut metadata21 = Metadata21::from_cargo_toml(&cargo_toml, &manifest_dir)
             .context("Failed to parse Cargo.toml into python metadata")?;
         if let Some(pyproject) = pyproject {
-            metadata21.merge_pyproject_toml(&manifest_dir, pyproject)?;
+            let pyproject_dir = pyproject_file.parent().unwrap();
+            metadata21.merge_pyproject_toml(&pyproject_dir, pyproject)?;
         }
         let extra_metadata = cargo_toml.remaining_core_metadata();
 


### PR DESCRIPTION
Same as #1049, see https://github.com/kitao/pyxel/issues/404#issuecomment-1242836175