### PR TITLE
CI: use GitHub Actions cache for docker test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,28 +261,14 @@ jobs:
         with:
           python-version: "3.8"
       - uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: maturin-test-docker-${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            maturin-test-docker-${{ runner.os }}-buildx-
       - name: Build
         uses: docker/build-push-action@v2
         with:
           push: false
           tags: maturin
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - name: Move cache
-        run: |
-          # Temp fix
-          # https://github.com/docker/build-push-action/issues/252
-          # https://github.com/moby/buildkit/issues/1896
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Cache test crates cargo build
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api