### PR TITLE
Fix `Cargo.toml` in new project template

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `Cargo.toml` in new project template in [#1109](https://github.com/PyO3/maturin/pull/1109)
+
 ## [0.13.3] - 2022-09-15
 
 * Allow user to override default Emscripten settings in [#1059](https://github.com/PyO3/maturin/pull/1059)

--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-{%- if bindings != "bin" -%}
+{% if bindings != "bin" -%}
 [lib]
 name = "{{ crate_name }}"
 crate-type = ["cdylib"]


### PR DESCRIPTION
Whitespace handling in minijinja is so tricky.