### PR TITLE
Keep `dev-dependencies` in sdist when there are no path dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,6 +420,9 @@ jobs:
   test-bootstrap:
     name: Test Bootstrap
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
@@ -439,11 +442,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@beta
         if: steps.changes.outputs.changed == 'true'
       # Caching
-      - name: Cache cargo build
+      - name: Sccache Setup
         if: steps.changes.outputs.changed == 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Xuanwo/sccache-action@c94e27bef21ab3fb4a5152c8a878c53262b4abb0
         with:
-          shared-key: maturin-build
+          version: "v0.4.0-pre.6"
       - uses: actions/setup-python@v4
         if: steps.changes.outputs.changed == 'true'
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -419,7 +419,6 @@ jobs:
 
   test-bootstrap:
     name: Test Bootstrap
-    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
@@ -453,9 +452,8 @@ jobs:
         shell: bash
         run: |
           set -ex
-          pip install build
-          python3 -m build --wheel -o dist
-          pip install dist/maturin*.whl
+          cargo run sdist -o dist
+          pip install -v dist/maturin-*.tar.gz
         if: steps.changes.outputs.changed == 'true'
       - run: maturin --version
         if: steps.changes.outputs.changed == 'true'

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -67,8 +67,10 @@ fn rewrite_cargo_toml(
     // ^^^^^^^^^^^^^ dep_name
     for dep_category in ["dependencies", "dev-dependencies", "build-dependencies"] {
         if let Some(table) = data.get_mut(dep_category).and_then(|x| x.as_table_mut()) {
-            if dep_category == "dev-dependencies" {
-                // Remove dev-dependencies since building from sdist doesn't need them
+            if dep_category == "dev-dependencies" && !known_path_deps.is_empty() {
+                // Remove dev-dependencies since building from sdist doesn't need them,
+                // Keep it when there are no path dependencies to support building from
+                // sdist with `--locked`/`--frozen`.
                 data.remove(dep_category);
                 rewritten = true;
                 continue;


### PR DESCRIPTION
Rewrite `Cargo.toml` without sync with `Cargo.lock` breaks building from sdist with `--locked`/`--frozen`

```
  cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --locked
      Updating crates.io index
       Running `git fetch --force --update-head-ok 'https://github.com/rust-lang/crates.io-index' '+HEAD:refs/remotes/origin/HEAD'`
  error: the lock file /home/conda/feedstock_root/build_artifacts/maturin_1675149830257/work/Cargo.lock needs to be updated but --locked was passed to prevent this
  If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
  error: `cargo build --manifest-path Cargo.toml --message-format=json-render-diagnostics --target x86_64-unknown-linux-gnu --release -v --locked` failed with code 101
  error: subprocess-exited-with-error
```

See https://github.com/conda-forge/maturin-feedstock/pull/84