### PR TITLE
Fix wrong platform tag when building in i386 docker container on x86_64 host

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,16 +278,11 @@ jobs:
     name: Test Alpine Linux
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        container:
-          - amd64/alpine:latest
-          - i386/alpine:latest
     env:
       RUST_BACKTRACE: '1'
       CARGO_INCREMENTAL: '0'
       CARGO_TERM_COLOR: always
-    container: ${{ matrix.container }}
+    container: alpine:latest
     steps:
       - uses: actions/checkout@v3
       - name: Install build requirements

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,11 +278,16 @@ jobs:
     name: Test Alpine Linux
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - amd64/alpine:latest
+          - i386/alpine:latest
     env:
       RUST_BACKTRACE: '1'
       CARGO_INCREMENTAL: '0'
       CARGO_TERM_COLOR: always
-    container: alpine:latest
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v3
       - name: Install build requirements

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Bump MSRV to 1.62.0 in [#1297](https://github.com/PyO3/maturin/pull/1297)
 * Fix build error when required features of bin target isn't enabled in [#1299](https://github.com/PyO3/maturin/pull/1299)
+* Fix wrong platform tag when building in i386 docker container in [#1301](https://github.com/PyO3/maturin/pull/1301)
 
 ## [0.14.2] - 2022-11-24
 


### PR DESCRIPTION
Fixes the i386 issue reported in https://github.com/PyO3/maturin/issues/1289#issuecomment-1328225431.

We can not trust the return value of `uname -m` in Docker container.