### PR TITLE
Fix `maturin develop` in Windows conda virtual environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
       RUST_BACKTRACE: '1'
     steps:
       - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-activate-base: 'false'
+          activate-environment: ''
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `maturin develop` in Windows conda virtual environment in [#1146](https://github.com/PyO3/maturin/pull/1146)
+
 ## [0.13.5] - 2022-09-27
 
 * Fix resolving crate name bug in [#1142](https://github.com/PyO3/maturin/pull/1142)

--- a/src/target.rs
+++ b/src/target.rs
@@ -579,13 +579,13 @@ impl Target {
         let venv = venv_base.as_ref();
         if self.is_windows() {
             let bin_dir = venv.join("Scripts");
-            if bin_dir.exists() {
+            if bin_dir.join("python.exe").exists() {
                 return bin_dir;
             }
             // Python innstalled via msys2 on Windows might produce a POSIX-like venv
             // See https://github.com/PyO3/maturin/issues/1108
             let bin_dir = venv.join("bin");
-            if bin_dir.exists() {
+            if bin_dir.join("python.exe").exists() {
                 return bin_dir;
             }
             // for conda environment

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -162,14 +162,15 @@ fn integration_pyo3_mixed_py_subdir() {
     ));
 }
 
-#[cfg(target_os = "windows")]
 #[test]
-#[ignore]
 fn integration_pyo3_pure_conda() {
-    handle_result(integration::test_integration_conda(
-        "text-crates/pyo3-pure",
-        None,
-    ));
+    // Only run on GitHub Actions for now
+    if std::env::var("GITHUB_ACTIONS").is_ok() {
+        handle_result(integration::test_integration_conda(
+            "test-crates/pyo3-mixed",
+            None,
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
TODO

- [ ] Add `develop` conda venv test
- [ ] Only run conda tests when `conda` is present in `PATH`

Fixes #1145 