### PR TITLE
Fix emscripten action

### DIFF
--- a/guide/src/develop.md
+++ b/guide/src/develop.md
@@ -29,6 +29,11 @@ Options:
 
           Use as `--extras=extra1,extra2`
 
+      --skip-install
+          Skip installation, only build the extension module inplace
+
+          Only works with mixed Rust/Python project layout
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -254,8 +254,11 @@ jobs:\n",
 
             // install pyodide-build for emscripten
             if matches!(platform, Platform::Emscripten) {
+                // instal stable pyodide-build
                 conf.push_str("      - run: pip install pyodide-build\n");
                 conf.push_str("      - shell: bash\n        run: echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV\n");
+                // get the current python version for the installed pyodide-build
+                conf.push_str("      - shell: bash\n        run: echo PYTHON_VERSION=$(pyodide config get python_version | cut -d '.' -f 1-2) >> $GITHUB_ENV\n");
                 conf.push_str(
                     "      - uses: mymindstorm/setup-emsdk@v12
         with:
@@ -268,7 +271,7 @@ jobs:\n",
             let mut maturin_args = if is_abi3 || (is_bin && !setup_python) {
                 Vec::new()
             } else if matches!(platform, Platform::Emscripten) {
-                vec!["-i".to_string(), "3.10".to_string()]
+                vec!["-i".to_string(), "${{ env.PYTHON_VERSION }}".to_string()]
             } else {
                 vec!["--find-interpreter".to_string()]
             };

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -256,9 +256,9 @@ jobs:\n",
             if matches!(platform, Platform::Emscripten) {
                 // instal stable pyodide-build
                 conf.push_str("      - run: pip install pyodide-build\n");
-                conf.push_str("      - shell: bash\n        run: echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV\n");
+                conf.push_str("      - shell: bash\n        run: |\n        echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV\n");
                 // get the current python version for the installed pyodide-build
-                conf.push_str("      - shell: bash\n        run: echo PYTHON_VERSION=$(pyodide config get python_version | cut -d '.' -f 1-2) >> $GITHUB_ENV\n");
+                conf.push_str("        echo PYTHON_VERSION=$(pyodide config get python_version | cut -d '.' -f 1-2) >> $GITHUB_ENV\n");
                 conf.push_str(
                     "      - uses: mymindstorm/setup-emsdk@v12
         with:


### PR DESCRIPTION
Hello and thanks for your software!

## What did not work

In the output of `generate-ci` with the `emscripten` option, the version of python in `maturin_args` was fixed at "3.10". But the stable version of pyodide-build is only compatible with "3.11" right now. 

## What I did

Now the ci fetches the current python version for pyodide with `pyodide config get python_version` similarly to what was already done for the emscripten_version. Like so, it should adapt to any future new versions

## Doubts

I'm new to Rust, so feel free to change anything. Tests are passing and the ci runs there in my library: https://github.com/cds-astro/mocpy/actions/workflows/emscripten.yml but I never know what I could have broken. 

