### PR TITLE
Refactor `Target::get_platform_tag` to use standard osname-release-machine fallback representation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,7 @@ jobs:
   test-emscripten:
     name: Test Emscripten
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PYODIDE_VERSION: '0.21.3'
       PYTHON_VERSION: '3.10.2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && python3.8 -m pip install --no-cache-dir cffi \
     && python3.9 -m pip install --no-cache-dir cffi \
     && python3.10 -m pip install --no-cache-dir cffi \
+    && python3.11 -m pip install --no-cache-dir cffi \
     && mkdir /io
 
 COPY --from=builder /usr/bin/maturin /usr/bin/maturin

--- a/test-dockerfile.sh
+++ b/test-dockerfile.sh
@@ -5,7 +5,7 @@
 set -e
 
 rm -rf venv-docker
-python3.8 -m venv venv-docker
+python3.11 -m venv venv-docker
 venv-docker/bin/pip install -U pip cffi
 
 # FIXME: Can we run the tests without activate? Currently hello-world fails because then the binary is not in PATH
@@ -14,7 +14,7 @@ source venv-docker/bin/activate
 for test_crate in hello-world cffi-pure cffi-mixed pyo3-pure pyo3-mixed pyo3-mixed-submodule
 do
   echo "Testing $test_crate"
-  docker run -e RUST_BACKTRACE=1 --rm -v "$(pwd):/io" -w /io/test-crates/$test_crate maturin build -i python3.8
+  docker run -e RUST_BACKTRACE=1 --rm -v "$(pwd):/io" -w /io/test-crates/$test_crate maturin build -i python3.11
   # --only-binary=:all: stops pip from picking a local already compiled sdist
   venv-docker/bin/pip install $test_crate --only-binary=:all: --find-links test-crates/$test_crate/target/wheels/
   if [[ $(venv-docker/bin/python test-crates/$test_crate/check_installed/check_installed.py) != 'SUCCESS' ]]; then


### PR DESCRIPTION
Expanded architecture support for FreeBSD, NetBSD and OpenBSD, even though rustup might not have toolchain support for them, distro itself might already have toolchain support in its packaging system.

Closes #1311 