### PR TITLE
Allow Rust crate to be placed outside of the directory containing `pyproject.toml`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `sdist-include` option in `pyproject.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
+* Allow Rust crate to be placed outside of the directory containing `pyproject.toml` in [#1347](https://github.com/PyO3/maturin/pull/1347)
 
 ## [0.14.5] - 2022-12-08
 

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -232,15 +232,6 @@ impl ProjectResolver {
             let pyproject =
                 PyProjectToml::new(&pyproject_file).context("pyproject.toml is invalid")?;
             if let Some(path) = pyproject.manifest_path() {
-                // pyproject.toml must be placed at top directory
-                let manifest_dir = path
-                    .parent()
-                    .context("missing parent directory")?
-                    .normalize()?
-                    .into_path_buf();
-                if !manifest_dir.starts_with(&current_dir) {
-                    bail!("Cargo.toml can not be placed outside of the directory containing pyproject.toml");
-                }
                 debug!("Using cargo manifest path from pyproject.toml {:?}", path);
                 return Ok((path.normalize()?.into_path_buf(), pyproject_file));
             } else {


### PR DESCRIPTION
Closes #1346 