### PR TITLE
Use `fs_err::canonicalize` instead of std `Path::canonicalize`

### DIFF
--- a/src/auditwheel/musllinux.rs
+++ b/src/auditwheel/musllinux.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
+use fs_err as fs;
 use goblin::elf::Elf;
 use regex::Regex;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -274,7 +274,7 @@ impl WheelWriter {
         metadata21: &Metadata21,
     ) -> Result<()> {
         if let Some(python_module) = &project_layout.python_module {
-            let absolute_path = python_module.canonicalize()?;
+            let absolute_path = fs::canonicalize(python_module)?;
             if let Some(python_path) = absolute_path.parent().and_then(|p| p.to_str()) {
                 let name = metadata21.get_distribution_escaped();
                 self.add_bytes(format!("{}.pth", name), python_path.as_bytes())?;

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -1,8 +1,8 @@
 use crate::PlatformTag;
-use anyhow::{format_err, Context, Result};
+use anyhow::{format_err, Result};
+use fs_err as fs;
 use pyproject_toml::PyProjectToml as ProjectToml;
 use serde::{Deserialize, Serialize};
-use std::fs;
 use std::path::{Path, PathBuf};
 
 /// The `[tool]` section of a pyproject.toml
@@ -80,10 +80,7 @@ impl PyProjectToml {
     /// source distributions
     pub fn new(pyproject_file: impl AsRef<Path>) -> Result<PyProjectToml> {
         let path = pyproject_file.as_ref();
-        let contents = fs::read_to_string(&path).context(format!(
-            "Couldn't find pyproject.toml at {}",
-            path.display()
-        ))?;
+        let contents = fs::read_to_string(&path)?;
         let pyproject: PyProjectToml = toml_edit::easy::from_str(&contents)
             .map_err(|err| format_err!("pyproject.toml is not PEP 517 compliant: {}", err))?;
         Ok(pyproject)

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -156,7 +156,7 @@ fn add_crate_to_source_distribution(
         .map(Path::new)
         .collect();
 
-    let abs_manifest_path = manifest_path.canonicalize()?;
+    let abs_manifest_path = fs::canonicalize(manifest_path)?;
     let abs_manifest_dir = abs_manifest_path.parent().unwrap();
     let pyproject_dir = pyproject_toml_path.parent().unwrap();
     let cargo_toml_in_subdir = root_crate
@@ -285,7 +285,7 @@ pub fn source_distribution(
 ) -> Result<PathBuf> {
     let metadata21 = &build_context.metadata21;
     let manifest_path = &build_context.manifest_path;
-    let pyproject_toml_path = build_context.pyproject_toml_path.canonicalize()?;
+    let pyproject_toml_path = fs::canonicalize(&build_context.pyproject_toml_path)?;
 
     let known_path_deps = find_path_deps(&build_context.cargo_metadata)?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -91,8 +91,7 @@ pub fn create_virtualenv(
         .unwrap()
         .to_string();
 
-    let venv_dir = PathBuf::from("test-crates")
-        .canonicalize()?
+    let venv_dir = fs::canonicalize(PathBuf::from("test-crates"))?
         .join("venvs")
         .join(format!("{}-{}", test_name, venv_suffix));
     let target = Target::from_target_triple(None)?;

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -15,9 +15,9 @@ use tar::Archive;
 #[cfg(target_os = "linux")]
 pub fn test_musl() -> Result<bool> {
     use anyhow::bail;
+    use fs_err as fs;
     use fs_err::File;
     use goblin::elf::Elf;
-    use std::fs;
     use std::io::ErrorKind;
     use std::io::Read;
     use std::process::Command;


### PR DESCRIPTION
`fs-err` produces better error messages.