### PR TITLE
Detect .venv in current or parent folder in maturin develop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: [`uniffi_bindgen` CLI](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) is required for building `uniffi` bindings wheels in [#1352](https://github.com/PyO3/maturin/pull/1352)
+* `maturin develop` now just like `maturin run` also look for a virtualenv .venv in the current or any parent directory if no environment is active.
 * Add Cargo compile targets configuration for filtering multiple bin targets in [#1339](https://github.com/PyO3/maturin/pull/1339)
 * Respect `rustflags` settings in cargo configuration file in [#1405](https://github.com/PyO3/maturin/pull/1405)
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: [`uniffi_bindgen` CLI](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) is required for building `uniffi` bindings wheels in [#1352](https://github.com/PyO3/maturin/pull/1352)
-* `maturin develop` now just like `maturin run` also look for a virtualenv .venv in the current or any parent directory if no environment is active.
+* `maturin develop` now looks for a virtualenv `.venv` in the current or any parent directory if no virtual environment is active.
 * Add Cargo compile targets configuration for filtering multiple bin targets in [#1339](https://github.com/PyO3/maturin/pull/1339)
 * Respect `rustflags` settings in cargo configuration file in [#1405](https://github.com/PyO3/maturin/pull/1405)
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use maturin::{upload_ui, PublishOpt};
 use std::env;
 use std::io;
 use std::path::PathBuf;
+use tracing::debug;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -211,6 +212,52 @@ enum Pep517Command {
     },
 }
 
+fn detect_venv(target: &Target) -> Result<PathBuf> {
+    match (env::var_os("VIRTUAL_ENV"), env::var_os("CONDA_PREFIX")) {
+        (Some(dir), None) => return Ok(PathBuf::from(dir)),
+        (None, Some(dir)) => return Ok(PathBuf::from(dir)),
+        (Some(_), Some(_)) => {
+            bail!("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them")
+        }
+        (None, None) => {
+            // No env var, try finding .venv
+        }
+    };
+
+    let current_dir = env::current_dir().context("Failed to detect current directory ಠ_ಠ")?;
+    // .venv in the current or any parent directory
+    for dir in current_dir.ancestors() {
+        let dot_venv = dir.join(".venv");
+        if dot_venv.is_dir() {
+            if !dot_venv.join("pyvenv.cfg").is_file() {
+                bail!(
+                    "Expected {} to be a virtual environment, but pyvenv.cfg is missing",
+                    dot_venv.display()
+                );
+            }
+            let python = target.get_venv_python(&dot_venv);
+            if !python.is_file() {
+                bail!(
+                    "Your virtualenv at {} is broken. It contains a pyvenv.cfg but no python at {}",
+                    dot_venv.display(),
+                    python.display()
+                );
+            }
+            debug!("Found a virtualenv named .venv at {}", dot_venv.display());
+            return Ok(dot_venv);
+        }
+    }
+
+    bail!(
+        "Couldn't find a virtualenv or conda environment, but you need one to use this command. \
+        For maturin to find your virtualenv you need to either set VIRTUAL_ENV (through activate), \
+        set CONDA_PREFIX (through conda activate) or have a virtualenv called .venv in the current \
+        or any parent folder. \
+        See https://virtualenv.pypa.io/en/latest/index.html on how to use virtualenv or \
+        use `maturin build` and `pip install <path/to/wheel>` instead."
+    )
+}
+
 /// Dispatches into the native implementations of the PEP 517 functions
 ///
 /// The last line of stdout is used as return value from the python part of the implementation
@@ -368,22 +415,8 @@ fn run() -> Result<()> {
             extras,
             cargo_options,
         } => {
-            let venv_dir = match (env::var_os("VIRTUAL_ENV"), env::var_os("CONDA_PREFIX")) {
-                (Some(dir), None) => PathBuf::from(dir),
-                (None, Some(dir)) => PathBuf::from(dir),
-                (Some(_), Some(_)) => {
-                    bail!("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them")
-                }
-                (None, None) => {
-                    bail!(
-                        "You need to be inside a virtualenv or conda environment to use develop \
-                        (neither VIRTUAL_ENV nor CONDA_PREFIX are set). \
-                        See https://virtualenv.pypa.io/en/latest/index.html on how to use virtualenv or \
-                        use `maturin build` and `pip install <path/to/wheel>` instead."
-                    )
-                }
-            };
-
+            let target = Target::from_target_triple(cargo_options.target.clone())?;
+            let venv_dir = detect_venv(&target)?;
             develop(bindings, cargo_options, &venv_dir, release, strip, extras)?;
         }
         Opt::SDist { manifest_path, out } => {


### PR DESCRIPTION
See discussion in #1461

---

`maturin develop` now looks for a virtualenv .venv in the current or any parent directory if no venv or conda environment is active.

---

If someone knows a good `execv` equivalent on windows i'll switch over to that, currently it's a subcommand which is still fine.