### PR TITLE
When determining the python module name, use pyproject.toml `project.name` over Cargo.toml `package.name`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * When determining the python module name, use pyproject.toml `project.name` over Cargo.toml `package.name`.
+
 ## [0.15.1] - 2023-05-07
 
 * Fix finding interpreters from bundled sysconfigs in [#1598](https://github.com/PyO3/maturin/pull/1598)


### PR DESCRIPTION
I propose to change the precedence for determining the module name to consider before pyproject.toml `project.name` over Cargo.toml `package.name`. This came up in ruff (https://github.com/charliermarsh/ruff/pull/4397, https://github.com/charliermarsh/ruff/pull/4399), where the crate name is `ruff_cli` and the project name is `ruff`.

I'm not sure if there are any cases a user would like the crate name over the package name.