### PR TITLE
Update wasmtime dependency version to 11.0

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -133,7 +133,7 @@ fn bin_wasi_helper(
         // Having the wasmtime version hardcoded is not ideal, it's easy enough to overwrite
         metadata21
             .requires_dist
-            .push(Requirement::from_str("wasmtime>=7.0.0,<8.0.0").unwrap());
+            .push(Requirement::from_str("wasmtime>=11.0.0,<12.0.0").unwrap());
     }
 
     Ok(metadata21)

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -353,7 +353,7 @@ fn integration_with_data() {
 }
 
 #[test]
-// Sourced from https://pypi.org/project/wasmtime/7.0.0/#files
+// Sourced from https://pypi.org/project/wasmtime/11.0.0/#files
 // update with wasmtime updates
 #[cfg(any(
     all(target_os = "windows", target_arch = "x86_64"),


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime-py/compare/7.0.0...11.0.0