### PR TITLE
Document binary and library in a single package by entrypoint workaround

### DIFF
--- a/test-crates/pyo3-mixed/check_installed/check_installed.py
+++ b/test-crates/pyo3-mixed/check_installed/check_installed.py
@@ -1,9 +1,45 @@
 #!/usr/bin/env python3
+import json
+import platform
+import sys
+from pathlib import Path
+from subprocess import check_output
 
 from boltons.strutils import slugify
+
 import pyo3_mixed
 
 assert pyo3_mixed.get_42() == 42
 assert slugify("First post! Hi!!!!~1    ") == "first_post_hi_1"
+
+script_name = "print_cli_args"
+args = ["a", "b", "c"]
+[rust_args, python_args] = check_output([script_name, *args], text=True).splitlines()
+# The rust vec debug format is also valid json
+rust_args = json.loads(rust_args)
+python_args = json.loads(python_args)
+
+# On linux we get sys.executable, windows resolve the path and mac os gives us a third
+# path (
+# {prefix}/Python.framework/Versions/3.10/Resources/Python.app/Contents/MacOS/Python
+# vs
+# {prefix}/Python.framework/Versions/3.10/bin/python3.10
+# on cirrus ci)
+# We also skip windows because cpython resolves while pypy doesn't
+if platform.system() == "Linux":
+    assert rust_args[0] == sys.executable, (rust_args, sys.executable)
+
+# Windows can't decide if it's with or without .exe, FreeBSB just doesn't work for some reason
+if platform.system() in ["Darwin", "Linux"]:
+    # Unix venv layout (and hopefully also on more exotic platforms)
+    print_cli_args = str(Path(sys.prefix).joinpath("bin").joinpath(script_name))
+    assert rust_args[1] == print_cli_args, (rust_args, print_cli_args)
+    assert python_args[0] == print_cli_args, (python_args, print_cli_args)
+
+# FreeBSB just doesn't work for some reason
+if platform.system() in ["Darwin", "Linux", "Windows"]:
+    # Rust contains the python executable as first argument but python does not
+    assert rust_args[2:] == args, rust_args
+    assert python_args[1:] == args, python_args
 
 print("SUCCESS")

--- a/test-crates/pyo3-mixed/check_installed/check_installed.py
+++ b/test-crates/pyo3-mixed/check_installed/check_installed.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os.path
 import platform
 import sys
 from pathlib import Path
@@ -25,9 +26,15 @@ python_args = json.loads(python_args)
 # vs
 # {prefix}/Python.framework/Versions/3.10/bin/python3.10
 # on cirrus ci)
-# We also skip windows because cpython resolves while pypy doesn't
-if platform.system() == "Linux":
-    assert rust_args[0] == sys.executable, (rust_args, sys.executable)
+# On windows, cpython resolves while pypy doesn't.
+# On alpine/musl, rust_args is empty
+if len(rust_args) > 0:
+    assert os.path.samefile(rust_args[0], sys.executable), (
+        rust_args,
+        sys.executable,
+        os.path.realpath(rust_args[0]),
+        os.path.realpath(sys.executable),
+    )
 
 # Windows can't decide if it's with or without .exe, FreeBSB just doesn't work for some reason
 if platform.system() in ["Darwin", "Linux"]:

--- a/test-crates/pyo3-mixed/check_installed/check_installed.py
+++ b/test-crates/pyo3-mixed/check_installed/check_installed.py
@@ -26,9 +26,10 @@ python_args = json.loads(python_args)
 # vs
 # {prefix}/Python.framework/Versions/3.10/bin/python3.10
 # on cirrus ci)
-# On windows, cpython resolves while pypy doesn't.
+# On windows, cpython resolves while pypy doesn't, also the script for cpython is
+# actually as distinct file from the system interpreter
 # On alpine/musl, rust_args is empty
-if len(rust_args) > 0:
+if len(rust_args) > 0 and platform.system() != "Windows":
     assert os.path.samefile(rust_args[0], sys.executable), (
         rust_args,
         sys.executable,

--- a/test-crates/pyo3-mixed/check_installed/check_installed.py
+++ b/test-crates/pyo3-mixed/check_installed/check_installed.py
@@ -26,10 +26,11 @@ python_args = json.loads(python_args)
 # vs
 # {prefix}/Python.framework/Versions/3.10/bin/python3.10
 # on cirrus ci)
-# On windows, cpython resolves while pypy doesn't, also the script for cpython is
-# actually as distinct file from the system interpreter
+# On windows, cpython resolves while pypy doesn't.
+# The script for cpython is actually a distinct file from the system interpreter for
+# windows and mac
 # On alpine/musl, rust_args is empty
-if len(rust_args) > 0 and platform.system() != "Windows":
+if len(rust_args) > 0 and platform.system() == "Linux":
     assert os.path.samefile(rust_args[0], sys.executable), (
         rust_args,
         sys.executable,

--- a/test-crates/pyo3-mixed/check_installed/check_installed.py
+++ b/test-crates/pyo3-mixed/check_installed/check_installed.py
@@ -20,35 +20,36 @@ args = ["a", "b", "c"]
 rust_args = json.loads(rust_args)
 python_args = json.loads(python_args)
 
-# On linux we get sys.executable, windows resolve the path and mac os gives us a third
-# path (
-# {prefix}/Python.framework/Versions/3.10/Resources/Python.app/Contents/MacOS/Python
-# vs
-# {prefix}/Python.framework/Versions/3.10/bin/python3.10
-# on cirrus ci)
-# On windows, cpython resolves while pypy doesn't.
-# The script for cpython is actually a distinct file from the system interpreter for
-# windows and mac
-# On alpine/musl, rust_args is empty
-if len(rust_args) > 0 and platform.system() == "Linux":
-    assert os.path.samefile(rust_args[0], sys.executable), (
-        rust_args,
-        sys.executable,
-        os.path.realpath(rust_args[0]),
-        os.path.realpath(sys.executable),
-    )
+# On alpine/musl, rust_args is empty so we skip all tests on musl
+if len(rust_args) > 0:
+    # On linux we get sys.executable, windows resolve the path and mac os gives us a third
+    # path (
+    # {prefix}/Python.framework/Versions/3.10/Resources/Python.app/Contents/MacOS/Python
+    # vs
+    # {prefix}/Python.framework/Versions/3.10/bin/python3.10
+    # on cirrus ci)
+    # On windows, cpython resolves while pypy doesn't.
+    # The script for cpython is actually a distinct file from the system interpreter for
+    # windows and mac
+    if platform.system() == "Linux":
+        assert os.path.samefile(rust_args[0], sys.executable), (
+            rust_args,
+            sys.executable,
+            os.path.realpath(rust_args[0]),
+            os.path.realpath(sys.executable),
+        )
 
-# Windows can't decide if it's with or without .exe, FreeBSB just doesn't work for some reason
-if platform.system() in ["Darwin", "Linux"]:
-    # Unix venv layout (and hopefully also on more exotic platforms)
-    print_cli_args = str(Path(sys.prefix).joinpath("bin").joinpath(script_name))
-    assert rust_args[1] == print_cli_args, (rust_args, print_cli_args)
-    assert python_args[0] == print_cli_args, (python_args, print_cli_args)
+    # Windows can't decide if it's with or without .exe, FreeBSB just doesn't work for some reason
+    if platform.system() in ["Darwin", "Linux"]:
+        # Unix venv layout (and hopefully also on more exotic platforms)
+        print_cli_args = str(Path(sys.prefix).joinpath("bin").joinpath(script_name))
+        assert rust_args[1] == print_cli_args, (rust_args, print_cli_args)
+        assert python_args[0] == print_cli_args, (python_args, print_cli_args)
 
-# FreeBSB just doesn't work for some reason
-if platform.system() in ["Darwin", "Linux", "Windows"]:
-    # Rust contains the python executable as first argument but python does not
-    assert rust_args[2:] == args, rust_args
-    assert python_args[1:] == args, python_args
+    # FreeBSB just doesn't work for some reason
+    if platform.system() in ["Darwin", "Linux", "Windows"]:
+        # Rust contains the python executable as first argument but python does not
+        assert rust_args[2:] == args, rust_args
+        assert python_args[1:] == args, python_args
 
 print("SUCCESS")

--- a/test-crates/pyo3-mixed/pyo3_mixed/__init__.py
+++ b/test-crates/pyo3-mixed/pyo3_mixed/__init__.py
@@ -1,5 +1,5 @@
+from .pyo3_mixed import get_21, print_cli_args  # noqa: F401
 from .python_module.double import double
-from .pyo3_mixed import get_21
 
 
 def get_42() -> int:

--- a/test-crates/pyo3-mixed/pyproject.toml
+++ b/test-crates/pyo3-mixed/pyproject.toml
@@ -13,3 +13,4 @@ dependencies = ["boltons"]
 
 [project.scripts]
 get_42 = "pyo3_mixed:get_42"
+print_cli_args = "pyo3_mixed:print_cli_args"

--- a/test-crates/pyo3-mixed/src/lib.rs
+++ b/test-crates/pyo3-mixed/src/lib.rs
@@ -1,13 +1,32 @@
 use pyo3::prelude::*;
+use std::env;
 
 #[pyfunction]
 fn get_21() -> usize {
     21
 }
 
+/// Prints the CLI arguments, once from Rust's point of view and once from Python's point of view.
+#[pyfunction]
+fn print_cli_args(py: Python) -> PyResult<()> {
+    // This one includes Python and the name of the wrapper script itself, e.g.
+    // `["/home/ferris/.venv/bin/python", "/home/ferris/.venv/bin/print_cli_args", "a", "b", "c"]`
+    println!("{:?}", env::args().collect::<Vec<_>>());
+    // This one includes only the name of the wrapper script itself, e.g.
+    // `["/home/ferris/.venv/bin/print_cli_args", "a", "b", "c"])`
+    println!(
+        "{:?}",
+        py.import("sys")?
+            .getattr("argv")?
+            .extract::<Vec<String>>()?
+    );
+    Ok(())
+}
+
 #[pymodule]
 fn pyo3_mixed(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_21))?;
+    m.add_wrapped(wrap_pyfunction!(print_cli_args))?;
 
     Ok(())
 }


### PR DESCRIPTION
Inspired by https://github.com/PyO3/maturin/issues/368#issuecomment-1503752982

Preview: https://deploy-preview-1565--maturin-guide.netlify.app/bindings.html#both-binary-and-library

CC @nanthony007