### PR TITLE
Update note that only Python 3.7+ is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _formerly pyo3-pack_
 Build and publish crates with pyo3, rust-cpython, cffi and uniffi bindings as well as rust binaries as python packages.
 
 This project is meant as a zero configuration replacement for [setuptools-rust](https://github.com/PyO3/setuptools-rust) and [milksnake](https://github.com/getsentry/milksnake).
-It supports building wheels for python 3.5+ on windows, linux, mac and freebsd, can upload them to [pypi](https://pypi.org/) and has basic pypy and graalpy support.
+It supports building wheels for python 3.7+ on windows, linux, mac and freebsd, can upload them to [pypi](https://pypi.org/) and has basic pypy and graalpy support.
 
 Check out the [User Guide](https://maturin.rs/)!
 

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -405,9 +405,9 @@ fn fun_with_abiflags(
         )
     }
 
-    if message.major != 3 || message.minor < 5 {
+    if message.major != 3 || message.minor < 7 {
         bail!(
-            "Only python >= 3.5 is supported, while you're using python {}.{}",
+            "Only python >= 3.7 is supported, while you're using python {}.{}",
             message.major,
             message.minor
         );


### PR DESCRIPTION
3.5 was dropped a long time ago, and 3.6 last year