### PR TITLE
Only check for minus in extension name

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -512,7 +512,7 @@ impl BuildOptions {
             }),
         )?;
 
-        if !bridge.is_bin() && module_name.contains('-') {
+        if !bridge.is_bin() && project_layout.extension_name.contains('-') {
             bail!(
                 "The module name must not contain a minus `-` \
                  (Make sure you have set an appropriate [lib] name or \


### PR DESCRIPTION
If user already set a correct `[package.metadata.maturin.name]`, we don't care whether the `[lib.name]` contains minus or not.