### PR TITLE
Enabled color output for error message

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -153,7 +153,7 @@ fn compile_target(
     let target = &context.target;
 
     let mut cargo_rustc: cargo_options::Rustc = context.cargo_options.clone().into();
-    cargo_rustc.message_format = vec!["json".to_string()];
+    cargo_rustc.message_format = vec!["json-render-diagnostics".to_string()];
 
     // --release and --profile are conflicting options
     if context.release && cargo_rustc.profile.is_none() {


### PR DESCRIPTION
Closes https://github.com/PyO3/maturin/issues/1576

It looks like you just need to change ` message-format` to `json-render-diagnostics`.

Example Result:
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/12986082/236431820-e7e559e5-9363-4585-b4bd-e32f516537c9.png">
