### PR TITLE
Remove `human-panic` dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       # ring doesn't support aarch64 windows yet
       - name: Build wheel (windows aarch64)
         if: matrix.target == 'aarch64-pc-windows-msvc'
-        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --no-default-features --features log,upload,human-panic
+        run: cargo run -- build --release -b bin -o dist --target ${{ matrix.target }} --no-default-features --features log,upload
 
       - name: Build wheel (without sdist)
         if: ${{ matrix.target != 'x86_64-unknown-linux-musl' && matrix.target != 'aarch64-pc-windows-msvc' }}
@@ -221,7 +221,7 @@ jobs:
             --target ${{ matrix.platform.target }} \
             --compatibility ${{ matrix.platform.compatibility }} \
             --no-default-features \
-            --features log,upload,human-panic,password-storage
+            --features log,upload,password-storage
       - name: Archive binary
         run: tar czvf target/release/maturin-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release maturin
       - name: Upload wheel artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,21 +146,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide 0.5.4",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -403,7 +379,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid 1.2.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1010,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1175,12 +1151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,21 +1242,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "human-panic"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f357a500abcbd7c5f967c1d45c8838585b36743823b9d43488f24850534e36"
-dependencies = [
- "backtrace",
- "os_type",
- "serde",
- "serde_derive",
- "termcolor",
- "toml",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1539,7 +1494,6 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin 0.6.0",
- "human-panic",
  "ignore",
  "indoc",
  "itertools",
@@ -1634,15 +1588,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
@@ -1659,7 +1604,7 @@ dependencies = [
  "byteorder",
  "cfb",
  "encoding",
- "uuid 1.2.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1844,15 +1789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "object"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,15 +1870,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "os_type"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
-dependencies = [
- "regex",
-]
 
 [[package]]
 name = "output_vt100"
@@ -2344,12 +2271,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -3119,15 +3040,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ cbindgen = { version = "0.24.2", default-features = false }
 uniffi_bindgen = "0.21.0"
 flate2 = "1.0.18"
 goblin = "0.6.0"
-human-panic = { version = "1.0.3", optional = true }
 keyring = { version = "1.1.1", optional = true }
 platform-info = "1.0.0"
 regex = "1.7.0"
@@ -83,7 +82,7 @@ rustversion = "1.0.9"
 trycmd = "0.14.0"
 
 [features]
-default = ["log", "upload", "rustls", "human-panic"]
+default = ["log", "upload", "rustls"]
 upload = ["ureq", "multipart", "rpassword", "configparser", "bytesize"]
 password-storage = ["upload", "keyring"]
 log = ["tracing-subscriber"]
@@ -91,6 +90,8 @@ rustls = ["ureq/tls", "cargo-xwin/rustls-tls"]
 native-tls = ["ureq/native-tls", "native-tls-crate", "cargo-xwin/native-tls"]
 # Internal feature to speed up the tests significantly
 faster-tests = []
+# Deprecated features, keep it now for compatibility
+human-panic = []
 
 # Without this, compressing the .gz archive becomes notably slow for debug builds
 [profile.dev.package.miniz_oxide]

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ if platform.machine() in (
     "riscv64",
     "sparc64",
 ) or (sys.platform == "win32" and platform.machine() == "ARM64"):
-    cargo_args.extend(["--no-default-features", "--features=upload,log,human-panic"])
+    cargo_args.extend(["--no-default-features", "--features=upload,log"])
 elif sys.platform.startswith("haiku"):
     # mio and ring doesn't build on haiku
-    cargo_args.extend(["--no-default-features", "--features=log,human-panic"])
+    cargo_args.extend(["--no-default-features", "--features=log"])
 
 setup(
     name="maturin",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Cargo features
 //!
-//! Default features: log, upload, rustls, human-panic
+//! Default features: log, upload, rustls
 //!
 //! - log: Configures pretty-env-logger, even though maturin doesn't use logging itself.
 //!
@@ -15,8 +15,6 @@
 //! docker container and which maturin itself manylinux compliant.
 //!
 //! - native-tls: Makes ureq use the platform native tls stack
-//!
-//! - human-panic: Adds https://github.com/rust-clique/human-panic
 //!
 //! - password-storage (off by default): Uses the keyring package to store the password. keyring
 //! pulls in a lot of shared libraries and outdated dependencies, so this is off by default, except

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,11 +413,6 @@ fn run() -> Result<()> {
 }
 
 fn main() {
-    #[cfg(feature = "human-panic")]
-    {
-        human_panic::setup_panic!();
-    }
-
     if let Err(e) = run() {
         eprintln!("💥 maturin failed");
         for cause in e.chain().collect::<Vec<_>>().iter() {


### PR DESCRIPTION
`human-panic` seems unmaintained and pulls in quite a lot of heavy dependencies for very limited value, we can explore lightweight alternative in the future.