### PR TITLE
Fix duplicated `Cargo.toml` of local dependencies in sdist

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix `Cargo.toml` in new project template in [#1109](https://github.com/PyO3/maturin/pull/1109)
 * Fix `maturin develop` on Windows when using Python installed from msys2 in [#1112](https://github.com/PyO3/maturin/pull/1112)
+* Fix duplicated `Cargo.toml` of local dependencies in sdist in [#1114](https://github.com/PyO3/maturin/pull/1114)
 
 ## [0.13.3] - 2022-09-15
 

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -179,9 +179,7 @@ fn add_crate_to_source_distribution(
         .filter(|(target, source)| {
             // Skip generated files. See https://github.com/rust-lang/cargo/issues/7938#issuecomment-593280660
             // and https://github.com/PyO3/maturin/issues/449
-            if target == Path::new("Cargo.toml.orig")
-                || (root_crate && target.file_name() == Some("Cargo.toml".as_ref()))
-            {
+            if target == Path::new("Cargo.toml.orig") || target == Path::new("Cargo.toml") {
                 false
             } else {
                 source.exists()

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -141,14 +141,17 @@ pub fn test_source_distribution(
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);
     let mut files = BTreeSet::new();
+    let mut file_count = 0;
     for entry in archive.entries()? {
         let entry = entry?;
         files.insert(format!("{}", entry.path()?.display()));
+        file_count += 1;
     }
     assert_eq!(
         files,
         BTreeSet::from_iter(expected_files.into_iter().map(ToString::to_string))
     );
+    assert_eq!(file_count, files.len(), "duplicated files found in sdist");
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1113 