### PR TITLE
Fix crashing on unknown platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ cargo-options = "0.6.0"
 cbindgen = { version = "0.24.2", default-features = false }
 flate2 = "1.0.18"
 goblin = "0.7.1"
-platform-info = "2.0.1"
+platform-info = "2.0.2"
 regex = "1.7.0"
 serde = { version = "1.0.141", features = ["derive"] }
 serde_json = "1.0.80"


### PR DESCRIPTION
`platform-info` has an issue which causes it to fail hard on unknown platforms. This issue was fixed in newer versions however the latest released version (`2.0.1`) does not have the fix in it.