### PR TITLE
Use extension_name instead of module_name for CFFI extensions in develop mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)
 * Deprecate `--univeral2` in favor of `universal2-apple-darwin` target in [#1457](https://github.com/PyO3/maturin/pull/1457)
 * Raise an error when `Cargo.toml` contains removed python package metadata in [#1471](https://github.com/PyO3/maturin/pull/1471)
+* Use `extension_name` instead of `module_name` for CFFI extensions in develop mode in [#1476](https://github.com/PyO3/maturin/pull/1476)
 
 ## [0.14.12] - 2023-01-31
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -807,7 +807,7 @@ pub fn write_cffi_module(
     let module;
     if let Some(python_module) = &project_layout.python_module {
         if editable {
-            let base_path = python_module.join(module_name);
+            let base_path = python_module.join(&project_layout.extension_name);
             fs::create_dir_all(&base_path)?;
             let target = base_path.join("native.so");
             fs::copy(artifact, &target).context(format!(


### PR DESCRIPTION
I noticed when running `maturin develop` with [sourmash](https://github.com/sourmash-bio/sourmash) that the CFFI extension ended in `src/sourmash/sourmash` instead of the expected `src/sourmash/_lowlevel.py` (to match the [`[package.maturin.metadata.name]`](https://github.com/sourmash-bio/sourmash/blob/fa3ead658e189cfb196c1ee0c5ffd2047c23af70/src/core/Cargo.toml#L95L96) field).
`maturin build` puts the extension in the right place, so checking how it worked I noticed that changing the line from this PR would make the behavior match in `develop` and `build`.

(and now I'm opening a PR to see if I missed some test and I'm breaking other use cases 😬 )