### PR TITLE
Fix module name when it's specified in `package.metadata.maturin.name`

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -532,7 +532,6 @@ impl BuildContext {
         write_bindings_module(
             &mut writer,
             &self.project_layout,
-            &self.module_name,
             &artifact.path,
             self.interpreter.first(),
             true,
@@ -611,7 +610,6 @@ impl BuildContext {
         write_bindings_module(
             &mut writer,
             &self.project_layout,
-            &self.module_name,
             &artifact.path,
             Some(python_interpreter),
             false,


### PR DESCRIPTION
Fixes #1520 