### PR TITLE
Check path-like interpreter arguments when cross compiling

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -303,6 +303,15 @@ impl BuildOptions {
                         if interpreter.is_empty() && !self.find_interpreter {
                             bail!("Couldn't find any python interpreters. Please specify at least one with -i");
                         }
+                        for interp in interpreter {
+                            // If `-i` looks like a file path, check if it's a valid interpreter
+                            if interp.components().count() > 1
+                                && PythonInterpreter::check_executable(interp, target, bridge)?
+                                    .is_none()
+                            {
+                                bail!("{} is not a valid python interpreter", interp.display());
+                            }
+                        }
                         interpreters =
                             find_interpreter_in_sysconfig(interpreter, target, min_python_minor)?;
                     }


### PR DESCRIPTION
For example: `maturin build -m test-crates/pyo3-mixed/Cargo.toml -i ./python3.10 --target aarch64-unknown-linux-gnu`, where `./python3.10` doesn't exists:

Before

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
💥 maturin failed
  Caused by: Unsupported Python interpreter: /python3.10
```

After

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
💥 maturin failed
  Caused by: /python3.10 is not a valid python interpreter
```

Or it exists but isn't runnable:

Before

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
💥 maturin failed
  Caused by: Unsupported Python interpreter: /Users/messense/Downloads/python/bin/python3.10
```

After

```bash
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
/Users/messense/Downloads/python/bin/python3.10: /Users/messense/Downloads/python/bin/python3.10: cannot execute binary file

💥 maturin failed
  Caused by: Trying to get metadata from the python interpreter '/Users/messense/Downloads/python/bin/python3.10' failed
```

See also https://github.com/PyO3/maturin/issues/1433#issuecomment-1407439600