### PR TITLE
Add support for testing against specific Python interpreter

### DIFF
--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -80,6 +80,9 @@ The `sysconfig` folder contains the output of `python -m sysconfig` for differen
 
 You need to install `cffi` and `virtualenv` (`pip install cffi virtualenv`) to run the tests.
 
+You can set the `MATURIN_TEST_PYTHON` environment variable to run the tests against a specific Python version, 
+for example `MATURIN_TEST_PYTHON=python3.11 cargo test` will run the tests against Python 3.11.
+
 There are some optional hacks that can speed up the tests (over 80s to 17s on my machine).
 1. By running `cargo build --release --manifest-path test-crates/cargo-mock/Cargo.toml` you can activate a cargo cache avoiding to rebuild the pyo3 test crates with every python version.
 2. Delete `target/test-cache` to clear the cache (e.g. after changing a test crate) or remove `test-crates/cargo-mock/target/release/cargo` to deactivate it.

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -30,6 +30,7 @@ pub fn test_integration(
     // The first argument is ignored by clap
     let shed = format!("test-crates/wheels/{}", unique_name);
     let target_dir = format!("test-crates/targets/{}", unique_name);
+    let python_interp = env::var("MATURIN_TEST_PYTHON");
     let mut cli = vec![
         "build",
         "--quiet",
@@ -59,6 +60,11 @@ pub fn test_integration(
         cli.push("linux");
         false
     };
+
+    if let Ok(interp) = python_interp.as_ref() {
+        cli.push("--interpreter");
+        cli.push(interp);
+    }
 
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let build_context = options.into_build_context(false, cfg!(feature = "faster-tests"), false)?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -106,7 +106,8 @@ pub fn create_virtualenv(name: &str, python_interp: Option<PathBuf>) -> Result<(
     }
 
     let mut cmd = Command::new("virtualenv");
-    if let Some(interp) = python_interp {
+    let interp = python_interp.or_else(|| env::var_os("MATURIN_TEST_PYTHON").map(|p| p.into()));
+    if let Some(interp) = interp {
         cmd.arg("-p").arg(interp);
     }
     let output = cmd


### PR DESCRIPTION
By setting `MATRUIN_TEST_PYTHON` env var, makes it easier to run the tests against PyPy locally.