### PR TITLE
fix: preserve workspace inherited dependencies when building binary

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -294,6 +294,13 @@ fn rewrite_dependencies_path(
                     // Cargo.toml contains relative paths, and we're already in LOCAL_DEPENDENCIES_FOLDER
                     toml_edit::value(format!("../{dep_name}"))
                 };
+                if workspace_inherit {
+                    // Remove workspace inheritance now that we converted it into a path dependency
+                    dep_table[&dep_name]
+                        .as_table_like_mut()
+                        .unwrap()
+                        .remove("workspace");
+                }
                 rewritten = true;
             }
         }


### PR DESCRIPTION
I don't have enough context for the fix but it did build on my local machine.

Before:
![image](https://github.com/PyO3/maturin/assets/2883231/e23e0403-2a2a-49cc-82fc-6268e415626c)

After:
![image](https://github.com/PyO3/maturin/assets/2883231/02710ed2-e432-41db-8983-714fce732ed4)


fix #1738