### PR TITLE
Query default macOS deployment target from `rustc --print deployment-target`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ freebsd_task:
 macos_arm64_task:
   name: Test (arm64 macOS)
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
   env:
     PATH: $HOME/.cargo/bin:/opt/homebrew/opt/python@3.10/bin:$PATH
   target_cache:


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/105354