### PR TITLE
Convert workspace.dependency entries to tables if necessary

### DIFF
--- a/test-crates/workspace-inheritance/Cargo.lock
+++ b/test-crates/workspace-inheritance/Cargo.lock
@@ -25,6 +25,17 @@ name = "generic_lib"
 version = "0.1.0"
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +94,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -163,6 +180,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +258,12 @@ name = "unindent"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -273,7 +326,9 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 name = "workspace-inheritance"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "generic_lib",
  "libc",
  "pyo3",
+ "rand",
 ]

--- a/test-crates/workspace-inheritance/Cargo.toml
+++ b/test-crates/workspace-inheritance/Cargo.toml
@@ -8,5 +8,7 @@ members = [
 version = "0.1.0"
 
 [workspace.dependencies]
+cfg-if = "1.0.0"
 libc = { version = "0.2", features = ["std"] }
+rand = "0.8"
 generic_lib = { path = "generic_lib" }

--- a/test-crates/workspace-inheritance/python/Cargo.toml
+++ b/test-crates/workspace-inheritance/python/Cargo.toml
@@ -16,3 +16,11 @@ generic_lib.workspace = true
 workspace = true
 optional = true
 features = ["extra_traits"]
+
+[dependencies.cfg-if]
+workspace = true
+optional = true
+
+[dependencies.rand]
+workspace = true
+features = ["small_rng"]


### PR DESCRIPTION
When a `worksapce.dependency` is written in its short form,
e.g. `rand = "0.8"`, we need to convert that to a table before
combining it with `optional` or `features` entries from the
crate dependencies.
