### PR TITLE
Build multi-platform docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,11 +14,13 @@ jobs:
       url: https://ghcr.io/pyo3/maturin
     steps:
       - uses: actions/checkout@v3
-      - uses: crazy-max/ghaction-docker-meta@v2
+      - name: Setup QEMU
+        uses: dbhi/qus/action@main
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/metadata-action@v4
         id: meta
         with:
           images: ghcr.io/pyo3/maturin
-      - uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -28,9 +30,11 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#registry-cache
+          cache-from: type=registry,ref=ghcr.io/pyo3/maturin:buildcache
+          cache-to: type=registry,ref=ghcr.io/pyo3/maturin:buildcache,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,6 +272,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: false
           tags: maturin
           load: true


### PR DESCRIPTION
* Add linux/arm64 support, see https://github.com/docker/buildx/issues/157#issuecomment-539457548
* Change docker cache to registry cache, gha cache limit is 10G which is better to be used only as cargo build cache
* Upgrade to Rust 1.64.0