### PR TITLE
maturin run, a new subcommand that launches python with the correct venv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "minijinja",
  "multipart",
  "native-tls",
+ "nix 0.26.2",
  "normpath",
  "once_cell",
  "pep440",
@@ -1543,6 +1544,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3197,7 +3210,7 @@ dependencies = [
  "fastrand",
  "futures",
  "nb-connect",
- "nix",
+ "nix 0.22.3",
  "once_cell",
  "polling",
  "scoped-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ ureq = { version = "2.6.1", features = ["gzip", "socks-proxy"], default-features
 native-tls-crate = { package = "native-tls", version = "0.2.8", optional = true }
 keyring = { version = "1.1.1", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.26.2", default-features = false, features = ["process"], optional = true }
+
 [dev-dependencies]
 indoc = "2.0.0"
 pretty_assertions = "1.3.0"
@@ -93,7 +96,7 @@ trycmd = "0.14.11"
 which = "4.3.0"
 
 [features]
-default = ["full", "rustls"]
+default = ["full", "rustls", "maturin-run"]
 
 full = ["cross-compile", "log", "scaffolding", "upload"]
 
@@ -119,6 +122,9 @@ faster-tests = []
 
 # Deprecated features, keep it now for compatibility
 human-panic = []
+
+# Enables the `maturin run` subcommando, which may not work on all platforms
+maturin-run = ["nix"]
 
 # Without this, compressing the .gz archive becomes notably slow for debug builds
 [profile.dev.package.miniz_oxide]

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Turn `patchelf` version warning into a hard error in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: [`uniffi_bindgen` CLI](https://mozilla.github.io/uniffi-rs/tutorial/Prerequisites.html#the-uniffi-bindgen-cli-tool) is required for building `uniffi` bindings wheels in [#1352](https://github.com/PyO3/maturin/pull/1352)
+* `maturin develop` now just like `maturin run` also look for a virtualenv .venv in the current or any parent directory if no environment is active.
 * Add Cargo compile targets configuration for filtering multiple bin targets in [#1339](https://github.com/PyO3/maturin/pull/1339)
 * Respect `rustflags` settings in cargo configuration file in [#1405](https://github.com/PyO3/maturin/pull/1405)
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)
 * Deprecate `--univeral2` in favor of `universal2-apple-darwin` target in [#1457](https://github.com/PyO3/maturin/pull/1457)
 * Raise an error when `Cargo.toml` contains removed python package metadata in [#1471](https://github.com/PyO3/maturin/pull/1471)
+* New subcommand: `maturin run <args>`. Equivalent to `python <args>`, except if neither a virtualenv nor a conda environment are activated, it looks for a virtualenv `.venv` in the current or any parent directory. This is inspired by [PEP 704](https://peps.python.org/pep-0704/). Note that on unix-like platforms this uses `execv` while on windows this uses a subcommand, for other platforms you can deactivate the `maturin-run` feature when building maturin.
 
 ## [0.14.12] - 2023-01-31
 

--- a/deny.toml
+++ b/deny.toml
@@ -187,6 +187,7 @@ skip = [
     { name = "memoffset", version = "0.6.5" },
     { name = "proc-macro-crate", version = "0.1.5" },
     { name = "sha2", version = "0.9.9" },
+    { name = "nix", version = "0.22.3" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use maturin::{upload_ui, PublishOpt};
 use std::env;
 use std::io;
 use std::path::PathBuf;
+use tracing::debug;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -209,6 +210,52 @@ enum Pep517Command {
         /// The path to the Cargo.toml
         manifest_path: Option<PathBuf>,
     },
+}
+
+fn detect_venv(target: &Target) -> Result<PathBuf> {
+    match (env::var_os("VIRTUAL_ENV"), env::var_os("CONDA_PREFIX")) {
+        (Some(dir), None) => return Ok(PathBuf::from(dir)),
+        (None, Some(dir)) => return Ok(PathBuf::from(dir)),
+        (Some(_), Some(_)) => {
+            bail!("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them")
+        }
+        (None, None) => {
+            // No env var, try finding .venv
+        }
+    };
+
+    let current_dir = env::current_dir().context("Failed to detect current directory ಠ_ಠ")?;
+    // .venv in the current or any parent directory
+    for dir in current_dir.ancestors() {
+        let dot_venv = dir.join(".venv");
+        if dot_venv.is_dir() {
+            if !dot_venv.join("pyvenv.cfg").is_file() {
+                bail!(
+                    "Expected {} to be a virtual environment, but pyvenv.cfg is missing",
+                    dot_venv.display()
+                );
+            }
+            let python = target.get_venv_python(&dot_venv);
+            if !python.is_file() {
+                bail!(
+                    "Your virtualenv at {} is broken. It contains a pyvenv.cfg but no python at {}",
+                    dot_venv.display(),
+                    python.display()
+                );
+            }
+            debug!("Found a virtualenv named .venv at {}", dot_venv.display());
+            return Ok(dot_venv);
+        }
+    }
+
+    bail!(
+        "Couldn't find a virtualenv or conda environment, but you need one to use this command. \
+        For maturin to find your virtualenv you need to either set VIRTUAL_ENV (through activate), \
+        set CONDA_PREFIX (through conda activate) or have a virtualenv called .venv in the current \
+        or any parent folder. \
+        See https://virtualenv.pypa.io/en/latest/index.html on how to use virtualenv or \
+        use `maturin build` and `pip install <path/to/wheel>` instead."
+    )
 }
 
 /// Dispatches into the native implementations of the PEP 517 functions

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -613,3 +613,13 @@ fn pyo3_source_date_epoch() {
         "pyo3_source_date_epoch",
     ))
 }
+
+#[test]
+fn maturin_run() {
+    handle_result(other::maturin_run())
+}
+
+#[test]
+fn maturin_run_error() {
+    handle_result(other::maturin_run_error())
+}


### PR DESCRIPTION
Based on #1462.

I don't think this needs to build project before running, it's effectively just `python <args>` except it picks the right `python` by default.