### PR TITLE
Build platform independent rust binary wheel through wasi

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,7 @@ build_and_test: &BUILD_AND_TEST
   setup_script:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --default-toolchain stable
+    - rustup target add wasm32-wasi
     - python3 -m pip install --upgrade cffi virtualenv
   build_script:
     - cargo build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          target: wasm32-wasi # Additional target
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Install aarch64-apple-darwin Rust target
@@ -351,7 +352,7 @@ jobs:
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * Initial support for shipping bin targets as wasm32-wasi binaries that are run through wasmtime in [#1107](https://github.com/PyO3/maturin/pull/1107). Note that wasmtime currently only support the five most popular platforms and that wasi binaries have restrictions when interacting with the host. Usage is by setting `--target wasm32-wasi`.
+
 ## [0.13.6] - 2022-10-08
 
 * Fix `maturin develop` in Windows conda virtual environment in [#1146](https://github.com/PyO3/maturin/pull/1146)

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -102,7 +102,7 @@ fn bin_wasi_helper(
             format!(
                 "{}.{}:main",
                 metadata21.get_distribution_escaped(),
-                base_name.replace("-", "_")
+                base_name.replace('-', "_")
             ),
         );
     }

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -81,6 +81,7 @@ fn bin_wasi_helper(
     artifacts_and_files: &[(&BuildArtifact, String)],
     mut metadata21: Metadata21,
 ) -> Result<Metadata21> {
+    eprintln!("⚠️  Warning: wasi support is experimental");
     // escaped can contain [\w\d.], but i don't know how we'd handle dots correctly here
     if metadata21.get_distribution_escaped().contains('.') {
         bail!(
@@ -122,7 +123,7 @@ fn bin_wasi_helper(
         // Having the wasmtime version hardcoded is not ideal, it's easy enough to overwrite
         metadata21
             .requires_dist
-            .push("wasmtime>=0.40,<0.41".to_string());
+            .push("wasmtime>=1.0.1,<2.0.0".to_string());
     }
 
     Ok(metadata21)
@@ -721,6 +722,15 @@ impl BuildContext {
                 .to_str()
                 .context("binary produced by cargo has non-utf8 filename")?
                 .to_string();
+
+            // From https://packaging.python.org/en/latest/specifications/entry-points/
+            // > The name may contain any characters except =, but it cannot start or end with any
+            // > whitespace character, or start with [. For new entry points, it is recommended to
+            // > use only letters, numbers, underscores, dots and dashes (regex [\w.-]+).
+            // All of these rules are already enforced by cargo:
+            // https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/src/cargo/util/restricted_names.rs#L39-L84
+            // i.e. we don't need to do any bin name validation here anymore
+
             artifacts_and_files.push((artifact, bin_name))
         }
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -761,7 +761,7 @@ pub fn write_bin(
     writer: &mut impl ModuleWriter,
     artifact: &Path,
     metadata: &Metadata21,
-    bin_name: &OsStr,
+    bin_name: &str,
 ) -> Result<()> {
     let data_dir = PathBuf::from(format!(
         "{}-{}.data",
@@ -774,6 +774,58 @@ pub fn write_bin(
 
     // We can't use add_file since we need to mark the file as executable
     writer.add_file_with_permissions(&data_dir.join(bin_name), artifact, 0o755)?;
+    Ok(())
+}
+
+/// Adds a wrapper script that start the wasm binary through wasmtime.
+///
+/// Note that the wasm binary needs to be written separately by [write_bin]
+pub fn write_wasm_launcher(
+    writer: &mut impl ModuleWriter,
+    metadata: &Metadata21,
+    bin_name: &str,
+) -> Result<()> {
+    let entrypoint_script = format!(
+        r#"from pathlib import Path
+
+from wasmtime import Store, Module, Engine, WasiConfig, Linker
+
+import sysconfig
+
+def main():
+    # The actual executable
+    program_location = Path(sysconfig.get_path("scripts")).joinpath("{}")
+    # wasmtime-py boilerplate
+    engine = Engine()
+    store = Store(engine)
+    # TODO: is there an option to just get the default of the wasmtime cli here?
+    wasi = WasiConfig()
+    wasi.inherit_argv()
+    wasi.inherit_env()
+    wasi.inherit_stdout()
+    wasi.inherit_stderr()
+    wasi.inherit_stdin()
+    store.set_wasi(wasi)
+    linker = Linker(engine)
+    linker.define_wasi()
+    module = Module.from_file(store.engine, str(program_location))
+    linking1 = linker.instantiate(store, module)
+    # TODO: this is taken from https://docs.wasmtime.dev/api/wasmtime/struct.Linker.html#method.get_default
+    #       is this always correct?
+    start = linking1.exports(store).get("") or linking1.exports(store)["_start"]
+    start(store)
+
+if __name__ == '__main__':
+    main()
+    "#,
+        bin_name
+    );
+
+    // We can't use add_file since we want to mark the file as executable
+    let launcher_path = Path::new(&metadata.get_distribution_escaped())
+        .join(bin_name.replace("-", "_"))
+        .with_extension("py");
+    writer.add_bytes_with_permissions(&launcher_path, entrypoint_script.as_bytes(), 0o755)?;
     Ok(())
 }
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -823,7 +823,7 @@ if __name__ == '__main__':
 
     // We can't use add_file since we want to mark the file as executable
     let launcher_path = Path::new(&metadata.get_distribution_escaped())
-        .join(bin_name.replace("-", "_"))
+        .join(bin_name.replace('-', "_"))
         .with_extension("py");
     writer.add_bytes_with_permissions(&launcher_path, entrypoint_script.as_bytes(), 0o755)?;
     Ok(())

--- a/test-crates/cargo-mock/src/main.rs
+++ b/test-crates/cargo-mock/src/main.rs
@@ -33,7 +33,8 @@ fn run() -> Result<()> {
         .replace("--quiet", "")
         .replace(&cwd, "")
         .replace(" ", "-")
-        .replace("/", "-");
+        .replace("/", "-")
+        .replace("-----C-link-arg=-s", "");
 
     let cache_path = base_cache_path.join(&env_key).join(&cargo_key);
     let stdout_path = cache_path.join("cargo.stdout");

--- a/test-crates/hello-world/check_installed/check_installed.py
+++ b/test-crates/hello-world/check_installed/check_installed.py
@@ -7,7 +7,7 @@ def main():
         raise Exception(output)
 
     output = check_output(["foo"]).decode("utf-8").strip()
-    if not output == "Hello, world!":
+    if not output == "🦀 Hello, world! 🦀":
         raise Exception(output)
     print("SUCCESS")
 

--- a/test-crates/hello-world/src/bin/foo.rs
+++ b/test-crates/hello-world/src/bin/foo.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("🦀 Hello, world! 🦀");
 }

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -46,7 +46,7 @@ pub fn test_integration(
         cli.push(bindings);
     }
 
-    if let Some(ref target) = target {
+    if let Some(target) = target {
         cli.push("--target");
         cli.push(target)
     }

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -15,6 +15,7 @@ pub fn test_integration(
     bindings: Option<String>,
     unique_name: &str,
     zig: bool,
+    target: Option<&str>,
 ) -> Result<()> {
     maybe_mock_cargo();
 
@@ -43,6 +44,11 @@ pub fn test_integration(
     if let Some(ref bindings) = bindings {
         cli.push("--bindings");
         cli.push(bindings);
+    }
+
+    if let Some(ref target) = target {
+        cli.push("--target");
+        cli.push(target)
     }
 
     let test_zig = if zig && (env::var("GITHUB_ACTIONS").is_ok() || Zig::find_zig().is_ok()) {
@@ -84,11 +90,14 @@ pub fn test_integration(
             };
             assert!(filename.to_string_lossy().ends_with(file_suffix))
         }
-        let venv_suffix = if supported_version == "py3" {
+        let mut venv_suffix = if supported_version == "py3" {
             "py3".to_string()
         } else {
             format!("{}.{}", python_interpreter.major, python_interpreter.minor,)
         };
+        if let Some(target) = target {
+            venv_suffix = format!("{}-{}", venv_suffix, target);
+        }
         let (venv_dir, python) = create_virtualenv(
             &package,
             &venv_suffix,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -76,7 +76,7 @@ pub fn handle_result<T>(result: Result<T>) -> T {
     match result {
         Err(e) => {
             for cause in e.chain().collect::<Vec<_>>().iter().rev() {
-                eprintln!("{}", cause);
+                eprintln!("Cause: {}", cause);
             }
             panic!("{}", e);
         }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,6 +1,7 @@
 //! To speed up the tests, they are tests all collected in a single module
 
 use common::{develop, editable, errors, handle_result, integration, other};
+use std::path::Path;
 
 mod common;
 
@@ -140,6 +141,7 @@ fn integration_pyo3_bin() {
         None,
         "integration_pyo3_bin",
         false,
+        None,
     ));
 }
 
@@ -150,6 +152,7 @@ fn integration_pyo3_pure() {
         None,
         "integration_pyo3_pure",
         false,
+        None,
     ));
 }
 
@@ -160,6 +163,7 @@ fn integration_pyo3_mixed() {
         None,
         "integration_pyo3_mixed",
         false,
+        None,
     ));
 }
 
@@ -170,6 +174,7 @@ fn integration_pyo3_mixed_submodule() {
         None,
         "integration_pyo3_mixed_submodule",
         false,
+        None,
     ));
 }
 
@@ -180,6 +185,7 @@ fn integration_pyo3_mixed_py_subdir() {
         None,
         "integration_pyo3_mixed_py_subdir",
         cfg!(unix),
+        None,
     ));
 }
 
@@ -201,6 +207,7 @@ fn integration_cffi_pure() {
         None,
         "integration_cffi_pure",
         false,
+        None,
     ));
 }
 
@@ -211,6 +218,7 @@ fn integration_cffi_mixed() {
         None,
         "integration_cffi_mixed",
         false,
+        None,
     ));
 }
 
@@ -221,6 +229,7 @@ fn integration_hello_world() {
         None,
         "integration_hello_world",
         false,
+        None,
     ));
 }
 
@@ -231,8 +240,10 @@ fn integration_pyo3_ffi_pure() {
         None,
         "integration_pyo3_ffi_pure",
         false,
+        None,
     ));
 }
+
 #[test]
 fn integration_with_data() {
     handle_result(integration::test_integration(
@@ -240,7 +251,24 @@ fn integration_with_data() {
         None,
         "integration_with_data",
         false,
+        None,
     ));
+}
+
+#[test]
+fn integration_wasm_hello_world() {
+    handle_result(integration::test_integration(
+        "test-crates/hello-world",
+        None,
+        "integration_wasm_hello_world",
+        false,
+        Some("wasm32-wasi"),
+    ));
+
+    // Make sure we're actually running wasm
+    assert!(
+        Path::new("test-crates/venvs/hello-world-py3-wasm32-wasi/bin/hello-world.wasm").is_file()
+    )
 }
 
 #[test]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -262,7 +262,8 @@ fn integration_with_data() {
     all(target_os = "windows", target_arch = "x86_64"),
     all(
         target_os = "linux",
-        any(target_arch = "x86_64", target_arch = "aarch64")
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        target_env = "gnu",
     ),
     all(
         target_os = "macos",

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -256,6 +256,19 @@ fn integration_with_data() {
 }
 
 #[test]
+// Sourced from https://pypi.org/project/wasmtime/0.40.0/#files
+// update with wasmtime updates
+#[cfg(any(
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ),
+    all(
+        target_os = "max",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ),
+))]
 fn integration_wasm_hello_world() {
     handle_result(integration::test_integration(
         "test-crates/hello-world",

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -280,9 +280,16 @@ fn integration_wasm_hello_world() {
     ));
 
     // Make sure we're actually running wasm
-    assert!(
-        Path::new("test-crates/venvs/hello-world-py3-wasm32-wasi/bin/hello-world.wasm").is_file()
-    )
+    assert!(Path::new("test-crates")
+        .join("venvs")
+        .join("hello-world-py3-wasm32-wasi")
+        .join(if cfg!(target_os = "windows") {
+            "Scripts"
+        } else {
+            "bin"
+        })
+        .join("hello-world.wasm")
+        .is_file())
 }
 
 #[test]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -265,7 +265,7 @@ fn integration_with_data() {
         any(target_arch = "x86_64", target_arch = "aarch64")
     ),
     all(
-        target_os = "max",
+        target_os = "macos",
         any(target_arch = "x86_64", target_arch = "aarch64")
     ),
 ))]


### PR DESCRIPTION
I had this idea that besides having to build a wheel for each platform and then still there are platforms without manylinux supports, we could have a single wasm wheel as a generic fallback. Currently more theoretical since wasmtime supports less platforms than manylinux. Also we could have isolation and such in the future.

We build the rust binaries to wasi and put them in a wheel with a wasmtime launcher. The resulting wheels are platform independent (py3-none-any) and run on all wasmtime platforms. 

TODO:

- [x] figure out what names are valid for binaries (esp. with dots) and how to translate them for the entrypoints scripts: cargo is stricter than pypa already
- [x] can we ship wasm entrypoints and a user python module: maybe later
- [x] https://github.com/bytecodealliance/wasmtime-py/issues/94: they don't really know either