### PR TITLE
Add basic support for GraalPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _formerly pyo3-pack_
 Build and publish crates with pyo3, rust-cpython, cffi and uniffi bindings as well as rust binaries as python packages.
 
 This project is meant as a zero configuration replacement for [setuptools-rust](https://github.com/PyO3/setuptools-rust) and [milksnake](https://github.com/getsentry/milksnake).
-It supports building wheels for python 3.5+ on windows, linux, mac and freebsd, can upload them to [pypi](https://pypi.org/) and has basic pypy support.
+It supports building wheels for python 3.5+ on windows, linux, mac and freebsd, can upload them to [pypi](https://pypi.org/) and has basic pypy and graalpy support.
 
 Check out the [User Guide](https://maturin.rs/)!
 

--- a/guide/src/bindings.md
+++ b/guide/src/bindings.md
@@ -8,7 +8,7 @@ specify which bindings to use.
 
 [pyo3](https://github.com/PyO3/pyo3) is Rust bindings for Python,
 including tools for creating native Python extension modules.
-It supports both CPython and PyPy.
+It supports CPython, PyPy, and GraalPy.
 
 maturin automatically detects pyo3 bindings when it's added as a dependency in `Cargo.toml`.
 

--- a/guide/src/platform_support.md
+++ b/guide/src/platform_support.md
@@ -36,7 +36,7 @@ supported by [manylinux](https://github.com/pypa/manylinux).
 CPython 3.7 to 3.10 are supported and tested on CI, though the entire 3.x series should work.
 This will be changed as new python versions are released and others have their end of life.
 
-PyPy 3.6 and later also works.
+PyPy 3.6 and later also works, as does GraalPy 23.0 and later.
 
 ## Manylinux/Musllinux
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -42,7 +42,7 @@ pub enum BridgeModel {
     /// providing crate, e.g. pyo3, the number is the minimum minor python version
     Bindings(String, usize),
     /// `Bindings`, but specifically for pyo3 with feature flags that allow building a single wheel
-    /// for all cpython versions (pypy still needs multiple versions).
+    /// for all cpython versions (pypy & graalpy still need multiple versions).
     /// The numbers are the minimum major and minor version
     BindingsAbi3(u8, u8),
     /// A native module with c bindings, i.e. `#[no_mangle] extern "C" <some item>`
@@ -234,7 +234,9 @@ impl BuildContext {
                     let interp_names: HashSet<_> = non_abi3_interps
                         .iter()
                         .map(|interp| match interp.interpreter_kind {
-                            InterpreterKind::CPython => interp.implementation_name.to_string(),
+                            InterpreterKind::CPython | InterpreterKind::GraalPy => {
+                                interp.implementation_name.to_string()
+                            }
                             InterpreterKind::PyPy => "PyPy".to_string(),
                         })
                         .collect();

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -269,6 +269,8 @@ impl BuildOptions {
                                     Some(InterpreterKind::PyPy)
                                 } else if tag.starts_with("cpython") {
                                     Some(InterpreterKind::CPython)
+                                } else if tag.starts_with("graalpy") {
+                                    Some(InterpreterKind::GraalPy)
                                 } else {
                                     None
                                 }
@@ -1133,6 +1135,11 @@ fn find_interpreter_in_sysconfig(
         let python = interp.display().to_string();
         let (python_impl, python_ver) = if let Some(ver) = python.strip_prefix("pypy") {
             (InterpreterKind::PyPy, ver.strip_prefix('-').unwrap_or(ver))
+        } else if let Some(ver) = python.strip_prefix("graalpy") {
+            (
+                InterpreterKind::GraalPy,
+                ver.strip_prefix('-').unwrap_or(ver),
+            )
         } else if let Some(ver) = python.strip_prefix("python") {
             (
                 InterpreterKind::CPython,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -350,10 +350,10 @@ fn compile_target(
     }
 
     if let BridgeModel::BindingsAbi3(_, _) = bridge_model {
-        let is_pypy = python_interpreter
-            .map(|p| p.interpreter_kind.is_pypy())
+        let is_pypy_or_graalpy = python_interpreter
+            .map(|p| p.interpreter_kind.is_pypy() || p.interpreter_kind.is_graalpy())
             .unwrap_or(false);
-        if !is_pypy && !target.is_windows() {
+        if !is_pypy_or_graalpy && !target.is_windows() {
             let pyo3_ver = pyo3_version(&context.cargo_metadata)
                 .context("Failed to get pyo3 version from cargo metadata")?;
             if pyo3_ver < PYO3_ABI3_NO_PYTHON_VERSION {
@@ -389,7 +389,8 @@ fn compile_target(
         } else if (bridge_model.is_bindings("pyo3")
             || bridge_model.is_bindings("pyo3-ffi")
             || (matches!(bridge_model, BridgeModel::BindingsAbi3(_, _))
-                && interpreter.interpreter_kind.is_pypy()))
+                && (interpreter.interpreter_kind.is_pypy()
+                    || interpreter.interpreter_kind.is_graalpy())))
             && env::var_os("PYO3_CONFIG_FILE").is_none()
         {
             let pyo3_config = interpreter.pyo3_config_file();

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -69,7 +69,7 @@ impl InterpreterConfig {
                     target.target_env().to_string().replace("musl", "gnu")
                 }
             }
-            PyPy => "gnu".to_string(),
+            PyPy | GraalPy => "gnu".to_string(),
         };
         match (target.target_os(), python_impl) {
             (Os::Linux, CPython) => {

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -19,6 +19,23 @@ if platform.python_implementation() == "PyPy":
 else:
     ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 
+
+def get_abi_tag():
+    # This should probably return the ABI tag based on EXT_SUFFIX in the same
+    # way as pypa/packaging. See https://github.com/pypa/packaging/pull/607.
+    # For simplicity, we just fix it up for GraalPy for now and leave the logic
+    # for the other interpreters untouched, but this should be fixed properly
+    # down the road.
+    if platform.python_implementation() == "GraalVM":
+        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+        parts = ext_suffix.split(".")
+        soabi = parts[1]
+        abi = "-".join(soabi.split("-")[:3])
+        return abi.replace(".", "_").replace("-", "_")
+    else:
+        return (sysconfig.get_config_var("SOABI") or "-").split("-")[1] or None,
+
+
 metadata = {
     # sys.implementation.name can differ from platform.python_implementation(), for example
     # Pyston has sys.implementation.name == "pyston" while platform.python_implementation() == cpython
@@ -30,7 +47,7 @@ metadata = {
     "interpreter": platform.python_implementation().lower(),
     "ext_suffix": ext_suffix,
     "soabi": sysconfig.get_config_var("SOABI") or None,
-    "abi_tag": (sysconfig.get_config_var("SOABI") or "-").split("-")[1] or None,
+    "abi_tag": get_abi_tag(),
     "platform": sysconfig.get_platform(),
     # This one isn't technically necessary, but still very useful for sanity checks
     "system": platform.system().lower(),

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -33,7 +33,7 @@ def get_abi_tag():
         abi = "-".join(soabi.split("-")[:3])
         return abi.replace(".", "_").replace("-", "_")
     else:
-        return (sysconfig.get_config_var("SOABI") or "-").split("-")[1] or None,
+        return (sysconfig.get_config_var("SOABI") or "-").split("-")[1]
 
 
 metadata = {
@@ -47,7 +47,7 @@ metadata = {
     "interpreter": platform.python_implementation().lower(),
     "ext_suffix": ext_suffix,
     "soabi": sysconfig.get_config_var("SOABI") or None,
-    "abi_tag": get_abi_tag(),
+    "abi_tag": get_abi_tag() or None,
     "platform": sysconfig.get_platform(),
     # This one isn't technically necessary, but still very useful for sanity checks
     "system": platform.system().lower(),

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -158,8 +158,8 @@ fn integration_pyo3_bin() {
         target.get_python()
     });
     let python_implementation = get_python_implementation(&python).unwrap();
-    if python_implementation == "pypy" {
-        // PyPy doesn't support the 'auto-initialize' feature of pyo3
+    if python_implementation == "pypy" || python_implementation == "graalpy" {
+        // PyPy & GraalPy do not support the 'auto-initialize' feature of pyo3
         return;
     }
 


### PR DESCRIPTION
I am working on making PyO3 support GraalPy in https://github.com/timfel/pyo3/tree/timfel/graalpy-support. To run the tests, I noticed I need maturin, so I had to make changes here as well. However, to run the maturin tests, I need the PyO3 changes. 

Right now with this PR and my PyO3 branch, I can run the maturin tutorial example and a small number of PyO3 tests. Since the PyO3 changes will grow, whereas I expect the changes here to not be much more, I would like to open this for discussion.