### PR TITLE
Update wasmtime dependency version to 4.0.0

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -130,7 +130,7 @@ fn bin_wasi_helper(
         // Having the wasmtime version hardcoded is not ideal, it's easy enough to overwrite
         metadata21
             .requires_dist
-            .push("wasmtime>=3.0.0,<4.0.0".to_string());
+            .push("wasmtime>=4.0.0,<5.0.0".to_string());
     }
 
     Ok(metadata21)

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -331,7 +331,7 @@ fn integration_with_data() {
 }
 
 #[test]
-// Sourced from https://pypi.org/project/wasmtime/3.0.0/#files
+// Sourced from https://pypi.org/project/wasmtime/4.0.0/#files
 // update with wasmtime updates
 #[cfg(any(
     all(target_os = "windows", target_arch = "x86_64"),


### PR DESCRIPTION
Changes: https://github.com/bytecodealliance/wasmtime-py/compare/3.0.0...4.0.0