### PR TITLE
Use module name specified by `[package.metadata.maturin]`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Cargo compile targets configuration for filtering multiple bin targets in [#1339](https://github.com/PyO3/maturin/pull/1339)
 * Respect `rustflags` settings in cargo configuration file in [#1405](https://github.com/PyO3/maturin/pull/1405)
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)
+* Use module name specified by `[package.metadata.maturin]` in [#1409](https://github.com/PyO3/maturin/pull/1409)
 
 ## [0.14.9] - 2023-01-10
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -503,8 +503,9 @@ impl BuildOptions {
 
         if !bridge.is_bin() && module_name.contains('-') {
             bail!(
-                "The module name must not contains a minus \
-                 (Make sure you have set an appropriate [lib] name in your Cargo.toml)"
+                "The module name must not contain a minus `-` \
+                 (Make sure you have set an appropriate [lib] name or \
+                 [package.metadata.maturin] name in your Cargo.toml)"
             );
         }
 

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -128,12 +128,7 @@ impl ProjectResolver {
             .unwrap_or(crate_name)
             .to_owned();
 
-        // Only use extension name from extra metadata if it contains dot
-        let extension_name = extra_metadata
-            .name
-            .as_ref()
-            .filter(|name| name.contains('.'))
-            .unwrap_or(&module_name);
+        let extension_name = extra_metadata.name.as_ref().unwrap_or(&module_name);
 
         let project_root = if pyproject_file.is_file() {
             pyproject_file.parent().unwrap_or(manifest_dir)


### PR DESCRIPTION
Reverts #536

It's counterintuitive and cause trouble when user needs to customize the name, we now emit a better error message when the name isn't appropriate for `lib`.

Helps with https://github.com/charliermarsh/ruff/pull/1816#issuecomment-1380589197