### PR TITLE
Add support for custom TLS certificate authority bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,8 @@ dependencies = [
  "python-pkginfo",
  "regex",
  "rustc_version",
+ "rustls",
+ "rustls-pemfile",
  "rustversion",
  "semver",
  "serde",
@@ -2170,6 +2172,15 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,9 @@ bytesize = { version = "1.0.1", optional = true }
 configparser = { version = "3.0.0", optional = true }
 multipart = { version = "0.18.0", features = ["client"], default-features = false, optional = true }
 ureq = { version = "2.6.1", features = ["gzip", "socks-proxy"], default-features = false, optional = true }
-native-tls-crate = { package = "native-tls", version = "0.2.8", optional = true }
+native-tls = { version = "0.2.8", optional = true }
+rustls = { version = "0.20.8", optional = true }
+rustls-pemfile = { version = "1.0.1", optional = true }
 keyring = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
@@ -105,8 +107,8 @@ upload = ["ureq", "multipart", "configparser", "bytesize", "dialoguer/password"]
 # keyring doesn't support *BSD so it's not enabled in `full` by default
 password-storage = ["upload", "keyring"]
 
-rustls = ["ureq/tls", "cargo-xwin/rustls-tls"]
-native-tls = ["ureq/native-tls", "native-tls-crate", "cargo-xwin/native-tls"]
+rustls = ["dep:rustls", "ureq?/tls", "cargo-xwin?/rustls-tls", "dep:rustls-pemfile"]
+native-tls = ["dep:native-tls", "ureq?/native-tls", "cargo-xwin?/native-tls", "dep:rustls-pemfile"]
 
 # cross compile using zig or xwin
 cross-compile = ["zig", "xwin"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Respect `rustflags` settings in cargo configuration file in [#1405](https://github.com/PyO3/maturin/pull/1405)
 * Bump MSRV to 1.63.0 in [#1407](https://github.com/PyO3/maturin/pull/1407)
 * Add support for uniffi 0.23 in [#1481](https://github.com/PyO3/maturin/pull/1481)
+* Add support for custom TLS certificate authority bundle in [#1483](https://github.com/PyO3/maturin/pull/1483)
 * Add support for Emscripten in `generate-ci` command in [#1484](https://github.com/PyO3/maturin/pull/1484)
 
 ## [0.14.13] - 2023-02-12


### PR DESCRIPTION
Custom TLS CA can be configured via one of the `MATURIN_CA_BUNDLE`, `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` env vars.

Closes #1418