### PR TITLE
Move maturin metadata from `Cargo.toml` to `pyproject.toml`

### DIFF
--- a/guide/src/project_layout.md
+++ b/guide/src/project_layout.md
@@ -127,11 +127,13 @@ my-rust-and-python-project
 ```
 #### Import Rust as a submodule of your project
 
-If the Python module created by Rust has the same name as the Python package in a mixed Rust/Python project, IDEs might get confused. You might also want to discourage end users from using the Rust functions directly by giving it a different name, say '\_my_project'. This can be done by adding `name = <package name>.<rust pymodule name>` to the `[package.metadata.maturin]` in your `Cargo.toml`. For example:
+If the Python module created by Rust has the same name as the Python package in a mixed Rust/Python project, IDEs might get confused.
+You might also want to discourage end users from using the Rust functions directly by giving it a different name, say '\_my_project'.
+This can be done by adding `module-name = <package name>.<rust pymodule name>` to the `[tool.maturin]` in your `pyproject.toml`. For example:
 
 ```toml
-[package.metadata.maturin]
-name = "my_project._my_project"
+[tool.maturin]
+module-name = "my_project._my_project"
 ```
 
 You can then import your Rust module inside your Python source as follows:

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -664,9 +664,9 @@ impl BuildOptions {
             .clone()
             .unwrap_or_else(|| cargo_metadata.target_directory.clone().into_std_path_buf());
 
-        let remaining_core_metadata = cargo_toml.remaining_core_metadata();
-        let config_targets = remaining_core_metadata.targets.as_deref();
-        let cargo_targets = filter_cargo_targets(&cargo_metadata, bridge, config_targets)?;
+        let config_targets = pyproject.and_then(|x| x.targets());
+        let cargo_targets =
+            filter_cargo_targets(&cargo_metadata, bridge, config_targets.as_deref())?;
 
         let crate_name = cargo_toml.package.name;
         Ok(BuildContext {
@@ -747,7 +747,7 @@ fn validate_bridge_type(
 fn filter_cargo_targets(
     cargo_metadata: &Metadata,
     bridge: BridgeModel,
-    config_targets: Option<&[crate::cargo_toml::CargoTarget]>,
+    config_targets: Option<&[crate::pyproject_toml::CargoTarget]>,
 ) -> Result<Vec<CompileTarget>> {
     let root_pkg = cargo_metadata.root_package().unwrap();
     let resolved_features = cargo_metadata

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -516,7 +516,7 @@ impl BuildOptions {
             bail!(
                 "The module name must not contain a minus `-` \
                  (Make sure you have set an appropriate [lib] name or \
-                 [package.metadata.maturin] name in your Cargo.toml)"
+                 [tool.maturin] module-name in your pyproject.toml)"
             );
         }
 
@@ -1497,18 +1497,14 @@ mod test {
 
     #[test]
     fn test_get_min_python_minor() {
-        use crate::CargoToml;
-
         // Nothing specified
         let manifest_path = "test-crates/pyo3-pure/Cargo.toml";
-        let cargo_toml = CargoToml::from_path(manifest_path).unwrap();
         let cargo_metadata = MetadataCommand::new()
             .manifest_path(manifest_path)
             .exec()
             .unwrap();
         let metadata21 =
-            Metadata21::from_cargo_toml(&cargo_toml, "test-crates/pyo3-pure", &cargo_metadata)
-                .unwrap();
+            Metadata21::from_cargo_toml("test-crates/pyo3-pure", &cargo_metadata).unwrap();
         assert_eq!(get_min_python_minor(&metadata21), None);
     }
 }

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -64,6 +64,7 @@ impl CargoToml {
                 "scripts",
                 "classifiers",
                 "classifier",
+                "data",
                 "maintainer",
                 "maintainer-email",
                 "requires-dist",
@@ -102,8 +103,6 @@ struct CargoTomlMetadata {
 #[serde(rename_all = "kebab-case")]
 pub struct RemainingCoreMetadata {
     pub name: Option<String>,
-    /// The directory containing the wheel data
-    pub data: Option<String>,
     /// Cargo compile targets
     pub targets: Option<Vec<CargoTarget>>,
     #[serde(flatten)]

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -102,23 +102,8 @@ struct CargoTomlMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct RemainingCoreMetadata {
-    /// Cargo compile targets
-    pub targets: Option<Vec<CargoTarget>>,
     #[serde(flatten)]
     pub other: HashMap<String, toml::Value>,
-}
-
-/// Cargo compile target
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "kebab-case")]
-pub struct CargoTarget {
-    /// Name as given in the `Cargo.toml` or generated from the file name
-    pub name: String,
-    /// Kind of target ("bin", "lib")
-    pub kind: Option<String>,
-    // TODO: Add bindings option
-    // Bridge model, which kind of bindings to use
-    // pub bindings: Option<String>,
 }
 
 #[cfg(test)]
@@ -158,10 +143,6 @@ mod test {
 
         let cargo_toml: Result<CargoToml, _> = toml::from_str(cargo_toml);
         assert!(cargo_toml.is_ok());
-
-        let maturin = cargo_toml.unwrap().remaining_core_metadata();
-        let targets = maturin.targets.unwrap();
-        assert_eq!("pyo3_pure", targets[0].name);
     }
 
     #[test]

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -102,7 +102,6 @@ struct CargoTomlMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct RemainingCoreMetadata {
-    pub name: Option<String>,
     /// Cargo compile targets
     pub targets: Option<Vec<CargoTarget>>,
     #[serde(flatten)]

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -168,23 +168,13 @@ impl ProjectResolver {
                 None => project_root.to_path_buf(),
             },
         };
-        let data = match pyproject.and_then(|x| x.data()) {
-            Some(data) => {
-                if data.is_absolute() {
-                    Some(data.to_path_buf())
-                } else {
-                    Some(project_root.join(data))
-                }
+        let data = pyproject.and_then(|x| x.data()).map(|data| {
+            if data.is_absolute() {
+                data.to_path_buf()
+            } else {
+                project_root.join(data)
             }
-            None => extra_metadata.data.as_ref().map(|data| {
-                let data = Path::new(data);
-                if data.is_absolute() {
-                    data.to_path_buf()
-                } else {
-                    manifest_dir.join(data)
-                }
-            }),
-        };
+        });
         let project_layout =
             ProjectLayout::determine(project_root, extension_name, py_root, python_packages, data)?;
         Ok(Self {

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -108,14 +108,12 @@ impl ProjectResolver {
 
         let cargo_metadata = Self::resolve_cargo_metadata(&manifest_file, &cargo_options)?;
 
-        let mut metadata21 =
-            Metadata21::from_cargo_toml(&cargo_toml, manifest_dir, &cargo_metadata)
-                .context("Failed to parse Cargo.toml into python metadata")?;
+        let mut metadata21 = Metadata21::from_cargo_toml(manifest_dir, &cargo_metadata)
+            .context("Failed to parse Cargo.toml into python metadata")?;
         if let Some(pyproject) = pyproject {
             let pyproject_dir = pyproject_file.parent().unwrap();
             metadata21.merge_pyproject_toml(pyproject_dir, pyproject)?;
         }
-        let extra_metadata = cargo_toml.remaining_core_metadata();
 
         let crate_name = &cargo_toml.package.name;
 
@@ -128,7 +126,7 @@ impl ProjectResolver {
             .unwrap_or(crate_name)
             .to_owned();
 
-        let extension_name = extra_metadata.name.as_ref().unwrap_or(&module_name);
+        let extension_name = pyproject.and_then(|x| x.name()).unwrap_or(&module_name);
 
         let project_root = if pyproject_file.is_file() {
             pyproject_file.parent().unwrap_or(manifest_dir)

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -86,6 +86,8 @@ impl GlobPattern {
 #[serde(rename_all = "kebab-case")]
 pub struct ToolMaturin {
     // maturin specific options
+    // extension module name, accepts setuptools style import name like `foo.bar`
+    module_name: Option<String>,
     include: Option<Vec<GlobPattern>>,
     exclude: Option<Vec<GlobPattern>>,
     bindings: Option<String>,
@@ -168,6 +170,11 @@ impl PyProjectToml {
     #[inline]
     pub fn maturin(&self) -> Option<&ToolMaturin> {
         self.tool.as_ref()?.maturin.as_ref()
+    }
+
+    /// Returns the value of `[tool.maturin.name]` in pyproject.toml
+    pub fn name(&self) -> Option<&str> {
+        self.maturin()?.module_name.as_deref()
     }
 
     /// Returns the value of `[tool.maturin.include]` in pyproject.toml

--- a/test-crates/hello-world/Cargo.toml
+++ b/test-crates/hello-world/Cargo.toml
@@ -8,10 +8,3 @@ readme = "../../README.md"
 default-run = "hello-world"
 
 [dependencies]
-
-[[package.metadata.maturin.targets]]
-name = "hello-world"
-bindings = "bin"
-
-[[package.metadata.maturin.targets]]
-name = "foo"

--- a/test-crates/hello-world/pyproject.toml
+++ b/test-crates/hello-world/pyproject.toml
@@ -4,3 +4,10 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "bin"
+
+[[tool.maturin.targets]]
+name = "hello-world"
+bindings = "bin"
+
+[[tool.maturin.targets]]
+name = "foo"

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -12,6 +12,3 @@ pyo3 = { version = "0.18.0", features = ["extension-module"] }
 [lib]
 name = "pyo3_mixed_py_subdir"
 crate-type = ["cdylib"]
-
-[package.metadata.maturin]
-name = "pyo3_mixed_py_subdir._pyo3_mixed"

--- a/test-crates/pyo3-mixed-py-subdir/pyproject.toml
+++ b/test-crates/pyo3-mixed-py-subdir/pyproject.toml
@@ -14,4 +14,5 @@ requires-python = ">=3.6"
 get_42 = "pyo3_mixed_py_subdir:get_42"
 
 [tool.maturin]
+module-name = "pyo3_mixed_py_subdir._pyo3_mixed"
 python-source = "python"

--- a/test-crates/pyo3-mixed-submodule/Cargo.toml
+++ b/test-crates/pyo3-mixed-submodule/Cargo.toml
@@ -6,9 +6,6 @@ description = "Implements a dummy function combining rust and python"
 readme = "README.md"
 edition = "2021"
 
-[package.metadata.maturin]
-name = "pyo3_mixed_submodule.rust_module.rust"
-
 [dependencies]
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 

--- a/test-crates/pyo3-mixed-submodule/pyproject.toml
+++ b/test-crates/pyo3-mixed-submodule/pyproject.toml
@@ -8,3 +8,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Rust"
 ]
+
+[tool.maturin]
+module-name = "pyo3_mixed_submodule.rust_module.rust"


### PR DESCRIPTION
Implements https://github.com/PyO3/maturin/issues/1489#issuecomment-1432975142