### PR TITLE
Release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.0.0-beta.9"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2064,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "serde",
  "time-core",
@@ -2075,15 +2075,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>", "messense <messense@icloud.com>"]
 name = "maturin"
-version = "1.0.0-beta.9"
+version = "0.15.0"
 description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
 exclude = ["test-crates/**/*", "sysconfig/*", "test-data/*", "ci/*", "tests/*", "guide/*", ".github/*"]
 homepage = "https://github.com/pyo3/maturin"

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2023-05-07
+
 * **Breaking Change**: Build with `--no-default-features` by default when bootstrapping from sdist in [#1333](https://github.com/PyO3/maturin/pull/1333)
 * **Breaking Change**: Remove deprecated `sdist-include` option in `pyproject.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
 * **Breaking Change**: Remove deprecated `python-source` option in `Cargo.toml` in [#1335](https://github.com/PyO3/maturin/pull/1335)
@@ -850,7 +852,8 @@ points-0.1.0-py2.py3-none-manylinux1_x86_64.whl | 2,8M | 752K | 85K
 
  * Initial Release
 
-[Unreleased]: https://github.com/pyo3/maturin/compare/v0.14.17...HEAD
+[Unreleased]: https://github.com/pyo3/maturin/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/pyo3/maturin/compare/v0.14.17...v0.15.0
 [0.14.17]: https://github.com/pyo3/maturin/compare/v0.14.16...v0.14.17
 [0.14.16]: https://github.com/pyo3/maturin/compare/v0.14.15...v0.14.16
 [0.14.15]: https://github.com/pyo3/maturin/compare/v0.14.14...v0.14.15

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -313,15 +313,17 @@ impl PyProjectToml {
             .iter()
             .find(|x| x.name == maturin)
         {
-            let current_major: usize = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
+            // Note: Update this once 1.0 is out
+            assert_eq!(env!("CARGO_PKG_VERSION_MAJOR"), "0");
+            let current_minor: usize = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
             if requires_maturin.version_or_url.is_none() {
                 eprintln!(
                     "⚠️  Warning: Please use {maturin} in pyproject.toml with a version constraint, \
-                    e.g. `requires = [\"{maturin}>={current}.0,<{next}.0\"]`. \
+                    e.g. `requires = [\"{maturin}>=0.{current},<0.{next}\"]`. \
                     This will become an error.",
                     maturin = maturin,
-                    current = current_major,
-                    next = current_major + 1,
+                    current = current_minor,
+                    next = current_minor + 1,
                 );
                 return false;
             }

--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {% if bindings == "pyo3" -%}
-pyo3 = "0.18.1"
+pyo3 = "0.18.3"
 {% elif bindings == "rust-cpython" -%}
 cpython = "0.7.1"
 {% elif bindings == "uniffi" -%}

--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>={{ version_major }}.{{ version_minor }},<{{ version_major + 1 }}.0"]
+requires = ["maturin>={{ version_major }}.{{ version_minor }},<{{ version_major }}.{{ version_minor + 1 }}"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
We plan to also bump version to 1.0.0 after about two weeks if there are no major breaking changes needed.

* 0.15 migration guide: https://www.maturin.rs/migration.html#from-014-to-015