### PR TITLE
Allow `rustix` dependency now that Alpine removed `thumb-mode` on armv7l

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -166,7 +166,6 @@ deny = [
     # Wrapper crates can optionally be specified to allow the crate when it
     # is a direct dependency of the otherwise banned crate
     #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
-    { name = "rustix" },
     { name = "indicatif", version = ">=0.17.0" },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.


### PR DESCRIPTION
https://github.com/alpinelinux/aports/commit/329ba719dc7f7d508b32185d11726c191ae952d7