### PR TITLE
Improve error message when python fails in develop

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -563,6 +563,8 @@ impl BuildOptions {
                     vec![PathBuf::from("python3")]
                 }
             } else {
+                // XXX: False positive clippy warning
+                #[allow(clippy::redundant_clone)]
                 self.interpreter.clone()
             };
             self.find_interpreters(&bridge, &interpreter, &target, None, generate_import_lib)?

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1101,8 +1101,7 @@ fn find_interpreter_in_host(
     requires_python: Option<&VersionSpecifiers>,
 ) -> Result<Vec<PythonInterpreter>> {
     let interpreters = if !interpreter.is_empty() {
-        PythonInterpreter::check_executables(interpreter, target, bridge)
-            .context("The given list of python interpreters is invalid")?
+        PythonInterpreter::check_executables(interpreter, target, bridge)?
     } else {
         PythonInterpreter::find_all(target, bridge, requires_python)
             .context("Finding python interpreters failed")?


### PR DESCRIPTION
Inspired by https://www.youtube.com/live/zepPZ6MFiGs?feature=share&t=648, i wanted to improve the error message when `maturin develop` fails because `python` doesn't work.

I unfortunately failed to reproduce the error in the video, but i'm nonetheless confident that this is the correct change: It shouldn't say "The given list of python interpreters is invalid" when you didn't provide any list. iirc the error message comes from a time when i assumed users would provide a list like python3.5 python3.6 python3.7 instead of building for one version per CI job.

I thought about redoing the error system around interpreters but i think just pointing out the faulty interpreter is all a user needs to understand and debug the problem