### PR TITLE
Upgrade to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/pyo3/maturin"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "cffi", "packaging", "pypi", "pyo3"]
 categories = ["api-bindings", "development-tools::ffi", "command-line-utilities"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 
 [[bin]]

--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -6,7 +6,7 @@ run in Python using pyo3.
 
 ## Create a new Rust project
 
-First, create a new Rust library project using `cargo new --lib --edition 2018
+First, create a new Rust library project using `cargo new --lib --edition 2021
 guessing-game`. This will create a directory with the following structure.
 
 ```ignore
@@ -25,7 +25,7 @@ stable ABI (`abi3`).
 [package]
 name = "guessing-game"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "guessing_game"

--- a/test-crates/cargo-mock/Cargo.toml
+++ b/test-crates/cargo-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-mock"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "cargo"

--- a/test-crates/cffi-mixed/Cargo.toml
+++ b/test-crates/cffi-mixed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-mixed"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cffi_mixed"

--- a/test-crates/cffi-pure/Cargo.toml
+++ b/test-crates/cffi-pure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cffi-pure"
 version = "0.1.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "cffi_pure"

--- a/test-crates/hello-world/Cargo.toml
+++ b/test-crates/hello-world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello-world"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 # Test references to out-of-project files
 readme = "../../README.md"
 default-run = "hello-world"

--- a/test-crates/lib_with_disallowed_lib/Cargo.toml
+++ b/test-crates/lib_with_disallowed_lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_disallowed_lib"
 version = "0.1.0"
 authors = ["messense <messense@icloud.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/lib_with_path_dep/Cargo.toml
+++ b/test-crates/lib_with_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_with_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/license-test/Cargo.toml
+++ b/test-crates/license-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "license-test"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/test-crates/pyo3-abi3-without-version/Cargo.toml
+++ b/test-crates/pyo3-abi3-without-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3-abi3-without-version"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["abi3", "extension-module"] }

--- a/test-crates/pyo3-bin/Cargo.toml
+++ b/test-crates/pyo3-bin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-bin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/pyo3-feature/Cargo.toml
+++ b/test-crates/pyo3-feature/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-feature"
 version = "0.7.3"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", optional = true }

--- a/test-crates/pyo3-ffi-pure/Cargo.toml
+++ b/test-crates/pyo3-ffi-pure/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyo3-ffi-pure"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3-ffi = { version = "0.17.3", features = ["abi3-py37", "extension-module"] }

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-py-subdir"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["extension-module"] }

--- a/test-crates/pyo3-mixed-src/rust/Cargo.toml
+++ b/test-crates/pyo3-mixed-src/rust/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-mixed-src"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["extension-module", "generate-import-lib"] }

--- a/test-crates/pyo3-mixed-submodule/Cargo.toml
+++ b/test-crates/pyo3-mixed-submodule/Cargo.toml
@@ -4,7 +4,7 @@ name = "pyo3-mixed-submodule"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.maturin]
 name = "pyo3_mixed_submodule.rust_module.rust"

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-mixed"
 version = "2.1.3"
 description = "Implements a dummy function combining rust and python"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["extension-module", "generate-import-lib"] }

--- a/test-crates/pyo3-no-extension-module/Cargo.toml
+++ b/test-crates/pyo3-no-extension-module/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-no-extension-module"
 version = "2.1.0"
 description = "Does not use the extension-module feature, thus erroneously linking libpython"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.17.3", default-features = false }

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-pure"
 version = "2.1.2"
-edition = "2018"
+edition = "2021"
 description = "Implements a dummy function (get_fortytwo.DummyClass.get_42()) in rust"
 license = "MIT"
 

--- a/test-crates/pyo3-pure/local-test/Cargo.toml
+++ b/test-crates/pyo3-pure/local-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local-test"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/sdist_with_path_dep/Cargo.toml
+++ b/test-crates/sdist_with_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdist_with_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/test-crates/some_path_dep/Cargo.toml
+++ b/test-crates/some_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "some_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/transitive_path_dep/Cargo.toml
+++ b/test-crates/transitive_path_dep/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transitive_path_dep"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/with-data/Cargo.toml
+++ b/test-crates/with-data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "with-data"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "with_data"

--- a/test-crates/workspace-inheritance/generic_lib/Cargo.toml
+++ b/test-crates/workspace-inheritance/generic_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "generic_lib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/workspace-inheritance/python/Cargo.toml
+++ b/test-crates/workspace-inheritance/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "workspace-inheritance"
 version.workspace = true
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/test-crates/workspace/py/Cargo.toml
+++ b/test-crates/workspace/py/Cargo.toml
@@ -2,6 +2,6 @@
 name = "py"
 version = "0.1.0"
 authors = ["konstin <konstin@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/test-crates/workspace_with_path_dep/dont_include_in_sdist/Cargo.toml
+++ b/test-crates/workspace_with_path_dep/dont_include_in_sdist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dont_include_in_sdist"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/workspace_with_path_dep/generic_lib/Cargo.toml
+++ b/test-crates/workspace_with_path_dep/generic_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "generic_lib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-crates/workspace_with_path_dep/python/Cargo.toml
+++ b/test-crates/workspace_with_path_dep/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "workspace_with_path_dep"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/test-crates/workspace_with_path_dep/transitive_lib/Cargo.toml
+++ b/test-crates/workspace_with_path_dep/transitive_lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transitive_lib"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -392,7 +392,7 @@ fn workspace_members_non_local_dep_sdist() {
         authors = ["konstin <konstin@mailbox.org>"]
         name = "pyo3-pure"
         version = "2.1.2"
-        edition = "2018"
+        edition = "2021"
         description = "Implements a dummy function (get_fortytwo.DummyClass.get_42()) in rust"
         license = "MIT"
 


### PR DESCRIPTION
2021 edition was released in [Rust 1.56.0](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html), now that our MSRV is 1.61.0 we can use it.