### PR TITLE
Add support for multiple `--config-settings` in PEP517 backend

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add support for multiple `--config-settings` in PEP517 backend in [#1624](https://github.com/PyO3/maturin/pull/1624)
+
 ## [0.15.3] - 2023-05-20
 
 * Fix cross compile Apple universal2 wheels on non-macOS platforms by MisLink in [#1613](https://github.com/PyO3/maturin/pull/1613)

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -37,14 +37,17 @@ def get_maturin_pep517_args(
 ) -> list[str]:
     build_args = config_settings.get("build-args") if config_settings else None
     if build_args is None:
-        args = os.getenv("MATURIN_PEP517_ARGS", "")
-        if args:
+        env_args = os.getenv("MATURIN_PEP517_ARGS", "")
+        if env_args:
             print(
-                f"'MATURIN_PEP517_ARGS' is deprecated, use `--config-settings build-args='{args}'` instead."
+                f"'MATURIN_PEP517_ARGS' is deprecated, use `--config-settings build-args='{env_args}'` instead."
             )
+        args = shlex.split(env_args)
+    elif isinstance(build_args, str):
+        args = shlex.split(build_args)
     else:
         args = build_args
-    return shlex.split(args)
+    return args
 
 
 def _additional_pep517_args() -> list[str]:


### PR DESCRIPTION
Note that this requires at least pip 23.1.

Closes #1623 