### PR TITLE
Tell people about setting `RUST_LOG=maturin=debug` when making bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to Reproduce
-      description: Please list the exact steps required to reproduce your error with all command output and if possible with a repository
+      description: Please list the exact steps required to reproduce your error with all command output and if possible with a repository. Please run maturin with `RUST_LOG=maturin=debug` being set, e.g. `RUST_LOG=maturin=debug maturin build` and share the output, either in a codeblock or as a [gist](https://gist.github.com/)
       placeholder: |
         1.
         2.


### PR DESCRIPTION
Now that we have it, we should use it. We might want to change general cargo messages to trace level though