### PR TITLE
Add support for workspace metadata inheritance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix `maturin develop` on Windows when using Python installed from msys2 in [#1112](https://github.com/PyO3/maturin/pull/1112)
 * Fix duplicated `Cargo.toml` of local dependencies in sdist in [#1114](https://github.com/PyO3/maturin/pull/1114)
 * Add support for Cargo workspace dependencies inheritance in [#1123](https://github.com/PyO3/maturin/pull/1123)
+* Add support for Cargo workspace metadata inheritance in [#1131](https://github.com/PyO3/maturin/pull/1131)
 
 ## [0.13.3] - 2022-09-15
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -488,7 +488,6 @@ impl BuildOptions {
         let ProjectResolver {
             project_layout,
             cargo_toml_path,
-            cargo_toml,
             pyproject_toml_path,
             pyproject_toml,
             module_name,
@@ -685,7 +684,7 @@ impl BuildOptions {
             .target_dir
             .clone()
             .unwrap_or_else(|| cargo_metadata.target_directory.clone().into_std_path_buf());
-        let crate_name = cargo_toml.package.name;
+        let crate_name = metadata21.name.clone();
 
         Ok(BuildContext {
             target,
@@ -1339,9 +1338,15 @@ mod test {
         use crate::CargoToml;
 
         // Nothing specified
-        let cargo_toml = CargoToml::from_path("test-crates/pyo3-pure/Cargo.toml").unwrap();
+        let manifest_path = "test-crates/pyo3-pure/Cargo.toml";
+        let cargo_toml = CargoToml::from_path(manifest_path).unwrap();
+        let cargo_metadata = MetadataCommand::new()
+            .manifest_path(manifest_path)
+            .exec()
+            .unwrap();
         let metadata21 =
-            Metadata21::from_cargo_toml(&cargo_toml, &"test-crates/pyo3-pure").unwrap();
+            Metadata21::from_cargo_toml(&cargo_toml, &"test-crates/pyo3-pure", &cargo_metadata)
+                .unwrap();
         assert_eq!(get_min_python_minor(&metadata21), None);
     }
 }

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -16,20 +16,6 @@ pub(crate) struct CargoTomlLib {
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct CargoTomlPackage {
-    // Those three fields are mandatory
-    // https://doc.rust-lang.org/cargo/reference/manifest.html#the-package-section
-    pub(crate) name: String,
-    pub(crate) version: String,
-    // All other fields are optional
-    pub(crate) authors: Option<Vec<String>>,
-    pub(crate) description: Option<String>,
-    pub(crate) documentation: Option<String>,
-    pub(crate) homepage: Option<String>,
-    pub(crate) repository: Option<String>,
-    pub(crate) readme: Option<String>,
-    pub(crate) keywords: Option<Vec<String>>,
-    pub(crate) categories: Option<Vec<String>>,
-    pub(crate) license: Option<String>,
     metadata: Option<CargoTomlMetadata>,
 }
 

--- a/test-crates/workspace-inheritance/Cargo.toml
+++ b/test-crates/workspace-inheritance/Cargo.toml
@@ -4,6 +4,9 @@ members = [
   "python"
 ]
 
+[workspace.package]
+version = "0.1.0"
+
 [workspace.dependencies]
 libc = { version = "0.2", features = ["std"] }
 generic_lib = { path = "generic_lib" }

--- a/test-crates/workspace-inheritance/python/Cargo.toml
+++ b/test-crates/workspace-inheritance/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-inheritance"
-version = "0.1.0"
+version.workspace = true
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
* https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html#duplication-in-crate-versions
* https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html#duplication-in-crate-metadata

TODO: 

- [x] rewrite workspace inherited fields in `Cargo.toml`.

Closes #1130 