### PR TITLE
Use the extension_name in develop builds

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -964,7 +964,7 @@ pub fn write_uniffi_module(
     let module;
     if let Some(python_module) = &project_layout.python_module {
         if editable {
-            let base_path = python_module.join(module_name);
+            let base_path = python_module.join(&project_layout.extension_name);
             fs::create_dir_all(&base_path)?;
             let target = base_path.join(&cdylib);
             fs::copy(artifact, &target).context(format!(


### PR DESCRIPTION
This is the same now as for non-develop builds.
If a user sets `package.metadata.maturin` the import in other Python files will reference that name.
For develop builds to also work it needs to have the same name.

---

At least in a local build for me this makes it work as expected. Not sure if that breaks others now though.