### PR TITLE
Run `uniffi-bindgen` command instead of depending on `uniffi_bindgen` crates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,7 @@ build_and_test: &BUILD_AND_TEST
     - rustup target add wasm32-wasi
     - python3 -m pip install --upgrade cffi virtualenv
   build_script:
+    - cargo install uniffi_bindgen
     - cargo build
   test_script:
     - cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,6 @@ build_and_test: &BUILD_AND_TEST
     - rustup target add wasm32-wasi
     - python3 -m pip install --upgrade cffi virtualenv
   build_script:
-    - cargo install uniffi_bindgen
     - cargo build
   test_script:
     - cargo test
@@ -54,6 +53,7 @@ macos_arm64_task:
       - cat Cargo.lock
   install_script:
     - brew install python3
+    - python3 -m pip install uniffi-bindgen
   <<: *BUILD_AND_TEST
 
 linux_aarch64_task:
@@ -74,4 +74,6 @@ linux_aarch64_task:
     fingerprint_script:
       - echo $CIRRUS_OS
       - cat Cargo.lock
+  install_script:
+    - python3 -m pip install uniffi-bindgen
   <<: *BUILD_AND_TEST

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,15 +132,13 @@ jobs:
         if: ${{ !contains(matrix.python-version, 'pypy') }}
         run: pip install cffi
       - name: Install python packages
-        run: pip install virtualenv ziglang~=0.10.0 twine
+        run: pip install virtualenv ziglang~=0.10.0 twine uniffi-bindgen
       - uses: dtolnay/rust-toolchain@stable
         id: rustup
         with:
           targets: wasm32-wasi  # Additional target
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
-      - name: Install uniffi_bindgen
-        run: cargo install uniffi_bindgen
       - name: Install aarch64-apple-darwin Rust target
         if: matrix.os == 'macos-latest'
         run: rustup target add aarch64-apple-darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,11 @@ jobs:
     env:
       RUST_BACKTRACE: '1'
     steps:
+      - name: Cleanup Disk
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -170,10 +175,9 @@ jobs:
         if: contains(matrix.python-version, 'pypy')
         run: echo "MATURIN_TEST_PYTHON=pypy3" >> $GITHUB_ENV
       - name: cargo test
+        env:
+          RUSTFLAGS: "-C debuginfo=0"  # save disk space
         run: cargo nextest run --features password-storage
-      - name: free up disk space
-        shell: bash
-        run: rm -rf test-crates/venvs test-crates/targets
       - name: test cross compiling with zig
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,8 @@ jobs:
           targets: wasm32-wasi  # Additional target
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
+      - name: Install uniffi_bindgen
+        run: cargo install uniffi_bindgen
       - name: Install aarch64-apple-darwin Rust target
         if: matrix.os == 'macos-latest'
         run: rustup target add aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,51 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
-name = "askama"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
-dependencies = [
- "askama_derive",
- "askama_escape",
- "askama_shared",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
-dependencies = [
- "askama_shared",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_shared"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
-dependencies = [
- "askama_escape",
- "mime",
- "mime_guess",
- "nom",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
-]
-
-[[package]]
 name = "async-io"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,17 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,15 +96,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -283,7 +218,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "860cd643171bc868500aff16c2405559b42fc71bd3130d761c2847b3e9e71cdc"
 dependencies = [
- "clap 4.0.29",
+ "clap",
 ]
 
 [[package]]
@@ -303,7 +238,7 @@ checksum = "e1396a7cea49da420388d759e81653a7b46cd9a207c82129c3453d8ccba8121e"
 dependencies = [
  "anyhow",
  "cargo-options",
- "clap 4.0.29",
+ "clap",
  "dirs",
  "fs-err",
  "indicatif",
@@ -321,7 +256,7 @@ dependencies = [
  "anyhow",
  "cargo-options",
  "cargo_metadata",
- "clap 4.0.29",
+ "clap",
  "dirs",
  "fs-err",
  "path-slash",
@@ -424,30 +359,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
- "clap_lex 0.3.0",
+ "clap_derive",
+ "clap_lex",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -461,7 +379,7 @@ version = "4.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b3c9eae0de7bf8e3f904a5e40612b21fb2e2e566456d177809a48b892d24da"
 dependencies = [
- "clap 4.0.29",
+ "clap",
 ]
 
 [[package]]
@@ -470,7 +388,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4160b4a4f72ef58bd766bad27c09e6ef1cc9d82a22f6a0f55d152985a4a48e31"
 dependencies = [
- "clap 4.0.29",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
 ]
@@ -481,21 +399,8 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b30e010e669cd021e5004f3be26cff6b7c08d2a8a0d65b48d43a8cc0efd6c3"
 dependencies = [
- "clap 4.0.29",
+ "clap",
  "clap_complete",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -509,15 +414,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -965,7 +861,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67f07131a2b944c2b42b6a58104600ef049c11df5454478d2b44ff5dfe58d149"
 dependencies = [
- "goblin 0.6.0",
+ "goblin",
 ]
 
 [[package]]
@@ -1168,17 +1064,6 @@ dependencies = [
  "fnv",
  "log",
  "regex",
-]
-
-[[package]]
-name = "goblin"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -1398,7 +1283,7 @@ checksum = "7580a02d700ecc9e06c72b7aace6e74427a56a69310f18fdd420a5fac3832969"
 dependencies = [
  "fs-err",
  "glob",
- "goblin 0.6.0",
+ "goblin",
 ]
 
 [[package]]
@@ -1471,7 +1356,7 @@ dependencies = [
  "cargo_metadata",
  "cbindgen",
  "cc",
- "clap 4.0.29",
+ "clap",
  "clap_complete_command",
  "configparser",
  "console",
@@ -1482,7 +1367,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "glob",
- "goblin 0.6.0",
+ "goblin",
  "ignore",
  "indoc",
  "itertools",
@@ -1515,8 +1400,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trycmd",
- "uniffi_bindgen",
  "ureq",
+ "which",
  "zip",
 ]
 
@@ -1903,12 +1788,6 @@ dependencies = [
  "smallvec",
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "path-slash"
@@ -2928,38 +2807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "uniffi_bindgen"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
-dependencies = [
- "anyhow",
- "askama",
- "bincode",
- "camino",
- "clap 3.2.23",
- "fs-err",
- "goblin 0.5.4",
- "heck",
- "once_cell",
- "paste",
- "serde",
- "serde_json",
- "toml",
- "uniffi_meta",
- "weedle2",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,15 +2992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weedle2"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,7 +3161,7 @@ dependencies = [
  "bytes",
  "cab",
  "camino",
- "clap 4.0.29",
+ "clap",
  "cli-table",
  "flate2",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ glob = "0.3.0"
 cargo_metadata = "0.15.2"
 cargo-options = "0.5.2"
 cbindgen = { version = "0.24.2", default-features = false }
-uniffi_bindgen = "0.21.0"
 flate2 = "1.0.18"
 goblin = "0.6.0"
 platform-info = "1.0.0"
@@ -88,6 +87,7 @@ indoc = "1.0.3"
 pretty_assertions = "1.3.0"
 rustversion = "1.0.9"
 trycmd = "0.14.0"
+which = "4.3.0"
 
 [features]
 default = ["full", "rustls"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `sdist-include` option in `pyproject.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
+* **Breaking Change**: [`uniffi_bindgen` CLI](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) is required for building `uniffi` bindings wheels in [#1352](https://github.com/PyO3/maturin/pull/1352)
 * Allow Rust crate to be placed outside of the directory containing `pyproject.toml` in [#1347](https://github.com/PyO3/maturin/pull/1347)
 
 ## [0.14.5] - 2022-12-08

--- a/deny.toml
+++ b/deny.toml
@@ -173,9 +173,8 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
-
-    # from uniffi-bindgen
-    { name = "goblin", version = "0.5.4" },
+    { name = "ahash", version = "0.3.8" },
+    { name = "hermit-abi", version = "0.1.19" },
     # from console
     { name = "terminal_size", version = "0.1.7" },
     # from secret-service
@@ -191,7 +190,6 @@ skip = [
 # by default infinite
 skip-tree = [
     #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
-    { name = "clap", version = "3.2.23" },
     { name = "windows-sys", version = "0.36.1" },
 ]
 

--- a/guide/src/bindings.md
+++ b/guide/src/bindings.md
@@ -94,4 +94,10 @@ directory of a virtual environment) once installed.
 ## `uniffi`
 
 uniffi bindings use [uniffi-rs](https://mozilla.github.io/uniffi-rs/) to generate Python `ctypes` bindings
-from an interface definition file. uniffi wheels are compatible with all python versions including pypy. 
+from an interface definition file. uniffi wheels are compatible with all python versions including pypy.
+
+You need to install [uniffi_bindgen](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) first to build wheels for `uniffi` bindings:
+
+```bash
+cargo install uniffi_bindgen
+```

--- a/test-crates/with-data/check_installed/check_installed.py
+++ b/test-crates/with-data/check_installed/check_installed.py
@@ -12,7 +12,7 @@ venv_root = Path(sys.prefix)
 installed_data = (
     venv_root.joinpath("data_subdir")
     .joinpath("hello.txt")
-    # With the default encoding, python under windows fails to read the file correctly :/
+    # With the default encoding, python under windows fails to read the file correctly
     .read_text(encoding="utf-8")
     .strip()
 )

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -8,6 +8,7 @@ use maturin::Target;
 use std::env;
 use std::path::{Path, PathBuf};
 use time::macros::datetime;
+use which::which;
 
 mod common;
 
@@ -25,7 +26,7 @@ fn develop_pyo3_pure() {
 #[ignore]
 fn develop_pyo3_pure_conda() {
     // Only run on GitHub Actions for now
-    if std::env::var("GITHUB_ACTIONS").is_ok() {
+    if env::var("GITHUB_ACTIONS").is_ok() {
         handle_result(develop::test_develop(
             "test-crates/pyo3-pure",
             None,
@@ -107,22 +108,26 @@ fn develop_cffi_mixed() {
 
 #[test]
 fn develop_uniffi_pure() {
-    handle_result(develop::test_develop(
-        "test-crates/uniffi-pure",
-        None,
-        "develop-uniffi-pure",
-        false,
-    ));
+    if env::var("GITHUB_ACTIONS").is_ok() || which("uniffi-bindgen").is_ok() {
+        handle_result(develop::test_develop(
+            "test-crates/uniffi-pure",
+            None,
+            "develop-uniffi-pure",
+            false,
+        ));
+    }
 }
 
 #[test]
 fn develop_uniffi_mixed() {
-    handle_result(develop::test_develop(
-        "test-crates/uniffi-mixed",
-        None,
-        "develop-uniffi-mixed",
-        false,
-    ));
+    if env::var("GITHUB_ACTIONS").is_ok() || which("uniffi-bindgen").is_ok() {
+        handle_result(develop::test_develop(
+            "test-crates/uniffi-mixed",
+            None,
+            "develop-uniffi-mixed",
+            false,
+        ));
+    }
 }
 
 #[test]
@@ -236,7 +241,7 @@ fn integration_pyo3_mixed_src_layout() {
 #[cfg_attr(target_os = "macos", ignore)] // Don't run it on macOS, too slow
 fn integration_pyo3_pure_conda() {
     // Only run on GitHub Actions for now
-    if std::env::var("GITHUB_ACTIONS").is_ok() {
+    if env::var("GITHUB_ACTIONS").is_ok() {
         handle_result(integration::test_integration_conda(
             "test-crates/pyo3-mixed",
             None,
@@ -268,24 +273,28 @@ fn integration_cffi_mixed() {
 
 #[test]
 fn integration_uniffi_pure() {
-    handle_result(integration::test_integration(
-        "test-crates/uniffi-pure",
-        None,
-        "integration-uniffi-pure",
-        false,
-        None,
-    ));
+    if env::var("GITHUB_ACTIONS").is_ok() || which("uniffi-bindgen").is_ok() {
+        handle_result(integration::test_integration(
+            "test-crates/uniffi-pure",
+            None,
+            "integration-uniffi-pure",
+            false,
+            None,
+        ));
+    }
 }
 
 #[test]
 fn integration_uniffi_mixed() {
-    handle_result(integration::test_integration(
-        "test-crates/uniffi-mixed",
-        None,
-        "integration-uniffi-mixed",
-        false,
-        None,
-    ));
+    if env::var("GITHUB_ACTIONS").is_ok() || which("uniffi-bindgen").is_ok() {
+        handle_result(integration::test_integration(
+            "test-crates/uniffi-mixed",
+            None,
+            "integration-uniffi-mixed",
+            false,
+            None,
+        ));
+    }
 }
 
 #[test]


### PR DESCRIPTION
`uniffi_bindgen` crate is too heavy weight and people uses `uniffi` usually have already installed uniffi-bindgen.

Part of #1337, reduces `--no-default-features` compile time on M2 MacBook Air from 26.2s to 22.3s.