### PR TITLE
Fix auditwheel with read-only libraries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Tighten src-layout detection logic in [#1281](https://github.com/PyO3/maturin/pull/1282)
 * Fix generating pep517 sdist for src-layout in [#1288](https://github.com/PyO3/maturin/pull/1288)
 * Deprecate `python-source` option in Cargo.toml in [#1291](https://github.com/PyO3/maturin/pull/1291)
+* Fix auditwheel with read-only libraries in [#1292](https://github.com/PyO3/maturin/pull/1292)
 
 ## [0.14.1] - 2022-11-20
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -392,6 +392,12 @@ impl BuildContext {
             fs::copy(&lib_path, &dest_path)?;
             libs_copied.insert(lib_path);
 
+            // fs::copy copies permissions as well, and the original
+            // file may have been read-only
+            let mut perms = fs::metadata(&dest_path)?.permissions();
+            perms.set_readonly(false);
+            fs::set_permissions(&dest_path, perms)?;
+
             patchelf::set_soname(&dest_path, &new_soname)?;
             if !lib.rpath.is_empty() || !lib.runpath.is_empty() {
                 patchelf::set_rpath(&dest_path, &libs_dir)?;


### PR DESCRIPTION
`std::fs::copy` also copies the original file permissions. If the original library at `lib_path` was not writable, e.g. because it had its permission set to 0o555, the copy inherited the same permission causing later file manipulations, like `patchelf --set-soname` to fail.

Fixes #1287 