### PR TITLE
Better error message when `normalize` path failed

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -482,7 +482,16 @@ impl BuildContext {
 
     fn excludes(&self, format: Format) -> Result<Option<Override>> {
         if let Some(pyproject) = self.pyproject_toml.as_ref() {
-            let pyproject_dir = self.pyproject_toml_path.normalize()?.into_path_buf();
+            let pyproject_dir = self
+                .pyproject_toml_path
+                .normalize()
+                .with_context(|| {
+                    format!(
+                        "failed to normalize path `{}`",
+                        self.pyproject_toml_path.display()
+                    )
+                })?
+                .into_path_buf();
             if let Some(glob_patterns) = &pyproject.exclude() {
                 let mut excludes = OverrideBuilder::new(pyproject_dir.parent().unwrap());
                 for glob in glob_patterns

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -296,7 +296,16 @@ impl WheelWriter {
         metadata21: &Metadata21,
     ) -> Result<()> {
         if project_layout.python_module.is_some() || !project_layout.python_packages.is_empty() {
-            let absolute_path = project_layout.python_dir.normalize()?.into_path_buf();
+            let absolute_path = project_layout
+                .python_dir
+                .normalize()
+                .with_context(|| {
+                    format!(
+                        "failed to normalize path `{}`",
+                        project_layout.python_dir.display()
+                    )
+                })?
+                .into_path_buf();
             if let Some(python_path) = absolute_path.to_str() {
                 let name = metadata21.get_distribution_escaped();
                 let target = format!("{name}.pth");

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -208,7 +208,10 @@ impl ProjectResolver {
     ) -> Result<(PathBuf, PathBuf)> {
         // use command line argument if specified
         if let Some(path) = cargo_manifest_path {
-            let path = path.normalize()?.into_path_buf();
+            let path = path
+                .normalize()
+                .with_context(|| format!("failed to normalize path `{}`", path.display()))?
+                .into_path_buf();
             debug!(
                 "Using cargo manifest path from command line argument: {:?}",
                 path
@@ -245,7 +248,12 @@ impl ProjectResolver {
                 PyProjectToml::new(&pyproject_file).context("pyproject.toml is invalid")?;
             if let Some(path) = pyproject.manifest_path() {
                 debug!("Using cargo manifest path from pyproject.toml {:?}", path);
-                return Ok((path.normalize()?.into_path_buf(), pyproject_file));
+                return Ok((
+                    path.normalize()
+                        .with_context(|| format!("failed to normalize path `{}`", path.display()))?
+                        .into_path_buf(),
+                    pyproject_file,
+                ));
             } else {
                 // Detect src layout:
                 //

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -330,7 +330,10 @@ fn add_crate_to_source_distribution(
         .map(Path::new)
         .collect();
 
-    let abs_manifest_path = manifest_path.normalize()?.into_path_buf();
+    let abs_manifest_path = manifest_path
+        .normalize()
+        .with_context(|| format!("failed to normalize path `{}`", manifest_path.display()))?
+        .into_path_buf();
     let abs_manifest_dir = abs_manifest_path.parent().unwrap();
     let pyproject_dir = pyproject_toml_path.parent().unwrap();
     let cargo_toml_in_subdir = root_crate
@@ -510,7 +513,13 @@ pub fn source_distribution(
     let manifest_path = &build_context.manifest_path;
     let pyproject_toml_path = build_context
         .pyproject_toml_path
-        .normalize()?
+        .normalize()
+        .with_context(|| {
+            format!(
+                "failed to normalize path `{}`",
+                build_context.pyproject_toml_path.display()
+            )
+        })?
         .into_path_buf();
     let workspace_manifest_path = build_context
         .cargo_metadata
@@ -586,7 +595,10 @@ pub fn source_distribution(
         true,
     )?;
 
-    let abs_manifest_path = manifest_path.normalize()?.into_path_buf();
+    let abs_manifest_path = manifest_path
+        .normalize()
+        .with_context(|| format!("failed to normalize path `{}`", manifest_path.display()))?
+        .into_path_buf();
     let abs_manifest_dir = abs_manifest_path.parent().unwrap();
     let cargo_lock_path = abs_manifest_dir.join("Cargo.lock");
     let cargo_lock_exists = cargo_lock_path.exists();


### PR DESCRIPTION
Before

```bash
$ maturin sdist -m ~/Desktop/ruff/ruff_cli/Cargo.toml -o dist
💥 maturin failed
  Caused by: No such file or directory (os error 2)
```

After

```bash
$ maturin sdist -m ~/Desktop/ruff/ruff_cli/Cargo.toml -o dist
💥 maturin failed
  Caused by: failed to normalize path `/Users/messense/Desktop/ruff/ruff_cli/Cargo.toml`
  Caused by: No such file or directory (os error 2)
```