### PR TITLE
Filter out unwanted Cargo target kinds when determine bridge model

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix `maturin develop` in Windows conda virtual environment in [#1146](https://github.com/PyO3/maturin/pull/1146)
+* Fix build for crate using `pyo3` and `build.rs` without `cdylib` crate type in [#1150](https://github.com/PyO3/maturin/pull/1150)
 
 ## [0.13.5] - 2022-09-27
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -861,6 +861,11 @@ pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<Br
     let targets: Vec<_> = root_package
         .targets
         .iter()
+        .filter(|target| {
+            target.kind.iter().any(|kind| {
+                kind != "example" && kind != "test" && kind != "bench" && kind != "custom-build"
+            })
+        })
         .flat_map(|target| target.crate_types.iter())
         .map(String::as_str)
         .collect();


### PR DESCRIPTION
Ignore `example`, `test`, `bench` and `custom-build` target kinds.

See https://github.com/rust-lang/cargo/blob/a3e352e4b8f24429404040b0c152b1e950d40996/src/cargo/core/manifest.rs#L132-L138

Fixes #1149