### PR TITLE
Update to wasmtime 2.0.0

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -123,7 +123,7 @@ fn bin_wasi_helper(
         // Having the wasmtime version hardcoded is not ideal, it's easy enough to overwrite
         metadata21
             .requires_dist
-            .push("wasmtime>=1.0.1,<2.0.0".to_string());
+            .push("wasmtime>=2.0.0,<3.0.0".to_string());
     }
 
     Ok(metadata21)

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -276,7 +276,7 @@ fn integration_with_data() {
 }
 
 #[test]
-// Sourced from https://pypi.org/project/wasmtime/0.40.0/#files
+// Sourced from https://pypi.org/project/wasmtime/2.0.0/#files
 // update with wasmtime updates
 #[cfg(any(
     all(target_os = "windows", target_arch = "x86_64"),


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime-py/pull/99

It seems that there are no breaking changes in public API.