### PR TITLE
Don't pass `MACOSX_DEPLOYMENT_TARGET` when query default value from rustc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: [`uniffi_bindgen` CLI](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) is required for building `uniffi` bindings wheels in [#1352](https://github.com/PyO3/maturin/pull/1352)
+* Don't pass `MACOSX_DEPLOYMENT_TARGET` when query default value from rustc in [#1395](https://github.com/PyO3/maturin/pull/1395)
 
 ## [0.14.8] - 2022-12-31
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -767,6 +767,7 @@ pub(crate) fn rustc_macosx_target_version(target: &str) -> (u16, u16) {
             .arg("--target")
             .arg(target)
             .env("RUSTC_BOOTSTRAP", "1")
+            .env_remove("MACOSX_DEPLOYMENT_TARGET")
             .output()
             .context("Failed to run rustc to get the target spec")?;
         let stdout = String::from_utf8(cmd.stdout).context("rustc output is not valid utf-8")?;


### PR DESCRIPTION
Otherwise `rustc` will output the same target version as `MACOSX_DEPLOYMENT_TARGET`.