### PR TITLE
Fix sdist when all Cargo workspace members are excluded

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * Support `SOURCE_DATE_EPOCH` when building wheels in [#1334](https://github.com/PyO3/maturin/pull/1334)
+* Fix sdist when all Cargo workspace members are excluded in [#1343](https://github.com/PyO3/maturin/pull/1343)
 
 ## [0.14.4] - 2022-12-05
 

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -213,8 +213,10 @@ fn rewrite_cargo_toml(
                     }
                     if !new_members.is_empty() {
                         workspace["members"] = toml_edit::value(new_members);
-                        rewritten = true;
+                    } else {
+                        workspace.remove("members");
                     }
+                    rewritten = true;
                 }
             }
         }


### PR DESCRIPTION
Fixes `ruff` conda build

> Error: `cargo metadata` exited with an error: error: failed to load manifest for workspace member `/home/conda/feedstock_root/build_artifacts/ruff_1670398792519/work/flake8_to_ruff`

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=624474&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=b2a8456a-fb11-5506-ca32-5ccd32538dc0