### PR TITLE
Use default `ext_suffix` for Emscripten target if not provided in `PYO3_CONFIG_FILE`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for custom TLS certificate authority bundle in [#1483](https://github.com/PyO3/maturin/pull/1483)
 * Add support for Emscripten in `generate-ci` command in [#1484](https://github.com/PyO3/maturin/pull/1484)
 * Add support for linking with pyo3 in abi3 debug mode on Windows in [#1487](https://github.com/PyO3/maturin/pull/1487)
+* Use default `ext_suffix` for Emscripten target if not provided in `PYO3_CONFIG_FILE` in [#1491](https://github.com/PyO3/maturin/pull/1491)
 
 ## [0.14.13] - 2023-02-12
 

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -198,6 +198,16 @@ impl InterpreterConfig {
                     )
                 }),
             }
+        } else if target.is_emscripten() && matches!(interpreter_kind, InterpreterKind::CPython) {
+            ext_suffix.unwrap_or_else(|| {
+                format!(
+                    ".cpython-{}-{}-{}.{}",
+                    abi_tag,
+                    target.get_python_arch(),
+                    target.get_python_os(),
+                    file_ext
+                )
+            })
         } else {
             ext_suffix.context("missing value for ext_suffix")?
         };

--- a/src/target.rs
+++ b/src/target.rs
@@ -330,12 +330,7 @@ impl Target {
             }
             // Emscripten
             (Os::Emscripten, Arch::Wasm32) => {
-                let os_version = env::var("MATURIN_EMSCRIPTEN_VERSION");
-                let release = match os_version {
-                    Ok(os_ver) => os_ver,
-                    Err(_) => emcc_version()?,
-                };
-                let release = release.replace(['.', '-'], "_");
+                let release = emscripten_version()?.replace(['.', '-'], "_");
                 format!("emscripten_{release}_wasm32")
             }
             (Os::Wasi, Arch::Wasm32) => {
@@ -781,6 +776,16 @@ pub(crate) fn rustc_macosx_target_version(target: &str) -> (u16, u16) {
         Ok((major, minor))
     };
     rustc_target_version().unwrap_or(fallback_version)
+}
+
+/// Emscripten version
+fn emscripten_version() -> Result<String> {
+    let os_version = env::var("MATURIN_EMSCRIPTEN_VERSION");
+    let release = match os_version {
+        Ok(os_ver) => os_ver,
+        Err(_) => emcc_version()?,
+    };
+    Ok(release)
 }
 
 fn emcc_version() -> Result<String> {


### PR DESCRIPTION
See https://github.com/pyodide/pyodide/pull/3590#issuecomment-1433888133