### PR TITLE
Add Python metadata support for `license-file` field of `Cargo.toml`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Usage is by setting `--target wasm32-wasi`.
 * Add support for python first [`src` project layout](https://py-pkgs.org/04-package-structure.html#the-source-layout) in [#1185](https://github.com/PyO3/maturin/pull/1185)
 * Add `--src` option to generate src layout for mixed Python/Rust projects in [#1189](https://github.com/PyO3/maturin/pull/1189)
+* Add Python metadata support for `license-file` field of `Cargo.toml` in [#1195](https://github.com/PyO3/maturin/pull/1195)
 
 ## [0.13.6] - 2022-10-08
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -348,6 +348,11 @@ impl Metadata21 {
         if let Some(repository) = package.repository.as_ref() {
             project_url.insert("Source Code".to_string(), repository.clone());
         }
+        let license_files = if let Some(license_file) = package.license_file.as_ref() {
+            vec![manifest_path.as_ref().join(license_file)]
+        } else {
+            Vec::new()
+        };
 
         let metadata = Metadata21 {
             metadata_version: "2.1".to_owned(),
@@ -373,7 +378,7 @@ impl Metadata21 {
             },
             author_email,
             license: package.license.clone(),
-            license_files: Vec::new(),
+            license_files,
 
             // Values provided through `[project.metadata.maturin]`
             classifiers,


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields