### PR TITLE
Always set `PYO3_PYTHON` if interpreter is runnable regardless of abi3

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -995,6 +995,7 @@ pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<Br
 
     if !(bridge.is_bindings("pyo3") || bridge.is_bindings("pyo3-ffi")) {
         eprintln!("🔗 Found {bridge} bindings");
+        return Ok(bridge);
     }
 
     for &lib in PYO3_BINDING_CRATES.iter() {


### PR DESCRIPTION
It can be useful in build scripts, like https://github.com/pyca/cryptography/pull/8815#issuecomment-1535461786