### PR TITLE
Deprecate `python-source` option in Cargo.toml

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Tighten src-layout detection logic in [#1281](https://github.com/PyO3/maturin/pull/1282)
 * Fix generating pep517 sdist for src-layout in [#1288](https://github.com/PyO3/maturin/pull/1288)
+* Deprecate `python-source` option in Cargo.toml in [#1291](https://github.com/PyO3/maturin/pull/1291)
 
 ## [0.14.1] - 2022-11-20
 

--- a/README.md
+++ b/README.md
@@ -114,20 +114,12 @@ my-project
     └── lib.rs
 ```
 
-You can specify a different python source directory in `pyproject.toml` by setting `tool.maturin.python-source`
-or in `Cargo.toml` by setting `package.metadata.maturin.python-source`, for example
+You can specify a different python source directory in `pyproject.toml` by setting `tool.maturin.python-source`, for example
 
 **pyproject.toml**
 
 ```toml
 [tool.maturin]
-python-source = "python"
-```
-
-**Cargo.toml**
-
-```toml
-[package.metadata.maturin]
 python-source = "python"
 ```
 

--- a/guide/src/project_layout.md
+++ b/guide/src/project_layout.md
@@ -80,20 +80,12 @@ modules. A popular way to avoid this is with the `src`-layout, where the Python
 package is nested within a `src` directory. Unfortunately this interferes with
 the structure of a typical Rust project. Fortunately, Python is nor particular
 about the name of the parent source directory. You tell maturin to use a
-different Python source directory in `pyproject.toml` by setting `tool.maturin.python-source`
-or in `Cargo.toml` by setting `package.metadata.maturin.python-source`, for example
+different Python source directory in `pyproject.toml` by setting `tool.maturin.python-source`, for example
 
 **pyproject.toml**
 
 ```toml
 [tool.maturin]
-python-source = "python"
-```
-
-**Cargo.toml**
-
-```toml
-[package.metadata.maturin]
 python-source = "python"
 ```
 
@@ -117,7 +109,6 @@ If the Python module created by Rust has the same name as the Python package in 
 
 ```toml
 [package.metadata.maturin]
-python-source = "python"
 name = "my_project._my_project"
 ```
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -126,13 +126,13 @@ pub fn develop(
         }
         if !output.stderr.is_empty() {
             eprintln!(
-                "⚠️  Warning: pip raised a warning running {:?}:\n{}",
+                "⚠️ Warning: pip raised a warning running {:?}:\n{}",
                 &command,
                 String::from_utf8_lossy(&output.stderr).trim(),
             );
         }
         println!(
-            "🛠  Installed {}-{}",
+            "🛠 Installed {}-{}",
             build_context.metadata21.name, build_context.metadata21.version
         );
     }

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -136,9 +136,12 @@ impl ProjectResolver {
             manifest_dir
         };
         let py_root = match pyproject.and_then(|x| x.python_source()) {
-            Some(py_src) => py_src.to_path_buf(),
+            Some(py_src) => project_root.join(py_src),
             None => match extra_metadata.python_source.as_ref() {
-                Some(py_src) => manifest_dir.join(py_src),
+                Some(py_src) => {
+                    println!("⚠️ Warning: specify python-source in Cargo.toml is deprecated, use python-source in [tool.maturin] section in pyproject.toml instead");
+                    manifest_dir.join(py_src)
+                }
                 None => match pyproject.and_then(|x| x.project_name()) {
                     Some(project_name) => {
                         // Detect src layout

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -14,5 +14,4 @@ name = "pyo3_mixed_py_subdir"
 crate-type = ["cdylib"]
 
 [package.metadata.maturin]
-python-source = "python"
 name = "pyo3_mixed_py_subdir._pyo3_mixed"

--- a/test-crates/pyo3-mixed-py-subdir/pyproject.toml
+++ b/test-crates/pyo3-mixed-py-subdir/pyproject.toml
@@ -12,3 +12,6 @@ requires-python = ">=3.6"
 
 [project.scripts]
 get_42 = "pyo3_mixed_py_subdir:get_42"
+
+[tool.maturin]
+python-source = "python"


### PR DESCRIPTION
The sdist generation code assumes it's relative to `pyproject.toml`, to keep it simple, let's deprecate the option in Cargo.toml and only support it in `pyproject.toml`.

Fixes #1290