### PR TITLE
Add `ignore_git_ignore` flag to build options

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -178,6 +178,8 @@ pub struct BuildContext {
     pub editable: bool,
     /// Cargo build options
     pub cargo_options: CargoOptions,
+    /// Ignore `.gitignore` files when including files for the Python part of a mixed project
+    pub ignore_git_ignore: bool,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).
@@ -474,6 +476,7 @@ impl BuildContext {
             None,
             &self.target,
             self.editable,
+            self.ignore_git_ignore,
         )
         .context("Failed to add the files to the wheel")?;
 
@@ -545,6 +548,7 @@ impl BuildContext {
             Some(python_interpreter),
             &self.target,
             self.editable,
+            self.ignore_git_ignore,
         )
         .context("Failed to add the files to the wheel")?;
 
@@ -663,6 +667,7 @@ impl BuildContext {
             &artifact.path,
             &self.interpreter[0].executable,
             self.editable,
+            self.ignore_git_ignore,
         )?;
 
         self.add_pth(&mut writer)?;
@@ -763,7 +768,7 @@ impl BuildContext {
                 bail!("Sorry, adding python code to a wasm binary is currently not supported")
             }
             if !self.editable {
-                write_python_part(&mut writer, python_module)
+                write_python_part(&mut writer, python_module, self.ignore_git_ignore)
                     .context("Failed to add the python module to the package")?;
             }
         }

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -174,6 +174,10 @@ pub struct BuildOptions {
     #[arg(long = "skip-auditwheel")]
     pub skip_auditwheel: bool,
 
+    /// Ignore `.gitignore` files when including files for the Python part of a mixed project
+    #[arg(long = "ignore-git-ignore")]
+    pub ignore_git_ignore: bool,
+
     /// For manylinux targets, use zig to ensure compliance for the chosen manylinux version
     ///
     /// Default to manylinux2014/manylinux_2_17 if you do not specify an `--compatibility`
@@ -597,6 +601,8 @@ impl BuildOptions {
         let strip = pyproject.map(|x| x.strip()).unwrap_or_default() || strip;
         let skip_auditwheel =
             pyproject.map(|x| x.skip_auditwheel()).unwrap_or_default() || self.skip_auditwheel;
+        let ignore_git_ignore =
+            pyproject.map(|x| x.ignore_git_ignore()).unwrap_or_default() || self.ignore_git_ignore;
         let platform_tags = if self.platform_tag.is_empty() {
             let compatibility = pyproject
                 .and_then(|x| {
@@ -721,6 +727,7 @@ impl BuildOptions {
             universal2,
             editable,
             cargo_options,
+            ignore_git_ignore,
         })
     }
 }

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -57,6 +57,7 @@ pub fn develop(
         bindings,
         out: Some(wheel_dir.path().to_path_buf()),
         skip_auditwheel: false,
+        ignore_git_ignore: false,
         zig: false,
         universal2: false,
         cargo: CargoOptions {

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -25,6 +25,8 @@ pub struct ToolMaturin {
     skip_auditwheel: bool,
     #[serde(default)]
     strip: bool,
+    #[serde(default)]
+    ignore_git_ignore: bool,
     /// The directory with python module, contains `<module_name>/__init__.py`
     python_source: Option<PathBuf>,
     /// Path to the wheel directory, defaults to `<module_name>.data`
@@ -140,6 +142,13 @@ impl PyProjectToml {
     /// Returns the value of `[tool.maturin.manifest-path]` in pyproject.toml
     pub fn manifest_path(&self) -> Option<&Path> {
         self.maturin()?.manifest_path.as_deref()
+    }
+
+    /// Returns the value of `[tool.maturin.ignore_git_ignore]` in pyproject.toml
+    pub fn ignore_git_ignore(&self) -> bool {
+        self.maturin()
+            .map(|maturin| maturin.ignore_git_ignore)
+            .unwrap_or_default()
     }
 
     /// Having a pyproject.toml without a version constraint is a bad idea

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -48,6 +48,9 @@ Options:
       --skip-auditwheel
           Don't check for manylinux compliance
 
+      --ignore-git-ignore
+          Ignore `.gitignore` files when including files for the Python part of a mixed project
+
       --zig
           For manylinux targets, use zig to ensure compliance for the chosen manylinux version
           

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -82,6 +82,9 @@ Options:
       --skip-auditwheel
           Don't check for manylinux compliance
 
+      --ignore-git-ignore
+          Ignore `.gitignore` files when including files for the Python part of a mixed project
+
       --zig
           For manylinux targets, use zig to ensure compliance for the chosen manylinux version
           


### PR DESCRIPTION
This can be set to include files that are ignored by `.gitignore` files. This was added in https://github.com/PyO3/maturin/pull/695.

This may be helpful when Python modules are generated as part of a build. The module should be included in the wheel, but not in the git repo which is why it's in the `.gitignore` file.