### PR TITLE
Fix auditwheel libpython check on Python 3.7 and older versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Python metadata support for `license-file` field of `Cargo.toml` in [#1195](https://github.com/PyO3/maturin/pull/1195)
 * Upgrade to clap 4.0 in [#1197](https://github.com/PyO3/maturin/pull/1197). This bumps MSRV to 1.61.0.
 * Remove `workspace.members` in `Cargo.toml` from sdist if there isn't any path dependency in #[1227](https://github.com/PyO3/maturin/pull/1227)
+* Fix auditwheel `libpython` check on Python 3.7 and older versions in [#1229](https://github.com/PyO3/maturin/pull/1229)
 
 ## [0.13.7] - 2022-10-29
 

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -212,7 +212,7 @@ fn policy_is_satisfied(
         ));
     }
     // Check for libpython and forbidden libraries
-    let is_libpython = Regex::new(r"^libpython3\.\d+\.so\.\d+\.\d+$").unwrap();
+    let is_libpython = Regex::new(r"^libpython3\.\d+m?u?\.so\.\d+\.\d+$").unwrap();
     let offenders: Vec<String> = offending_libs.into_iter().collect();
     match offenders.as_slice() {
         [] => Ok(()),


### PR DESCRIPTION
Found in https://github.com/PyO3/maturin/actions/runs/3360316035/jobs/5569360257

```
🐍 Found CPython 3.7m at /opt/hostedtoolcache/Python/3.7.15/x64/bin/python
⚠️  Warning: Couldn't find the symbol `PyInit_pyo3_no_extension_module` in the native library. Python will fail to import this module. If you're using pyo3, check that `#[pymodule]` uses `pyo3_no_extension_module` as module name
🖨  Copied external shared libraries to package pyo3_no_extension_module.libs directory:
    /opt/hostedtoolcache/Python/3.7.15/x64/lib/libpython3.7m.so.1.0
📦 Built wheel for CPython 3.7m to test-crates/targets/pyo3_no_extension_module/pyo3_no_extension_module-2.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
```