### PR TITLE
Fix wrong `EXT_SUFFIX` when cross compiling musllinux wheels for Python 3.11

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump MSRV to 1.64.0 in [#1528](https://github.com/PyO3/maturin/pull/1528)
 * Add wildcards support to publish/upload commands on Windows in [#1534](https://github.com/PyO3/maturin/pull/1534)
 * Add support for configuring macOS deployment target version in `pyproject.toml` in [#1536](https://github.com/PyO3/maturin/pull/1536)
+* Fix wrong `EXT_SUFFIX` when cross compiling musllinux wheels for Python 3.11 in [#1560](https://github.com/PyO3/maturin/pull/1560)
 
 ## [0.14.16] - 2023-03-26
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1149,15 +1149,10 @@ fn find_interpreter_in_sysconfig(
         let ver_minor = ver_minor.parse::<usize>().with_context(|| {
             format!("Invalid python interpreter minor version '{ver_minor}', expect a digit")
         })?;
-        let sysconfig = InterpreterConfig::lookup(
-            target.target_os(),
-            target.target_arch(),
-            python_impl,
-            (ver_major, ver_minor),
-        )
-        .with_context(|| {
-            format!("Failed to find a {python_impl} {ver_major}.{ver_minor} interpreter")
-        })?;
+        let sysconfig = InterpreterConfig::lookup(target, python_impl, (ver_major, ver_minor))
+            .with_context(|| {
+                format!("Failed to find a {python_impl} {ver_major}.{ver_minor} interpreter")
+            })?;
         debug!(
             "Found {} {}.{} in bundled sysconfig",
             sysconfig.interpreter_kind, sysconfig.major, sysconfig.minor,


### PR DESCRIPTION
Fixes #1559 