### PR TITLE
Fix sdist build for maturin itself

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -511,6 +511,7 @@ pub fn source_distribution(
                 debug!("Ignoring {}", source.display());
                 continue;
             }
+            let source = fs::canonicalize(source)?;
             let target = root_dir.join(source.strip_prefix(&pyproject_dir)?);
             if source.is_dir() {
                 writer.add_directory(target)?;


### PR DESCRIPTION
```
cargo run sdist
   Compiling maturin v0.13.6 (/Users/messense/Projects/maturin)
    Finished dev [unoptimized + debuginfo] target(s) in 2.28s
     Running `target/debug/maturin sdist`
⚠️  Warning: `build-backend` in pyproject.toml is not set to `maturin`, packaging tools such as pip will not use maturin to build this project.
🍹 Building a mixed python/rust project
🔗 Found bin bindings
📡 Using build options bindings from pyproject.toml
💥 maturin failed
  Caused by: Failed to build source distribution
  Caused by: prefix not found
```