### PR TITLE
Fix installation message for uniffi-bindgen

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -921,7 +921,7 @@ fn generate_uniffi_bindings(
     cmd.arg(udl);
     debug!("Running {:?}", cmd);
     let mut child = cmd.spawn().context(
-        "Failed to run uniffi-bindgen, did you install it? Try `cargo install uniffi_bindgen`",
+        "Failed to run uniffi-bindgen, did you install it? Try `pip install uniffi-bindgen`",
     )?;
     let exit_status = child.wait().context("Failed to run uniffi-bindgen")?;
     if !exit_status.success() {


### PR DESCRIPTION
The docs recommend installing uniffi-bindgen via pip (https://github.com/PyO3/maturin/blob/main/guide/src/bindings.md#uniffi), since it's no longer available as a Cargo binary anymore (https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#migrating-to-uniffi-023).
