### PR TITLE
Fix cross-compile to Apple universal2 in the other platform

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -49,7 +49,7 @@ pub fn compile(
     python_interpreter: Option<&PythonInterpreter>,
     targets: &[CompileTarget],
 ) -> Result<Vec<HashMap<String, BuildArtifact>>> {
-    if context.target.is_macos() && context.universal2 {
+    if context.universal2 {
         compile_universal2(context, python_interpreter, targets)
     } else {
         compile_targets(context, python_interpreter, targets)


### PR DESCRIPTION
Since the `--universal2` option is deprecated, only providing `--target=universal2-apple-darwin` cannot set the correct target for Linux or Windows platforms. I suggest that we disregard the current target if the user specifies the `universal2-apple-darwin` target.