### PR TITLE
Fix maturin failing to handle empty sysroot

### DIFF
--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -423,7 +423,11 @@ pub fn get_sysroot_path(target: &Target) -> Result<PathBuf> {
                 .context("Failed to read the sysroot path")?
                 .trim()
                 .to_owned();
-            return Ok(PathBuf::from(sysroot));
+            if sysroot.is_empty() {
+                return Ok(PathBuf::from("/"));
+            } else {
+                return Ok(PathBuf::from(sysroot));
+            }
         } else {
             bail!(
                 "Failed to get the sysroot path: {}",


### PR DESCRIPTION
I'm using nixpkgs' gcc as a cross-compilation linker, and unfortunately, it's causing maturin's wheel repair to fail with the following error: 

```
💥 maturin failed
  Caused by: Cannot repair wheel, because required library libgcc_s.so.1 could not be located.
```

After some investigation, it appears that, when trying to autodetect the sysroot, maturin runs `$CC --print-sysroot`. Unfortunately, the version of `gcc` used by nixpkgs will simply print an empty string in this case, causing the build to fail. With this patch, however, it all works and generates a working wheel.