### PR TITLE
Add wildcards support to publish/upload commands on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "trycmd",
  "ureq",
  "which",
+ "wild",
  "zip",
 ]
 
@@ -2472,6 +2473,15 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ native-tls = { version = "0.2.8", optional = true }
 rustls = { version = "0.20.8", optional = true }
 rustls-pemfile = { version = "1.0.1", optional = true }
 keyring = { version = "2.0.0", default-features = false, features = ["linux-no-secret-service"], optional = true }
+wild = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 indoc = "2.0.0"
@@ -103,7 +104,7 @@ log = ["tracing-subscriber"]
 
 cli-completion = ["dep:clap_complete_command"]
 
-upload = ["ureq", "multipart", "configparser", "bytesize", "dialoguer/password"]
+upload = ["ureq", "multipart", "configparser", "bytesize", "dialoguer/password", "wild"]
 # keyring doesn't support *BSD so it's not enabled in `full` by default
 password-storage = ["upload", "keyring"]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for uniffi 0.23 in [#1481](https://github.com/PyO3/maturin/pull/1481)
 * Add support for custom TLS certificate authority bundle in [#1483](https://github.com/PyO3/maturin/pull/1483)
 * Bump MSRV to 1.64.0 in [#1528](https://github.com/PyO3/maturin/pull/1528)
+* Add wildcards support to publish/upload commands on Windows in [#1534](https://github.com/PyO3/maturin/pull/1534)
 
 ## [0.14.16] - 2023-03-26
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,10 @@ fn run() -> Result<()> {
         }
     }
 
+    #[cfg(not(feature = "wild"))]
     let opt = Opt::parse();
+    #[cfg(feature = "wild")]
+    let opt = Opt::parse_from(wild::args_os());
 
     match opt {
         Opt::Build {


### PR DESCRIPTION
So that `maturin upload dist/*.whl` works on Windows.

https://docs.rs/wild/latest/wild/