### PR TITLE
0.14: Deprecate `package.metadata.maturin.name` in favor of `tool.maturin.module-name` in `pyproject.toml`

### DIFF
--- a/guide/src/project_layout.md
+++ b/guide/src/project_layout.md
@@ -105,11 +105,13 @@ my-rust-and-python-project
 ```
 #### Import Rust as a submodule of your project
 
-If the Python module created by Rust has the same name as the Python package in a mixed Rust/Python project, IDEs might get confused. You might also want to discourage end users from using the Rust functions directly by giving it a different name, say '\_my_project'. This can be done by adding `name = <package name>.<rust pymodule name>` to the `[package.metadata.maturin]` in your `Cargo.toml`. For example:
+If the Python module created by Rust has the same name as the Python package in a mixed Rust/Python project, IDEs might get confused.
+You might also want to discourage end users from using the Rust functions directly by giving it a different name, say '\_my_project'.
+This can be done by adding `module-name = <package name>.<rust pymodule name>` to the `[tool.maturin]` in your `pyproject.toml`. For example:
 
 ```toml
-[package.metadata.maturin]
-name = "my_project._my_project"
+[tool.maturin]
+module-name = "my_project._my_project"
 ```
 
 You can then import your Rust module inside your Python source as follows:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# maturin is self bootstraping, however on platforms like alpine linux that aren't
+# maturin is self bootstrapping, however on platforms like alpine linux that aren't
 # manylinux, pip will try installing maturin from the source distribution.
 # That source distribution obviously can't depend on maturin, so we're using
 # the always available setuptools.

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -514,7 +514,7 @@ impl BuildOptions {
             bail!(
                 "The module name must not contain a minus `-` \
                  (Make sure you have set an appropriate [lib] name or \
-                 [package.metadata.maturin] name in your Cargo.toml)"
+                 [tool.maturin] module-name in your pyproject.toml)"
             );
         }
 

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -86,6 +86,8 @@ impl GlobPattern {
 #[serde(rename_all = "kebab-case")]
 pub struct ToolMaturin {
     // maturin specific options
+    // extension module name, accepts setuptools style import name like `foo.bar`
+    module_name: Option<String>,
     // TODO(0.15.0): remove deprecated
     sdist_include: Option<Vec<String>>,
     include: Option<Vec<GlobPattern>>,
@@ -170,6 +172,11 @@ impl PyProjectToml {
     #[inline]
     pub fn maturin(&self) -> Option<&ToolMaturin> {
         self.tool.as_ref()?.maturin.as_ref()
+    }
+
+    /// Returns the value of `[tool.maturin.module-name]` in pyproject.toml
+    pub fn module_name(&self) -> Option<&str> {
+        self.maturin()?.module_name.as_deref()
     }
 
     /// Returns the value of `[tool.maturin.sdist-include]` in pyproject.toml

--- a/test-crates/pyo3-mixed-py-subdir/Cargo.toml
+++ b/test-crates/pyo3-mixed-py-subdir/Cargo.toml
@@ -12,6 +12,3 @@ pyo3 = { version = "0.18.0", features = ["extension-module"] }
 [lib]
 name = "pyo3_mixed_py_subdir"
 crate-type = ["cdylib"]
-
-[package.metadata.maturin]
-name = "pyo3_mixed_py_subdir._pyo3_mixed"

--- a/test-crates/pyo3-mixed-py-subdir/pyproject.toml
+++ b/test-crates/pyo3-mixed-py-subdir/pyproject.toml
@@ -14,4 +14,5 @@ requires-python = ">=3.6"
 get_42 = "pyo3_mixed_py_subdir:get_42"
 
 [tool.maturin]
+module-name = "pyo3_mixed_py_subdir._pyo3_mixed"
 python-source = "python"

--- a/test-crates/pyo3-mixed-submodule/Cargo.toml
+++ b/test-crates/pyo3-mixed-submodule/Cargo.toml
@@ -6,9 +6,6 @@ description = "Implements a dummy function combining rust and python"
 readme = "README.md"
 edition = "2021"
 
-[package.metadata.maturin]
-name = "pyo3_mixed_submodule.rust_module.rust"
-
 [dependencies]
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 

--- a/test-crates/pyo3-mixed-submodule/pyproject.toml
+++ b/test-crates/pyo3-mixed-submodule/pyproject.toml
@@ -8,3 +8,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Rust"
 ]
+
+[tool.maturin]
+module-name = "pyo3_mixed_submodule.rust_module.rust"


### PR DESCRIPTION
See #1493