### PR TITLE
Add PEP 517 `config_settings` support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.2] - 2023-05-16
 
- * When determining the python module name, use pyproject.toml `project.name` over Cargo.toml `package.name` in [#1608](https://github.com/PyO3/maturin/pull/1608)
- * Fix rewriting `dev-dependencies` in sdist in [#1610](https://github.com/PyO3/maturin/pull/1610)
+* When determining the python module name, use pyproject.toml `project.name` over Cargo.toml `package.name` in [#1608](https://github.com/PyO3/maturin/pull/1608)
+* Fix rewriting `dev-dependencies` in sdist in [#1610](https://github.com/PyO3/maturin/pull/1610)
+* Add PEP 517 `config_settings` support in [#1619](https://github.com/PyO3/maturin/pull/1619),
+  deprecate `MATURIN_PEP517_ARGS` in favor of the new `build-args` config setting.
 
 ## [0.15.1] - 2023-05-07
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -32,9 +32,19 @@ def get_config() -> Dict[str, str]:
     return pyproject_toml.get("tool", {}).get("maturin", {})
 
 
-def get_maturin_pep517_args() -> list[str]:
-    args = shlex.split(os.getenv("MATURIN_PEP517_ARGS", ""))
-    return args
+def get_maturin_pep517_args(
+    config_settings: Mapping[str, Any] | None = None
+) -> list[str]:
+    build_args = config_settings.get("build-args") if config_settings else None
+    if build_args is None:
+        args = os.getenv("MATURIN_PEP517_ARGS", "")
+        if args:
+            print(
+                f"'MATURIN_PEP517_ARGS' is deprecated, use `--config-settings build-args='{args}'` instead."
+            )
+    else:
+        args = build_args
+    return shlex.split(args)
 
 
 def _additional_pep517_args() -> list[str]:
@@ -68,7 +78,7 @@ def _build_wheel(
     if editable:
         command.append("--editable")
 
-    pep517_args = get_maturin_pep517_args()
+    pep517_args = get_maturin_pep517_args(config_settings)
     if pep517_args:
         command.extend(pep517_args)
 
@@ -185,7 +195,7 @@ def prepare_metadata_for_build_wheel(
         sys.executable,
     ]
     command.extend(_additional_pep517_args())
-    pep517_args = get_maturin_pep517_args()
+    pep517_args = get_maturin_pep517_args(config_settings)
     if pep517_args:
         command.extend(pep517_args)
 

--- a/test-crates/cffi-mixed/pyproject.toml
+++ b/test-crates/cffi-mixed/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/cffi-pure/pyproject.toml
+++ b/test-crates/cffi-pure/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/hello-world/pyproject.toml
+++ b/test-crates/hello-world/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/test-crates/lib_with_disallowed_lib/pyproject.toml
+++ b/test-crates/lib_with_disallowed_lib/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/lib_with_path_dep/pyproject.toml
+++ b/test-crates/lib_with_path_dep/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/license-test/pyproject.toml
+++ b/test-crates/license-test/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-ffi-pure/pyproject.toml
+++ b/test-crates/pyo3-ffi-pure/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-mixed-include-exclude/pyproject.toml
+++ b/test-crates/pyo3-mixed-include-exclude/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-mixed-py-subdir/pyproject.toml
+++ b/test-crates/pyo3-mixed-py-subdir/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-mixed-src/pyproject.toml
+++ b/test-crates/pyo3-mixed-src/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-mixed-submodule/pyproject.toml
+++ b/test-crates/pyo3-mixed-submodule/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-mixed/pyproject.toml
+++ b/test-crates/pyo3-mixed/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/pyo3-pure/pyproject.toml
+++ b/test-crates/pyo3-pure/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/test-crates/sdist_with_path_dep/pyproject.toml
+++ b/test-crates/sdist_with_path_dep/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/sdist_with_target_path_dep/pyproject.toml
+++ b/test-crates/sdist_with_target_path_dep/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/uniffi-mixed/pyproject.toml
+++ b/test-crates/uniffi-mixed/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/uniffi-pure/pyproject.toml
+++ b/test-crates/uniffi-pure/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/with-data/pyproject.toml
+++ b/test-crates/with-data/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]

--- a/test-crates/workspace-inheritance/python/pyproject.toml
+++ b/test-crates/workspace-inheritance/python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/workspace/py/pyproject.toml
+++ b/test-crates/workspace/py/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"

--- a/test-crates/workspace_with_path_dep/pyproject.toml
+++ b/test-crates/workspace_with_path_dep/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
Replaces `MATURIN_PEP517_ARGS` environment variable with `--config-settings build-args=<cargo build args>`.

Closes #1541 