### PR TITLE
fix: cargo.toml empty line when new project

### DIFF
--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-{% if bindings != "bin" -%}
+{%- if bindings != "bin" %}
 [lib]
 name = "{{ crate_name }}"
 crate-type = ["cdylib"]


### PR DESCRIPTION
Hi, There is no line break in [lib] in the cargo.toml file generated when I use maturin v0.13.3 init, the latest you have fixed it, but when bindings==bin will generate an extra blank line, I have fixed it.

this is bingings==bin:
```sh
☺  cargo run                                                                                                                                                                                                                    master 
   Compiling workhome v0.1.0 (/Users/hulk/code/rust/workhome)
    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
     Running `target/debug/workhome`
[package]
name = "World"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]

```

this is bingings==pyo3:
```sh
☺  cargo run                                                                                                                                                                                                                    master 
   Compiling workhome v0.1.0 (/Users/hulk/code/rust/workhome)
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/workhome`
[package]
name = "World"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
[lib]
name = "hello_rust"
crate-type = ["cdylib"]

[dependencies]
pyo3 = { version = "0.17.1", features = ["extension-module"] }

```

this is bingings==rust-cpython
```sh
☺  cargo run                                                                                                                                                                                                                    master 
   Compiling workhome v0.1.0 (/Users/hulk/code/rust/workhome)
    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
     Running `target/debug/workhome`
[package]
name = "World"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
[lib]
name = "hello_rust"
crate-type = ["cdylib"]

[dependencies]
cpython = { version = "0.7.0", features = ["extension-module"] }

```