### PR TITLE
Use pep440_rs and pep508_rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,8 @@ dependencies = [
  "native-tls",
  "normpath",
  "once_cell",
- "pep440",
+ "pep440_rs",
+ "pep508_rs",
  "platform-info",
  "pretty_assertions",
  "pyproject-toml",
@@ -1353,13 +1354,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
-name = "pep440"
-version = "0.2.0"
+name = "pep440_rs"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8841b00ca6fabc903e8ecd496d9611db402e23f15e3d19b0b587e2ca653abd89"
+checksum = "d0cbf1fd438eeb1b1e42e8390951ec90d1cf87bbe3d3305b28551bca30b7595a"
 dependencies = [
  "lazy_static",
  "regex",
+ "serde",
+ "tracing",
+ "unicode-width",
+]
+
+[[package]]
+name = "pep508_rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e566191336ac8cf72db45240583769ab9fb75bd87dd9544cd96a9bc7e28585c4"
+dependencies = [
+ "once_cell",
+ "pep440_rs",
+ "regex",
+ "serde",
+ "thiserror",
+ "tracing",
+ "unicode-width",
+ "url",
 ]
 
 [[package]]
@@ -1464,11 +1484,13 @@ dependencies = [
 
 [[package]]
 name = "pyproject-toml"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f42b59c8c31880743982eefb884d364e825ea4349a937ed138f23919dd414e6"
+checksum = "71c24ad9fa3f11e0b5f45bf86ea6e1ae4dfef288fb7b077a15b6a19ebc87a37f"
 dependencies = [
  "indexmap",
+ "pep440_rs",
+ "pep508_rs",
  "serde",
  "toml 0.7.3",
 ]
@@ -2130,6 +2152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2310,6 +2333,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rustc_version = "0.4.0"
 semver = "1.0.13"
 target-lexicon = "0.12.0"
 indexmap = "1.9.3"
-pyproject-toml = "0.4.0"
+pyproject-toml = "0.5.1"
 python-pkginfo = "0.5.5"
 textwrap = "0.16.0"
 ignore = "0.4.20"
@@ -57,7 +57,8 @@ lddtree = "0.3.2"
 cc = "1.0.72"
 dunce = "1.0.2"
 normpath = "1.0.0"
-pep440 = "0.2.0"
+pep440_rs = { version = "0.3.3", features = ["serde"] }
+pep508_rs = { version = "0.1.1", features = ["serde"] }
 time = "0.3.17"
 
 # cli

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -21,6 +21,7 @@ use ignore::overrides::{Override, OverrideBuilder};
 use indexmap::IndexMap;
 use lddtree::Library;
 use normpath::PathExt;
+use pep508_rs::Requirement;
 use platform_info::*;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -29,7 +30,6 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use pep508_rs::Requirement;
 
 /// The way the rust code is used in the wheel
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -893,7 +893,8 @@ impl BuildContext {
         if !self
             .metadata21
             .requires_dist
-            .iter().any(|requirement| requirement.name == "cffi")
+            .iter()
+            .any(|requirement| requirement.name == "cffi")
         {
             eprintln!(
                 "⚠️  Warning: missing cffi package dependency, please add it to pyproject.toml. \

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -22,13 +22,14 @@ use indexmap::IndexMap;
 use lddtree::Library;
 use normpath::PathExt;
 use platform_info::*;
-use regex::Regex;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use pep508_rs::Requirement;
 
 /// The way the rust code is used in the wheel
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -123,18 +124,16 @@ fn bin_wasi_helper(
         .entry_points
         .insert("console_scripts".to_string(), console_scripts);
 
-    // A real pip version specification parser would be better, but bearing this we use this regex
-    // which tries to find the name wasmtime and then any specification
-    let wasmtime_re = Regex::new("^wasmtime[^a-zA-Z.-_]").unwrap();
+    // Add our wasmtime default version if the user didn't provide one
     if !metadata21
         .requires_dist
         .iter()
-        .any(|requirement| wasmtime_re.is_match(requirement))
+        .any(|requirement| requirement.name == "wasmtime")
     {
         // Having the wasmtime version hardcoded is not ideal, it's easy enough to overwrite
         metadata21
             .requires_dist
-            .push("wasmtime>=7.0.0,<8.0.0".to_string());
+            .push(Requirement::from_str("wasmtime>=7.0.0,<8.0.0").unwrap());
     }
 
     Ok(metadata21)
@@ -894,8 +893,7 @@ impl BuildContext {
         if !self
             .metadata21
             .requires_dist
-            .iter()
-            .any(|dep| dep.to_ascii_lowercase().starts_with("cffi"))
+            .iter().any(|requirement| requirement.name == "cffi")
         {
             eprintln!(
                 "⚠️  Warning: missing cffi package dependency, please add it to pyproject.toml. \

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1273,13 +1273,14 @@ pub fn add_data(writer: &mut impl ModuleWriter, data: Option<&Path>) -> Result<(
 #[cfg(test)]
 mod tests {
     use ignore::overrides::OverrideBuilder;
+    use pep440_rs::Version;
 
     use super::*;
 
     #[test]
     // The mechanism is the same for wheel_writer
     fn sdist_writer_excludes() -> Result<(), Box<dyn std::error::Error>> {
-        let metadata = Metadata21::default();
+        let metadata = Metadata21::new("dummy".to_string(), Version::from_release(vec![1, 0]));
         let perm = 0o777;
 
         // No excludes

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -283,10 +283,10 @@ impl PyProjectToml {
             .build_system
             .requires
             .iter()
-            .find(|x| x.starts_with(maturin))
+            .find(|x| x.name == maturin)
         {
             let current_major: usize = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
-            if requires_maturin == maturin {
+            if requires_maturin.version_or_url.is_none() {
                 eprintln!(
                     "⚠️  Warning: Please use {maturin} in pyproject.toml with a version constraint, \
                     e.g. `requires = [\"{maturin}>={current}.0,<{next}.0\"]`. \


### PR DESCRIPTION
This switches from string heuristics to proper PEP 440 and PEP 508 parsing. This includes full support for `requires-python`, extra handling and wasmtime detection.