### PR TITLE
Add license classifiers to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = ["tomli>=1.1.0 ; python_version<'3.11'"]
 dynamic = [

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ setup(
         "Programming Language :: Rust",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
+        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
     ],
     install_requires=["tomli>=1.1.0 ; python_version<'3.11'"],
     setup_requires=["setuptools-rust>=1.4.0"],


### PR DESCRIPTION
This adds standard license classifiers from https://pypi.org/classifiers/ to the package metadata for maturin itself.

This is useful because some internal Python package registries check licenses when importing packages, and the license value of `MIT OR Apache-2.0` generally can't be automatically parsed since it is a freeform text field.