### PR TITLE
Drop PyPy 3.8 from test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,24 +349,24 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             abi: cp37-cp37m
             python: python3.7
-            container: ghcr.io/messense/manylinux2014-cross:aarch64
+            container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
           - target: armv7-unknown-linux-gnueabihf
             abi: cp39-cp39
             python: python3.9
-            container: ghcr.io/messense/manylinux2014-cross:armv7
+            container: ghcr.io/rust-cross/manylinux2014-cross:armv7
           - target: s390x-unknown-linux-gnu
             abi: cp310-cp310
             python: python3.10
-            container: ghcr.io/messense/manylinux2014-cross:s390x
+            container: ghcr.io/rust-cross/manylinux2014-cross:s390x
           # PyPy
           - target: aarch64-unknown-linux-gnu
             abi: pp39-pypy39_pp73
             python: pypy3.9
-            container: ghcr.io/messense/manylinux2014-cross:aarch64
+            container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
           - target: aarch64-unknown-linux-gnu
             abi: pp310-pypy310_pp73
             python: pypy3.10
-            container: ghcr.io/messense/manylinux2014-cross:aarch64
+            container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,6 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - 'pypy3.8'
         - 'pypy3.9'
         - 'pypy3.10'
 
@@ -361,12 +360,12 @@ jobs:
             container: ghcr.io/messense/manylinux2014-cross:s390x
           # PyPy
           - target: aarch64-unknown-linux-gnu
-            abi: pp37-pypy37_pp73
-            python: pypy3.7
+            abi: pp39-pypy39_pp73
+            python: pypy3.9
             container: ghcr.io/messense/manylinux2014-cross:aarch64
           - target: aarch64-unknown-linux-gnu
-            abi: pp38-pypy38_pp73
-            python: pypy3.8
+            abi: pp310-pypy310_pp73
+            python: pypy3.10
             container: ghcr.io/messense/manylinux2014-cross:aarch64
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Upstream has dropped support for PyPy 3.8:
https://doc.pypy.org/en/latest/release-v7.3.11.html