### PR TITLE
Detect src-layout for pure Rust projects with multiple Python packages

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -926,16 +926,18 @@ impl BuildContext {
             self.excludes(Format::Wheel)?,
         )?;
 
-        if let Some(python_module) = &self.project_layout.python_module {
-            if self.target.is_wasi() {
-                // TODO: Can we have python code and the wasm launchers coexisting
-                // without clashes?
-                bail!("Sorry, adding python code to a wasm binary is currently not supported")
-            }
-            if !self.editable {
-                write_python_part(&mut writer, python_module, self.pyproject_toml.as_ref())
-                    .context("Failed to add the python module to the package")?;
-            }
+        if self.project_layout.python_module.is_some() && self.target.is_wasi() {
+            // TODO: Can we have python code and the wasm launchers coexisting
+            // without clashes?
+            bail!("Sorry, adding python code to a wasm binary is currently not supported")
+        }
+        if !self.editable {
+            write_python_part(
+                &mut writer,
+                &self.project_layout,
+                self.pyproject_toml.as_ref(),
+            )
+            .context("Failed to add the python module to the package")?;
         }
 
         let mut artifacts_ref = Vec::with_capacity(artifacts.len());

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -620,42 +620,38 @@ pub fn source_distribution(
 
     let pyproject_dir = pyproject_toml_path.parent().unwrap();
     // Add python source files
+    let mut python_packages = Vec::new();
     if let Some(python_module) = build_context.project_layout.python_module.as_ref() {
-        let mut python_packages = vec![python_module.to_path_buf()];
-        for package in build_context
-            .pyproject_toml
-            .as_ref()
-            .and_then(|toml| toml.python_packages())
-            .unwrap_or_default()
-        {
-            let package_path = build_context.project_layout.python_dir.join(package);
-            if python_packages.iter().any(|p| *p == package_path) {
+        python_packages.push(python_module.to_path_buf());
+    }
+    for package in &build_context.project_layout.python_packages {
+        let package_path = build_context.project_layout.python_dir.join(package);
+        if python_packages.iter().any(|p| *p == package_path) {
+            continue;
+        }
+        python_packages.push(package_path);
+    }
+
+    for package in python_packages {
+        for entry in ignore::Walk::new(package) {
+            let source = entry?.into_path();
+            // Technically, `ignore` crate should handle this,
+            // but somehow it doesn't on Alpine Linux running in GitHub Actions,
+            // so we do it manually here.
+            // See https://github.com/PyO3/maturin/pull/1187#issuecomment-1273987013
+            if source
+                .extension()
+                .map(|ext| ext == "pyc" || ext == "pyd" || ext == "so")
+                .unwrap_or_default()
+            {
+                debug!("Ignoring {}", source.display());
                 continue;
             }
-            python_packages.push(package_path);
-        }
-
-        for package in python_packages {
-            for entry in ignore::Walk::new(package) {
-                let source = entry?.into_path();
-                // Technically, `ignore` crate should handle this,
-                // but somehow it doesn't on Alpine Linux running in GitHub Actions,
-                // so we do it manually here.
-                // See https://github.com/PyO3/maturin/pull/1187#issuecomment-1273987013
-                if source
-                    .extension()
-                    .map(|ext| ext == "pyc" || ext == "pyd" || ext == "so")
-                    .unwrap_or_default()
-                {
-                    debug!("Ignoring {}", source.display());
-                    continue;
-                }
-                let target = root_dir.join(source.strip_prefix(pyproject_dir).unwrap());
-                if source.is_dir() {
-                    writer.add_directory(target)?;
-                } else {
-                    writer.add_file(target, &source)?;
-                }
+            let target = root_dir.join(source.strip_prefix(pyproject_dir).unwrap());
+            if source.is_dir() {
+                writer.add_directory(target)?;
+            } else {
+                writer.add_file(target, &source)?;
             }
         }
     }


### PR DESCRIPTION
Follow-up of #1378, `python-packages` actually slightly changes the meaning of mixed Rust/Python project layout.