### PR TITLE
Add non-interactive mode to `upload` command

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -479,7 +479,7 @@ jobs:\n",
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --skip-existing *
+          args: --non-interactive --skip-existing *
 "#,
         );
         if platforms.contains(&Platform::Emscripten) {
@@ -645,7 +645,7 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --skip-existing *
+                      args: --non-interactive --skip-existing *
         "#};
         assert_eq!(conf, expected.trim());
     }
@@ -759,7 +759,7 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --skip-existing *
+                      args: --non-interactive --skip-existing *
         "#};
         assert_eq!(conf, expected.trim());
     }
@@ -936,7 +936,7 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --skip-existing *
+                      args: --non-interactive --skip-existing *
         "#};
         assert_eq!(conf, expected.trim());
     }
@@ -1055,7 +1055,7 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --skip-existing *
+                      args: --non-interactive --skip-existing *
         "#};
         assert_eq!(conf, expected.trim());
     }

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -50,6 +50,13 @@ Options:
           Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other
           implementations may not support this.)
 
+      --non-interactive
+          Do not interactively prompt for username/password if the required credentials are missing.
+          
+          Can also be set via MATURIN_NON_INTERACTIVE environment variable.
+          
+          [env: MATURIN_NON_INTERACTIVE=]
+
       --compatibility [<compatibility>...]
           Control the platform tag on linux.
           

--- a/tests/cmd/upload.stdout
+++ b/tests/cmd/upload.stdout
@@ -43,5 +43,12 @@ Options:
           Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other
           implementations may not support this.)
 
+      --non-interactive
+          Do not interactively prompt for username/password if the required credentials are missing.
+          
+          Can also be set via MATURIN_NON_INTERACTIVE environment variable.
+          
+          [env: MATURIN_NON_INTERACTIVE=]
+
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
Same as `twine upload --non-interactive`.