### PR TITLE
Fix wrong platform tag when building in armv7 docker container on aarch64 host

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Bump MSRV to 1.62.0 in [#1297](https://github.com/PyO3/maturin/pull/1297)
 * Fix build error when required features of bin target isn't enabled in [#1299](https://github.com/PyO3/maturin/pull/1299)
-* Fix wrong platform tag when building in i386 docker container in [#1301](https://github.com/PyO3/maturin/pull/1301)
+* Fix wrong platform tag when building in i386 docker container on x86_64 host in [#1301](https://github.com/PyO3/maturin/pull/1301)
+* Fix wrong platform tag when building in armv7 docker container on aarch64 host in [#1303](https://github.com/PyO3/maturin/pull/1303)
 
 ## [0.14.2] - 2022-11-24
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -368,8 +368,10 @@ impl Target {
         let machine = PlatformInfo::new().map(|info| info.machine().into_owned());
         let arch = match machine {
             Ok(machine) => {
-                if machine == "x86_64" && self.arch != Arch::X86_64 {
-                    // When running in Docker sometimes uname returns x86_64 but the container is actually x86,
+                let linux32 = (machine == "x86_64" && self.arch != Arch::X86_64)
+                    || (machine == "aarch64" && self.arch != Arch::Aarch64);
+                if linux32 {
+                    // When running in Docker sometimes uname returns 64-bit architecture while the container is actually 32-bit,
                     // In this case we trust the architecture of rustc target
                     self.arch.to_string()
                 } else {


### PR DESCRIPTION
Doesn't resolve the armv8l issue though.