### PR TITLE
Refactor Cargo sdist generator to avoid rewriting local dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +674,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -1071,6 +1087,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "dunce",
+ "expect-test",
  "fat-macho",
  "flate2",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,6 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustversion",
- "same-file",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ dunce = "1.0.2"
 normpath = "1.0.0"
 pep440_rs = { version = "0.3.6", features = ["serde"] }
 pep508_rs = { version = "0.2.1", features = ["serde"] }
-same-file = "1.0.6"
 time = "0.3.17"
 
 # cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ wild = { version = "2.1.0", optional = true }
 url = { version = "2.3.1", optional = true }
 
 [dev-dependencies]
+expect-test = "1.4.1"
 indoc = "2.0.3"
 pretty_assertions = "1.3.0"
 rustversion = "1.0.9"

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -514,8 +514,7 @@ jobs:\n",
 mod tests {
     use super::GenerateCI;
     use crate::BridgeModel;
-    use indoc::indoc;
-    use pretty_assertions::assert_eq;
+    use expect_test::expect;
 
     #[test]
     fn test_generate_github() {
@@ -530,7 +529,7 @@ mod tests {
             .skip(5)
             .collect::<Vec<_>>()
             .join("\n");
-        let expected = indoc! {r#"
+        let expected = expect![[r#"
             name: CI
 
             on:
@@ -645,9 +644,8 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --non-interactive --skip-existing *
-        "#};
-        assert_eq!(conf, expected.trim());
+                      args: --non-interactive --skip-existing *"#]];
+        expected.assert_eq(&conf);
     }
 
     #[test]
@@ -659,7 +657,7 @@ mod tests {
             .skip(5)
             .collect::<Vec<_>>()
             .join("\n");
-        let expected = indoc! {r#"
+        let expected = expect![[r#"
             name: CI
 
             on:
@@ -759,9 +757,8 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --non-interactive --skip-existing *
-        "#};
-        assert_eq!(conf, expected.trim());
+                      args: --non-interactive --skip-existing *"#]];
+        expected.assert_eq(&conf);
     }
 
     #[test]
@@ -782,7 +779,7 @@ mod tests {
             .skip(5)
             .collect::<Vec<_>>()
             .join("\n");
-        let expected = indoc! {r#"
+        let expected = expect![[r#"
             name: CI
 
             on:
@@ -936,9 +933,8 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --non-interactive --skip-existing *
-        "#};
-        assert_eq!(conf, expected.trim());
+                      args: --non-interactive --skip-existing *"#]];
+        expected.assert_eq(&conf);
     }
 
     #[test]
@@ -950,7 +946,7 @@ mod tests {
             .skip(5)
             .collect::<Vec<_>>()
             .join("\n");
-        let expected = indoc! {r#"
+        let expected = expect![[r#"
             name: CI
 
             on:
@@ -1055,8 +1051,7 @@ mod tests {
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
                     with:
                       command: upload
-                      args: --non-interactive --skip-existing *
-        "#};
-        assert_eq!(conf, expected.trim());
+                      args: --non-interactive --skip-existing *"#]];
+        expected.assert_eq(&conf);
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -582,13 +582,14 @@ fn fold_header(text: &str) -> String {
 mod test {
     use super::*;
     use cargo_metadata::MetadataCommand;
+    use expect_test::{expect, Expect};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     fn assert_metadata_from_cargo_toml(
         readme: &str,
         cargo_toml: &str,
-        expected: &str,
+        expected: Expect,
     ) -> Metadata21 {
         let crate_dir = tempfile::tempdir().unwrap();
         let crate_path = crate_dir.path();
@@ -617,13 +618,7 @@ mod test {
 
         let actual = metadata.to_file_contents().unwrap();
 
-        assert_eq!(
-            actual.trim(),
-            expected.trim(),
-            "Actual metadata differed from expected\nEXPECTED:\n{}\n\nGOT:\n{}",
-            expected,
-            actual
-        );
+        expected.assert_eq(&actual);
 
         // get_dist_info_dir test checks against hard-coded values - check that they are as expected in the source first
         assert!(
@@ -662,8 +657,7 @@ mod test {
         "#
         );
 
-        let expected = indoc!(
-            r#"
+        let expected = expect![[r#"
             Metadata-Version: 2.1
             Name: info-project
             Version: 0.1.0
@@ -677,8 +671,8 @@ mod test {
             # Some test package
 
             This is the readme for a test package
-        "#
-        );
+
+        "#]];
 
         assert_metadata_from_cargo_toml(readme, cargo_toml, expected);
     }

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -350,6 +350,7 @@ mod tests {
         pyproject_toml::{Format, Formats, GlobPattern, ToolMaturin},
         PyProjectToml,
     };
+    use expect_test::expect;
     use fs_err as fs;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
@@ -521,16 +522,13 @@ mod tests {
         let outer_error = PyProjectToml::new(&pyproject_toml).unwrap_err();
         let inner_error = outer_error.source().unwrap();
 
-        assert_eq!(
-            inner_error.to_string(),
-            indoc!(
-                r#"TOML parse error at line 7, column 17
-                  |
-                7 | license-files = [ "license.txt",]
-                  |                 ^^^^^^^^^^^^^^^^^
-                wanted string or table
-                "#
-            )
-        );
+        let expected = expect![[r#"
+            TOML parse error at line 7, column 17
+              |
+            7 | license-files = [ "license.txt",]
+              |                 ^^^^^^^^^^^^^^^^^
+            wanted string or table
+        "#]];
+        expected.assert_eq(&inner_error.to_string());
     }
 }

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -388,6 +388,7 @@ suppress_build_script_link_lines=false"#,
 #[cfg(test)]
 mod test {
     use super::*;
+    use expect_test::expect;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -712,7 +713,15 @@ mod test {
         )
         .unwrap();
         let config_file = sysconfig.pyo3_config_file();
-        assert_eq!(config_file, "implementation=CPython\nversion=3.10\nshared=true\nabi3=false\nbuild_flags=WITH_THREAD\nsuppress_build_script_link_lines=false\npointer_width=64");
+        let expected = expect![[r#"
+            implementation=CPython
+            version=3.10
+            shared=true
+            abi3=false
+            build_flags=WITH_THREAD
+            suppress_build_script_link_lines=false
+            pointer_width=64"#]];
+        expected.assert_eq(&config_file);
     }
 
     #[test]
@@ -725,6 +734,14 @@ mod test {
         .unwrap();
         assert_eq!(sysconfig.ext_suffix, ".cpython-311-x86_64-linux-musl.so");
         let config_file = sysconfig.pyo3_config_file();
-        assert_eq!(config_file, "implementation=CPython\nversion=3.11\nshared=true\nabi3=false\nbuild_flags=WITH_THREAD\nsuppress_build_script_link_lines=false\npointer_width=64");
+        let expected = expect![[r#"
+            implementation=CPython
+            version=3.11
+            shared=true
+            abi3=false
+            build_flags=WITH_THREAD
+            suppress_build_script_link_lines=false
+            pointer_width=64"#]];
+        expected.assert_eq(&config_file);
     }
 }

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -217,14 +217,6 @@ fn find_path_deps(cargo_metadata: &Metadata) -> Result<HashMap<String, PathBuf>>
         for dependency in &top.dependencies {
             if let Some(path) = &dependency.path {
                 let dep_name = dependency.rename.as_ref().unwrap_or(&dependency.name);
-                if matches!(dependency.kind, cargo_metadata::DependencyKind::Development) {
-                    // Skip dev-only dependency
-                    debug!(
-                        "Skipping development only dependency {} ({})",
-                        dep_name, path
-                    );
-                    continue;
-                }
                 // we search for the respective package by `manifest_path`, there seems
                 // to be no way to query the dependency graph given `dependency`
                 let dep_manifest_path = path.join("Cargo.toml");

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -2,7 +2,7 @@ use crate::module_writer::{add_data, ModuleWriter};
 use crate::pyproject_toml::SdistGenerator;
 use crate::{pyproject_toml::Format, BuildContext, PyProjectToml, SDistWriter};
 use anyhow::{bail, Context, Result};
-use cargo_metadata::{Metadata, MetadataCommand};
+use cargo_metadata::Metadata;
 use fs_err as fs;
 use ignore::overrides::Override;
 use normpath::PathExt as _;
@@ -12,44 +12,10 @@ use std::process::Command;
 use std::str;
 use tracing::debug;
 
-const LOCAL_DEPENDENCIES_FOLDER: &str = "local_dependencies";
-const RUST_SRC_FOLDER: &str = "rust_src";
-
-/// Inheritable workspace fields, see
-/// https://github.com/rust-lang/cargo/blob/13ae438cf079da58272edc71f4d4968043dbd27b/src/cargo/util/toml/mod.rs#L1140-L1158
-const WORKSPACE_INHERITABLE_FIELDS: &[&str] = &[
-    "version",
-    "authors",
-    "description",
-    "homepage",
-    "documentation",
-    "readme",
-    "keywords",
-    "categories",
-    "license",
-    "license-file",
-    "repository",
-    "publish",
-    "edition",
-    "badges",
-    "exclude",
-    "include",
-    "rust-version",
-];
-
-/// We need cargo to load the local dependencies from the location where we put them in the source
-/// distribution. Since there is no cargo-backed way to replace dependencies
-/// (see https://github.com/rust-lang/cargo/issues/9170), we do a simple
-/// Cargo.toml rewrite ourselves.
-/// A big chunk of that comes from cargo edit, and esp.
-/// https://github.com/killercup/cargo-edit/blob/2a08f0311bcb61690d71d39cb9e55e69b256c8e1/src/manifest.rs
-/// This method is rather frail, but unfortunately I don't know a better solution.
+/// Rewrite Cargo.toml to only retain path dependencies that are actually used
 fn rewrite_cargo_toml(
     manifest_path: impl AsRef<Path>,
-    workspace_manifest: &toml_edit::Document,
     known_path_deps: &HashMap<String, PathBuf>,
-    local_deps_folder: String,
-    root_crate: bool,
 ) -> Result<String> {
     let manifest_path = manifest_path.as_ref();
     let text = fs::read_to_string(manifest_path).context(format!(
@@ -61,109 +27,36 @@ fn rewrite_cargo_toml(
         manifest_path.display()
     ))?;
 
-    let workspace = workspace_manifest.get("workspace");
-    let workspace_deps = workspace
-        .and_then(|x| x.get("dependencies"))
-        .and_then(|x| x.as_table_like());
-
-    let mut rewritten = rewrite_dependencies_path(
-        document.as_table_mut(),
-        workspace_deps,
-        manifest_path,
-        known_path_deps,
-        &local_deps_folder,
-        root_crate,
-    )?;
-    if let Some(target_specs) = document
-        .get_mut("target")
-        .and_then(|x| x.as_table_like_mut())
-    {
-        for target_spec in target_specs
-            .iter_mut()
-            .filter_map(|x| x.1.as_table_like_mut())
-        {
-            rewritten |= rewrite_dependencies_path(
-                target_spec,
-                workspace_deps,
-                manifest_path,
-                known_path_deps,
-                &local_deps_folder,
-                root_crate,
-            )?;
-        }
-    }
-
-    // Update workspace inherited metadata
-    if let Some(package) = document.get_mut("package").and_then(|x| x.as_table_mut()) {
-        let workspace_package = workspace
-            .and_then(|x| x.get("package"))
-            .and_then(|x| x.as_table_like());
-        for key in WORKSPACE_INHERITABLE_FIELDS.iter().copied() {
-            let workspace_inherited = package
-                .get(key)
-                .and_then(|x| x.get("workspace"))
-                .and_then(|x| x.as_bool())
-                .unwrap_or_default();
-            if workspace_inherited {
-                if let Some(workspace_value) = workspace_package.and_then(|ws| ws.get(key)) {
-                    package[key] = workspace_value.clone();
-                    rewritten = true;
+    let mut rewritten = false;
+    // Update workspace members
+    if let Some(workspace) = document.get_mut("workspace").and_then(|x| x.as_table_mut()) {
+        if let Some(members) = workspace.get_mut("members").and_then(|x| x.as_array_mut()) {
+            if known_path_deps.is_empty() {
+                // Remove workspace members when there isn't any path dep
+                workspace.remove("members");
+                if workspace.is_empty() {
+                    // Remove workspace all together if it's empty
+                    document.remove("workspace");
                 }
-            }
-        }
-
-        // Update resolver if workspace set one
-        if let Some(resolver) = workspace.and_then(|x| x.get("resolver")) {
-            package["resolver"] = resolver.clone();
-            rewritten = true;
-        }
-    }
-
-    if root_crate {
-        // Update workspace members
-        if let Some(workspace) = document.get_mut("workspace").and_then(|x| x.as_table_mut()) {
-            if let Some(members) = workspace.get_mut("members").and_then(|x| x.as_array_mut()) {
-                if known_path_deps.is_empty() {
-                    // Remove workspace members when there isn't any path dep
-                    workspace.remove("members");
-                    if workspace.is_empty() {
-                        // Remove workspace all together if it's empty
-                        document.remove("workspace");
-                    }
-                    rewritten = true;
-                } else {
-                    let mut new_members = toml_edit::Array::new();
-                    for member in members.iter() {
-                        if let toml_edit::Value::String(ref s) = member {
-                            let path = Path::new(s.value());
-                            if let Some(name) = path.file_name().and_then(|x| x.to_str()) {
-                                if known_path_deps.contains_key(name) {
-                                    new_members.push(format!("{LOCAL_DEPENDENCIES_FOLDER}/{name}"));
-                                }
+                rewritten = true;
+            } else {
+                let mut new_members = toml_edit::Array::new();
+                for member in members.iter() {
+                    if let toml_edit::Value::String(ref s) = member {
+                        let path = Path::new(s.value());
+                        if let Some(name) = path.file_name().and_then(|x| x.to_str()) {
+                            if known_path_deps.contains_key(name) {
+                                new_members.push(s.value());
                             }
                         }
                     }
-                    if !new_members.is_empty() {
-                        workspace["members"] = toml_edit::value(new_members);
-                    } else {
-                        workspace.remove("members");
-                    }
-                    rewritten = true;
                 }
-            }
-        }
-    } else {
-        // Update package.workspace
-        // https://rust-lang.github.io/rfcs/1525-cargo-workspace.html#implicit-relations
-        // https://doc.rust-lang.org/cargo/reference/manifest.html#the-workspace-field
-        if let Some(package) = document.get_mut("package").and_then(|x| x.as_table_mut()) {
-            if let Some(workspace) = package.get("workspace").and_then(|x| x.as_str()) {
-                // This is enough to fix https://github.com/PyO3/maturin/issues/838
-                // Other cases can be fixed on demand
-                if workspace == ".." || workspace == "../" {
-                    package.remove("workspace");
-                    rewritten = true;
+                if !new_members.is_empty() {
+                    workspace["members"] = toml_edit::value(new_members);
+                } else {
+                    workspace.remove("members");
                 }
+                rewritten = true;
             }
         }
     }
@@ -174,158 +67,12 @@ fn rewrite_cargo_toml(
     }
 }
 
-fn rewrite_dependencies_path(
-    table: &mut dyn toml_edit::TableLike,
-    workspace_deps: Option<&dyn toml_edit::TableLike>,
-    manifest_path: &Path,
-    known_path_deps: &HashMap<String, PathBuf>,
-    local_deps_folder: &str,
-    root_crate: bool,
-) -> Result<bool> {
-    let mut rewritten = false;
-    //  ˇˇˇˇˇˇˇˇˇˇˇˇ dep_category
-    // [dependencies]
-    // some_path_dep = { path = "../some_path_dep" }
-    //                          ^^^^^^^^^^^^^^^^^^ table[&dep_name]["path"]
-    // ^^^^^^^^^^^^^ dep_name
-    for dep_category in ["dependencies", "dev-dependencies", "build-dependencies"] {
-        if let Some(dep_table) = table.get_mut(dep_category).and_then(|x| x.as_table_mut()) {
-            if dep_category == "dev-dependencies" && !known_path_deps.is_empty() {
-                // Remove dev-dependencies since building from sdist doesn't need them,
-                // Keep it when there are no path dependencies to support building from
-                // sdist with `--locked`/`--frozen`.
-                table.remove(dep_category).unwrap();
-                debug!(
-                    "Removing `dev-dependencies` from {} all together since there are no path dependencies",
-                    manifest_path.display(),
-                );
-                rewritten = true;
-                continue;
-            }
-            let dep_names: Vec<_> = dep_table.iter().map(|(key, _)| key.to_string()).collect();
-            for dep_name in dep_names {
-                let workspace_inherit = dep_table
-                    .get(&dep_name)
-                    .and_then(|x| x.get("workspace"))
-                    .and_then(|x| x.as_bool())
-                    .unwrap_or_default();
-
-                if !workspace_inherit {
-                    // There should either be no value for path, or it should be a string
-                    if dep_table
-                        .get(&dep_name)
-                        .and_then(|x| x.get("path"))
-                        .is_none()
-                    {
-                        continue;
-                    }
-                    if !dep_table[&dep_name]["path"].is_str() {
-                        bail!(
-                            "In {}, {} {} has a path value that is not a string",
-                            manifest_path.display(),
-                            dep_category,
-                            dep_name
-                        )
-                    }
-                    if !known_path_deps.contains_key(&dep_name) {
-                        bail!(
-                            "cargo metadata does not know about the path for {}.{} present in {}, \
-                            which should never happen ಠ_ಠ",
-                            dep_category,
-                            dep_name,
-                            manifest_path.display()
-                        );
-                    }
-                } else {
-                    // If a workspace inherited dependency isn't a path dep,
-                    // we need to replace `workspace = true` with its full requirement spec.
-                    if !known_path_deps.contains_key(&dep_name) {
-                        if let Some(workspace_dep) = workspace_deps.and_then(|x| x.get(&dep_name)) {
-                            let mut workspace_dep = workspace_dep.clone();
-                            // Merge optional and features from the current Cargo.toml
-                            if dep_table[&dep_name].get("optional").is_some() {
-                                ensure_dep_is_inline_table(&mut workspace_dep);
-                                workspace_dep["optional"] =
-                                    dep_table[&dep_name]["optional"].clone();
-                            }
-                            if let Some(features) = dep_table[&dep_name]
-                                .get("features")
-                                .and_then(|x| x.as_array())
-                            {
-                                ensure_dep_is_inline_table(&mut workspace_dep);
-                                let existing_features = workspace_dep
-                                    .as_table_like_mut()
-                                    .unwrap()
-                                    .entry("features")
-                                    .or_insert_with(|| {
-                                        toml_edit::Item::Value(toml_edit::Array::new().into())
-                                    })
-                                    .as_array_mut()
-                                    .with_context(|| {
-                                        format!(
-                                            "In {}, {} {} has a features value that is not an array",
-                                            manifest_path.display(),
-                                            dep_category,
-                                            dep_name
-                                        )
-                                    })?;
-                                existing_features.extend(features);
-                            }
-                            // See https://github.com/toml-rs/toml/issues/594
-                            dep_table.remove(&dep_name);
-                            dep_table[&dep_name] = workspace_dep;
-                            rewritten = true;
-                        } else {
-                            bail!(
-                                "In {}, {} {} is marked as `workspace = true`, but it is found neither in \
-                                    the workspace manifest nor in the known path dependencies",
-                                manifest_path.display(),
-                                dep_category,
-                                dep_name
-                            )
-                        }
-                        continue;
-                    }
-                }
-                // This is the location of the targeted crate in the source distribution
-                dep_table[&dep_name]["path"] = if root_crate {
-                    toml_edit::value(format!("{local_deps_folder}/{dep_name}"))
-                } else {
-                    // Cargo.toml contains relative paths, and we're already in LOCAL_DEPENDENCIES_FOLDER
-                    toml_edit::value(format!("../{dep_name}"))
-                };
-                if workspace_inherit {
-                    // Remove workspace inheritance now that we converted it into a path dependency
-                    dep_table[&dep_name]
-                        .as_table_like_mut()
-                        .unwrap()
-                        .remove("workspace");
-                }
-                rewritten = true;
-            }
-        }
-    }
-    Ok(rewritten)
-}
-
-/// Make sure that the dep entry is an inline table
-/// e.g. in the form of `{ version = "..." }`
-/// so that we can add entries for `optional` and `features`
-fn ensure_dep_is_inline_table(dep: &mut toml_edit::Item) {
-    if let Some(v) = dep.as_value_mut() {
-        if v.is_str() {
-            let val = std::mem::replace(v, toml_edit::Value::from(false));
-            let mut tab = toml_edit::InlineTable::new();
-            tab.insert("version", val);
-            *v = toml_edit::Value::InlineTable(tab);
-        }
-    }
-}
-
-/// When `Cargo.toml` is outside of the directory containing `pyproject.toml`,
-/// we put Rust crate source to `RUST_SRC_FOLDER` and
-/// update `tool.maturin.manifest-path` in `pyproject.toml`.
-fn rewrite_pyproject_toml(pyproject_toml_path: &Path) -> Result<String> {
+/// When `pyproject.toml` is inside of Cargo workspace root,
+/// we need to update `tool.maturin.manifest-path` in `pyproject.toml`.
+fn rewrite_pyproject_toml(
+    pyproject_toml_path: &Path,
+    relative_manifest_path: &Path,
+) -> Result<String> {
     let text = fs::read_to_string(pyproject_toml_path).context(format!(
         "Can't read pyproject.toml at {}",
         pyproject_toml_path.display(),
@@ -334,23 +81,23 @@ fn rewrite_pyproject_toml(pyproject_toml_path: &Path) -> Result<String> {
         "Failed to parse pyproject.toml at {}",
         pyproject_toml_path.display()
     ))?;
-    if let Some(tool) = data.get_mut("tool").and_then(|x| x.as_table_mut()) {
-        if let Some(maturin) = tool.get_mut("maturin").and_then(|x| x.as_table_mut()) {
-            if let Some(manifest_path) = maturin.get_mut("manifest-path") {
-                // original: ../$crate/Cargo.toml or ../../$crate/Cargo.toml
-                // rewrite to: $RUST_SRC_FOLDER/$crate/Cargo.toml
-                let path =
-                    Path::new(manifest_path.as_str().context(
-                        "tool.maturin.manifest-path in pyproject.toml must be a string",
-                    )?);
-                let crate_name = path.parent().unwrap().file_name().unwrap();
-                let new_path = Path::new(RUST_SRC_FOLDER)
-                    .join(crate_name)
-                    .join("Cargo.toml");
-                *manifest_path = toml_edit::value(new_path.to_str().unwrap());
-            }
-        }
-    }
+    let tool = data
+        .entry("tool")
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+        .as_table_like_mut()
+        .unwrap();
+    let maturin = tool
+        .entry("maturin")
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+        .as_table_like_mut()
+        .unwrap();
+
+    maturin.remove("manifest-path");
+    maturin.insert(
+        "manifest-path",
+        toml_edit::value(relative_manifest_path.to_str().unwrap()),
+    );
+
     Ok(data.to_string())
 }
 
@@ -362,7 +109,6 @@ fn add_crate_to_source_distribution(
     writer: &mut SDistWriter,
     pyproject_toml_path: impl AsRef<Path>,
     manifest_path: impl AsRef<Path>,
-    workspace_manifest: &toml_edit::Document,
     prefix: impl AsRef<Path>,
     known_path_deps: &HashMap<String, PathBuf>,
     root_crate: bool,
@@ -407,7 +153,7 @@ fn add_crate_to_source_distribution(
 
     // manifest_dir should be a relative path
     let manifest_dir = manifest_path.parent().unwrap();
-    let mut target_source: Vec<(PathBuf, PathBuf)> = file_list
+    let target_source: Vec<(PathBuf, PathBuf)> = file_list
         .iter()
         .map(|relative_to_manifests| {
             let relative_to_cwd = manifest_dir.join(relative_to_manifests);
@@ -428,6 +174,8 @@ fn add_crate_to_source_distribution(
             // and https://github.com/PyO3/maturin/issues/449
             if target == Path::new("Cargo.toml.orig") || target == Path::new("Cargo.toml") {
                 false
+            } else if root_crate && target == Path::new("pyproject.toml") {
+                false
             } else if matches!(target.extension(), Some(ext) if ext == "pyc" || ext == "pyd" || ext == "so") {
                 // Technically, `cargo package --list` should handle this,
                 // but somehow it doesn't on Alpine Linux running in GitHub Actions,
@@ -444,91 +192,19 @@ fn add_crate_to_source_distribution(
     let prefix = prefix.as_ref();
     writer.add_directory(prefix)?;
 
-    let mut cargo_toml_in_rust_src = false;
-
-    if root_crate
-        && !target_source
-            .iter()
-            .any(|(target, _)| target == Path::new("pyproject.toml"))
-    {
-        // Add pyproject.toml to the source distribution
-        // `pyproject.toml` may not be included in `cargo package --list`
-        // (e.g. it's not specified in `include` or is specified in `exclude` by mistake)
-        // we check if it's the same pyproject.toml file in Cargo.toml directory
-        let pyproject_toml_in_manifest_dir =
-            same_file::is_same_file(pyproject_toml_path, abs_manifest_dir.join("pyproject.toml"))
-                .unwrap_or(false);
-        if cargo_toml_in_subdir || pyproject_toml_in_manifest_dir {
-            // if Cargo.toml is in subdirectory of pyproject.toml directory
-            target_source.push((
-                PathBuf::from("pyproject.toml"),
-                pyproject_toml_path.to_path_buf(),
-            ));
-        } else {
-            // if pyproject.toml was not included by `cargo package --list`
-            // (e.g. because it is in a parent directory)
-            // we need to add `cargo package --list` files to a subdirectory
-            // and rewrite `tool.maturin.manifest-path` in pyproject.toml
-            let crate_name = abs_manifest_dir.file_name().unwrap();
-            // check that there isn't already a $RUST_SRC_FOLDER/$crate_name/ folder in python root
-            let rust_src = Path::new(RUST_SRC_FOLDER).join(crate_name);
-            if target_source
-                .iter()
-                .any(|(target, _)| target.starts_with(&rust_src))
-            {
-                bail!(
-                    "Cannot add crate {} to source distribution because there is already a {} folder, consider rename it to avoid conflicts",
-                    crate_name.to_string_lossy(),
-                    rust_src.display(),
-                );
-            }
-            target_source.iter_mut().for_each(|(target, _)| {
-                *target = rust_src.join(&target);
-            });
-            // rewrite `tool.maturin.manifest-path` in pyproject.toml
-            let rewritten_pyproject_toml = rewrite_pyproject_toml(pyproject_toml_path)?;
-            writer.add_bytes(
-                prefix.join("pyproject.toml"),
-                rewritten_pyproject_toml.as_bytes(),
-            )?;
-            cargo_toml_in_rust_src = true;
-        }
-    }
-
     let cargo_toml_path = if cargo_toml_in_subdir {
         let relative_manifest_path = abs_manifest_path.strip_prefix(pyproject_dir).unwrap();
         prefix.join(relative_manifest_path)
-    } else if cargo_toml_in_rust_src {
-        let crate_name = abs_manifest_dir.file_name().unwrap();
-        prefix
-            .join(RUST_SRC_FOLDER)
-            .join(crate_name)
-            .join(manifest_path.file_name().unwrap())
     } else {
         prefix.join(manifest_path.file_name().unwrap())
     };
 
-    let local_deps_folder = if cargo_toml_in_subdir {
-        let level = abs_manifest_dir
-            .strip_prefix(pyproject_dir)
-            .unwrap()
-            .components()
-            .count();
-        format!("{}{}", "../".repeat(level), LOCAL_DEPENDENCIES_FOLDER)
-    } else if cargo_toml_in_rust_src {
-        format!("../../{LOCAL_DEPENDENCIES_FOLDER}")
+    if root_crate {
+        let rewritten_cargo_toml = rewrite_cargo_toml(manifest_path, known_path_deps)?;
+        writer.add_bytes(cargo_toml_path, rewritten_cargo_toml.as_bytes())?;
     } else {
-        LOCAL_DEPENDENCIES_FOLDER.to_string()
-    };
-    let rewritten_cargo_toml = rewrite_cargo_toml(
-        manifest_path,
-        workspace_manifest,
-        known_path_deps,
-        local_deps_folder,
-        root_crate,
-    )?;
-
-    writer.add_bytes(cargo_toml_path, rewritten_cargo_toml.as_bytes())?;
+        writer.add_file(cargo_toml_path, manifest_path)?;
+    }
 
     for (target, source) in target_source {
         writer.add_file(prefix.join(target), source)?;
@@ -622,52 +298,31 @@ fn add_cargo_package_files_to_sdist(
     root_dir: &Path,
 ) -> Result<()> {
     let manifest_path = &build_context.manifest_path;
-    let workspace_manifest_path = build_context
-        .cargo_metadata
-        .workspace_root
-        .join("Cargo.toml");
-    let workspace_manifest: toml_edit::Document =
-        fs::read_to_string(workspace_manifest_path)?.parse()?;
+    let workspace_root = &build_context.cargo_metadata.workspace_root;
+    let workspace_manifest_path = workspace_root.join("Cargo.toml");
 
     let known_path_deps = find_path_deps(&build_context.cargo_metadata)?;
+    let mut sdist_root = workspace_root.clone().into_std_path_buf();
+    for path_dep in known_path_deps.values() {
+        if let Some(prefix) = common_path_prefix(&sdist_root, path_dep.parent().unwrap()) {
+            sdist_root = prefix;
+        } else {
+            bail!("Failed to determine common path prefix of path dependencies");
+        }
+    }
 
     // Add local path dependencies
-    let mut path_dep_workspace_manifests = HashMap::new();
     for (name, path_dep) in known_path_deps.iter() {
-        // Path dependencies may not be in the same workspace as the root crate,
-        // thus we need to find out its workspace root from `cargo metadata`
-        let path_dep_metadata = MetadataCommand::new()
-            .manifest_path(path_dep)
-            .verbose(true)
-            // We don't need to resolve the dependency graph
-            .no_deps()
-            .exec()
-            .with_context(|| {
-                format!(
-                    "Cargo metadata failed for {} at '{}'",
-                    name,
-                    path_dep.display()
-                )
-            })?;
-        let path_dep_workspace_manifest =
-            if path_dep_metadata.workspace_root == build_context.cargo_metadata.workspace_root {
-                &workspace_manifest
-            } else {
-                if !path_dep_workspace_manifests.contains_key(&path_dep_metadata.workspace_root) {
-                    let manifest: toml_edit::Document =
-                        fs::read_to_string(path_dep_metadata.workspace_root.join("Cargo.toml"))?
-                            .parse()?;
-                    path_dep_workspace_manifests
-                        .insert(path_dep_metadata.workspace_root.clone(), manifest);
-                }
-                &path_dep_workspace_manifests[&path_dep_metadata.workspace_root]
-            };
+        let relative_path_dep_manifest_dir = path_dep
+            .parent()
+            .unwrap()
+            .strip_prefix(&sdist_root)
+            .unwrap();
         add_crate_to_source_distribution(
             writer,
             pyproject_toml_path,
             path_dep,
-            path_dep_workspace_manifest,
-            &root_dir.join(LOCAL_DEPENDENCIES_FOLDER).join(name),
+            &root_dir.join(relative_path_dep_manifest_dir),
             &known_path_deps,
             false,
         )
@@ -679,42 +334,71 @@ fn add_cargo_package_files_to_sdist(
     }
 
     // Add the main crate
+    let relative_main_crate_manifest_dir = manifest_path
+        .parent()
+        .unwrap()
+        .strip_prefix(&sdist_root)
+        .unwrap();
     add_crate_to_source_distribution(
         writer,
         pyproject_toml_path,
         manifest_path,
-        &workspace_manifest,
-        root_dir,
+        root_dir.join(relative_main_crate_manifest_dir),
         &known_path_deps,
         true,
     )?;
 
+    // Add Cargo.lock file and workspace Cargo.toml
     let abs_manifest_path = manifest_path
         .normalize()
         .with_context(|| format!("failed to normalize path `{}`", manifest_path.display()))?
         .into_path_buf();
     let abs_manifest_dir = abs_manifest_path.parent().unwrap();
-    let cargo_lock_path = abs_manifest_dir.join("Cargo.lock");
-    let cargo_lock_exists = cargo_lock_path.exists();
-    let workspace_cargo_lock = build_context
-        .cargo_metadata
-        .workspace_root
-        .join("Cargo.lock");
-    let workspace_cargo_lock_exists = workspace_cargo_lock.exists();
+    let manifest_cargo_lock_path = abs_manifest_dir.join("Cargo.lock");
+    let workspace_cargo_lock = workspace_root.join("Cargo.lock").into_std_path_buf();
+    let (cargo_lock_path, use_workspace_cargo_lock) = if manifest_cargo_lock_path.exists() {
+        (Some(manifest_cargo_lock_path.clone()), false)
+    } else if workspace_cargo_lock.exists() {
+        (Some(workspace_cargo_lock), true)
+    } else {
+        (None, false)
+    };
     let cargo_lock_required =
         build_context.cargo_options.locked || build_context.cargo_options.frozen;
-    if cargo_lock_required || cargo_lock_exists || workspace_cargo_lock_exists {
-        let project_root = pyproject_toml_path.parent().unwrap();
-        let relative_cargo_lock = if cargo_lock_path.starts_with(project_root) {
-            cargo_lock_path.strip_prefix(project_root).unwrap()
-        } else {
-            cargo_lock_path.strip_prefix(abs_manifest_dir).unwrap()
-        };
-        if cargo_lock_exists {
+    if cargo_lock_required || cargo_lock_path.is_some() {
+        if let Some(cargo_lock_path) = cargo_lock_path {
+            let pyproject_root = pyproject_toml_path.parent().unwrap();
+            let project_root =
+                if pyproject_root == sdist_root || pyproject_root.starts_with(&sdist_root) {
+                    &sdist_root
+                } else if sdist_root.starts_with(pyproject_root) {
+                    pyproject_root
+                } else {
+                    unreachable!()
+                };
+            let relative_cargo_lock = cargo_lock_path.strip_prefix(project_root).unwrap();
             writer.add_file(root_dir.join(relative_cargo_lock), &cargo_lock_path)?;
+            if use_workspace_cargo_lock {
+                let relative_workspace_cargo_toml =
+                    relative_cargo_lock.with_file_name("Cargo.toml");
+                let mut deps_to_keep = known_path_deps.clone();
+                // Also need to the main Python binding crate
+                let main_member_name = abs_manifest_dir
+                    .strip_prefix(&sdist_root)
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                deps_to_keep.insert(main_member_name, manifest_path.clone());
+                let workspace_cargo_toml =
+                    rewrite_cargo_toml(workspace_manifest_path, &deps_to_keep)?;
+                writer.add_bytes(
+                    root_dir.join(relative_workspace_cargo_toml),
+                    workspace_cargo_toml.as_bytes(),
+                )?;
+            }
         } else {
-            // Fallback to workspace Cargo lock file
-            writer.add_file(root_dir.join(relative_cargo_lock), workspace_cargo_lock)?;
+            bail!("Cargo.lock is required by `--locked`/`--frozen` but it's not found.");
         }
     } else {
         eprintln!(
@@ -723,7 +407,22 @@ fn add_cargo_package_files_to_sdist(
         );
     }
 
+    // Add pyproject.toml
     let pyproject_dir = pyproject_toml_path.parent().unwrap();
+    if pyproject_dir != sdist_root {
+        // rewrite `tool.maturin.manifest-path` in pyproject.toml
+        let rewritten_pyproject_toml = rewrite_pyproject_toml(
+            pyproject_toml_path,
+            &relative_main_crate_manifest_dir.join("Cargo.toml"),
+        )?;
+        writer.add_bytes(
+            root_dir.join("pyproject.toml"),
+            rewritten_pyproject_toml.as_bytes(),
+        )?;
+    } else {
+        writer.add_file(root_dir.join("pyproject.toml"), pyproject_toml_path)?;
+    }
+
     // Add python source files
     let mut python_packages = Vec::new();
     if let Some(python_module) = build_context.project_layout.python_module.as_ref() {
@@ -869,4 +568,32 @@ pub fn source_distribution(
     );
 
     Ok(source_distribution_path)
+}
+
+/// Find the common prefix, if any, between two paths
+fn common_path_prefix<P, Q>(one: P, two: Q) -> Option<PathBuf>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+{
+    let one = one.as_ref();
+    let two = two.as_ref();
+    let one = one.components();
+    let two = two.components();
+    let mut final_path = PathBuf::new();
+    let mut found = false;
+    let paths = one.zip(two);
+    for (l, r) in paths {
+        if l == r {
+            final_path.push(l.as_os_str());
+            found = true;
+        } else {
+            break;
+        }
+    }
+    if found {
+        Some(final_path)
+    } else {
+        None
+    }
 }

--- a/test-crates/workspace_with_path_dep/python/pyproject.toml
+++ b/test-crates/workspace_with_path_dep/python/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
 requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
-
-[tool.maturin]
-manifest-path = "python/Cargo.toml"

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -8,7 +8,6 @@ use pretty_assertions::assert_eq;
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::Read;
-use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use tar::Archive;
 use time::OffsetDateTime;
@@ -118,7 +117,7 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
 pub fn test_source_distribution(
     package: impl AsRef<Path>,
     sdist_generator: SdistGenerator,
-    expected_files: Vec<&str>,
+    expected_files: Expect,
     expected_cargo_toml: Option<(&Path, Expect)>,
     unique_name: &str,
 ) -> Result<()> {
@@ -176,10 +175,7 @@ pub fn test_source_distribution(
             }
         }
     }
-    assert_eq!(
-        BTreeSet::from_iter(expected_files.into_iter().map(ToString::to_string)),
-        files
-    );
+    expected_files.assert_debug_eq(&files);
     assert_eq!(file_count, files.len(), "duplicated files found in sdist");
 
     if let Some((cargo_toml_path, expected)) = expected_cargo_toml {

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -483,19 +483,21 @@ fn workspace_members_non_local_dep_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/pyo3-pure",
         SdistGenerator::Cargo,
-        vec![
-            "pyo3_pure-0.1.0+abc123de/Cargo.lock",
-            "pyo3_pure-0.1.0+abc123de/Cargo.toml",
-            "pyo3_pure-0.1.0+abc123de/LICENSE",
-            "pyo3_pure-0.1.0+abc123de/PKG-INFO",
-            "pyo3_pure-0.1.0+abc123de/README.md",
-            "pyo3_pure-0.1.0+abc123de/check_installed/check_installed.py",
-            "pyo3_pure-0.1.0+abc123de/pyo3_pure.pyi",
-            "pyo3_pure-0.1.0+abc123de/pyproject.toml",
-            "pyo3_pure-0.1.0+abc123de/src/lib.rs",
-            "pyo3_pure-0.1.0+abc123de/tests/test_pyo3_pure.py",
-            "pyo3_pure-0.1.0+abc123de/tox.ini",
-        ],
+        expect![[r#"
+            {
+                "pyo3_pure-0.1.0+abc123de/Cargo.lock",
+                "pyo3_pure-0.1.0+abc123de/Cargo.toml",
+                "pyo3_pure-0.1.0+abc123de/LICENSE",
+                "pyo3_pure-0.1.0+abc123de/PKG-INFO",
+                "pyo3_pure-0.1.0+abc123de/README.md",
+                "pyo3_pure-0.1.0+abc123de/check_installed/check_installed.py",
+                "pyo3_pure-0.1.0+abc123de/pyo3_pure.pyi",
+                "pyo3_pure-0.1.0+abc123de/pyproject.toml",
+                "pyo3_pure-0.1.0+abc123de/src/lib.rs",
+                "pyo3_pure-0.1.0+abc123de/tests/test_pyo3_pure.py",
+                "pyo3_pure-0.1.0+abc123de/tox.ini",
+            }
+        "#]],
         Some((Path::new("pyo3_pure-0.1.0+abc123de/Cargo.toml"), cargo_toml)),
         "sdist-workspace-members-non-local-dep",
     ))
@@ -506,17 +508,19 @@ fn lib_with_path_dep_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/sdist_with_path_dep",
         SdistGenerator::Cargo,
-        vec![
-            "sdist_with_path_dep-0.1.0/some_path_dep/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/some_path_dep/src/lib.rs",
-            "sdist_with_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
-            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.lock",
-            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/src/lib.rs",
-            "sdist_with_path_dep-0.1.0/pyproject.toml",
-            "sdist_with_path_dep-0.1.0/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "sdist_with_path_dep-0.1.0/PKG-INFO",
+                "sdist_with_path_dep-0.1.0/pyproject.toml",
+                "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.lock",
+                "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.toml",
+                "sdist_with_path_dep-0.1.0/sdist_with_path_dep/src/lib.rs",
+                "sdist_with_path_dep-0.1.0/some_path_dep/Cargo.toml",
+                "sdist_with_path_dep-0.1.0/some_path_dep/src/lib.rs",
+                "sdist_with_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
+                "sdist_with_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
+            }
+        "#]],
         None,
         "sdist-lib-with-path-dep",
     ))
@@ -544,17 +548,19 @@ fn lib_with_target_path_dep_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/sdist_with_target_path_dep",
         SdistGenerator::Cargo,
-        vec![
-            "sdist_with_target_path_dep-0.1.0/some_path_dep/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/some_path_dep/src/lib.rs",
-            "sdist_with_target_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
-            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.lock",
-            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/src/lib.rs",
-            "sdist_with_target_path_dep-0.1.0/pyproject.toml",
-            "sdist_with_target_path_dep-0.1.0/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "sdist_with_target_path_dep-0.1.0/PKG-INFO",
+                "sdist_with_target_path_dep-0.1.0/pyproject.toml",
+                "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.lock",
+                "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.toml",
+                "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/src/lib.rs",
+                "sdist_with_target_path_dep-0.1.0/some_path_dep/Cargo.toml",
+                "sdist_with_target_path_dep-0.1.0/some_path_dep/src/lib.rs",
+                "sdist_with_target_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
+                "sdist_with_target_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
+            }
+        "#]],
         Some((
             Path::new("sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.toml"),
             cargo_toml,
@@ -568,17 +574,19 @@ fn pyo3_mixed_src_layout_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/pyo3-mixed-src/rust",
         SdistGenerator::Cargo,
-        vec![
-            "pyo3_mixed_src-2.1.3/pyproject.toml",
-            "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/__init__.py",
-            "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/python_module/__init__.py",
-            "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/python_module/double.py",
-            "pyo3_mixed_src-2.1.3/src/tests/test_pyo3_mixed.py",
-            "pyo3_mixed_src-2.1.3/rust/Cargo.toml",
-            "pyo3_mixed_src-2.1.3/rust/Cargo.lock",
-            "pyo3_mixed_src-2.1.3/rust/src/lib.rs",
-            "pyo3_mixed_src-2.1.3/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "pyo3_mixed_src-2.1.3/PKG-INFO",
+                "pyo3_mixed_src-2.1.3/pyproject.toml",
+                "pyo3_mixed_src-2.1.3/rust/Cargo.lock",
+                "pyo3_mixed_src-2.1.3/rust/Cargo.toml",
+                "pyo3_mixed_src-2.1.3/rust/src/lib.rs",
+                "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/__init__.py",
+                "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/python_module/__init__.py",
+                "pyo3_mixed_src-2.1.3/src/pyo3_mixed_src/python_module/double.py",
+                "pyo3_mixed_src-2.1.3/src/tests/test_pyo3_mixed.py",
+            }
+        "#]],
         None,
         "sdist-pyo3-mixed-src-layout",
     ))
@@ -589,23 +597,22 @@ fn pyo3_mixed_include_exclude_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/pyo3-mixed-include-exclude",
         SdistGenerator::Cargo,
-        vec![
-            // "pyo3_mixed_include_exclude-2.1.3/.gitignore", // excluded
-            "pyo3_mixed_include_exclude-2.1.3/Cargo.lock",
-            "pyo3_mixed_include_exclude-2.1.3/Cargo.toml",
-            "pyo3_mixed_include_exclude-2.1.3/PKG-INFO",
-            "pyo3_mixed_include_exclude-2.1.3/README.md",
-            "pyo3_mixed_include_exclude-2.1.3/check_installed/check_installed.py",
-            // "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/exclude_this_file, excluded
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/__init__.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/include_this_file", // included
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/__init__.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/double.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyproject.toml",
-            "pyo3_mixed_include_exclude-2.1.3/src/lib.rs",
-            // "pyo3_mixed_include_exclude-2.1.3/tests/test_pyo3_mixed_include_exclude.py", excluded
-            "pyo3_mixed_include_exclude-2.1.3/tox.ini",
-        ],
+        expect![[r#"
+            {
+                "pyo3_mixed_include_exclude-2.1.3/Cargo.lock",
+                "pyo3_mixed_include_exclude-2.1.3/Cargo.toml",
+                "pyo3_mixed_include_exclude-2.1.3/PKG-INFO",
+                "pyo3_mixed_include_exclude-2.1.3/README.md",
+                "pyo3_mixed_include_exclude-2.1.3/check_installed/check_installed.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/__init__.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/include_this_file",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/__init__.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/double.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyproject.toml",
+                "pyo3_mixed_include_exclude-2.1.3/src/lib.rs",
+                "pyo3_mixed_include_exclude-2.1.3/tox.ini",
+            }
+        "#]],
         None,
         "sdist-pyo3-mixed-include-exclude",
     ))
@@ -619,23 +626,22 @@ fn pyo3_mixed_include_exclude_git_sdist_generator() {
     handle_result(other::test_source_distribution(
         "test-crates/pyo3-mixed-include-exclude",
         SdistGenerator::Git,
-        vec![
-            // "pyo3_mixed_include_exclude-2.1.3/.gitignore", // excluded
-            "pyo3_mixed_include_exclude-2.1.3/Cargo.lock",
-            "pyo3_mixed_include_exclude-2.1.3/Cargo.toml",
-            "pyo3_mixed_include_exclude-2.1.3/PKG-INFO",
-            "pyo3_mixed_include_exclude-2.1.3/README.md",
-            "pyo3_mixed_include_exclude-2.1.3/check_installed/check_installed.py",
-            // "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/exclude_this_file, excluded
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/__init__.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/include_this_file", // included
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/__init__.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/double.py",
-            "pyo3_mixed_include_exclude-2.1.3/pyproject.toml",
-            "pyo3_mixed_include_exclude-2.1.3/src/lib.rs",
-            // "pyo3_mixed_include_exclude-2.1.3/tests/test_pyo3_mixed_include_exclude.py", excluded
-            "pyo3_mixed_include_exclude-2.1.3/tox.ini",
-        ],
+        expect![[r#"
+            {
+                "pyo3_mixed_include_exclude-2.1.3/Cargo.lock",
+                "pyo3_mixed_include_exclude-2.1.3/Cargo.toml",
+                "pyo3_mixed_include_exclude-2.1.3/PKG-INFO",
+                "pyo3_mixed_include_exclude-2.1.3/README.md",
+                "pyo3_mixed_include_exclude-2.1.3/check_installed/check_installed.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/__init__.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/include_this_file",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/__init__.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyo3_mixed_include_exclude/python_module/double.py",
+                "pyo3_mixed_include_exclude-2.1.3/pyproject.toml",
+                "pyo3_mixed_include_exclude-2.1.3/src/lib.rs",
+                "pyo3_mixed_include_exclude-2.1.3/tox.ini",
+            }
+        "#]],
         None,
         "sdist-pyo3-mixed-include-exclude-git",
     ))
@@ -665,14 +671,16 @@ fn workspace_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/workspace/py",
         SdistGenerator::Cargo,
-        vec![
-            "py-0.1.0/Cargo.toml",
-            "py-0.1.0/Cargo.lock",
-            "py-0.1.0/py/Cargo.toml",
-            "py-0.1.0/PKG-INFO",
-            "py-0.1.0/pyproject.toml",
-            "py-0.1.0/py/src/main.rs",
-        ],
+        expect![[r#"
+            {
+                "py-0.1.0/Cargo.lock",
+                "py-0.1.0/Cargo.toml",
+                "py-0.1.0/PKG-INFO",
+                "py-0.1.0/py/Cargo.toml",
+                "py-0.1.0/py/src/main.rs",
+                "py-0.1.0/pyproject.toml",
+            }
+        "#]],
         None,
         "sdist-workspace",
     ))
@@ -683,18 +691,20 @@ fn workspace_with_path_dep_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/workspace_with_path_dep/python",
         SdistGenerator::Cargo,
-        vec![
-            "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/Cargo.lock",
-            "workspace_with_path_dep-0.1.0/python/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/python/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/pyproject.toml",
-            "workspace_with_path_dep-0.1.0/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "workspace_with_path_dep-0.1.0/Cargo.lock",
+                "workspace_with_path_dep-0.1.0/Cargo.toml",
+                "workspace_with_path_dep-0.1.0/PKG-INFO",
+                "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
+                "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
+                "workspace_with_path_dep-0.1.0/pyproject.toml",
+                "workspace_with_path_dep-0.1.0/python/Cargo.toml",
+                "workspace_with_path_dep-0.1.0/python/src/lib.rs",
+                "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
+                "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rs",
+            }
+        "#]],
         None,
         "sdist-workspace-with-path-dep",
     ))
@@ -708,12 +718,14 @@ fn workspace_with_path_dep_git_sdist_generator() {
     handle_result(other::test_source_distribution(
         "test-crates/workspace_with_path_dep/python",
         SdistGenerator::Git,
-        vec![
-            "workspace_with_path_dep-0.1.0/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/pyproject.toml",
-            "workspace_with_path_dep-0.1.0/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "workspace_with_path_dep-0.1.0/Cargo.toml",
+                "workspace_with_path_dep-0.1.0/PKG-INFO",
+                "workspace_with_path_dep-0.1.0/pyproject.toml",
+                "workspace_with_path_dep-0.1.0/src/lib.rs",
+            }
+        "#]],
         None,
         "sdist-workspace-with-path-dep-git",
     ))
@@ -725,16 +737,18 @@ fn workspace_inheritance_sdist() {
     handle_result(other::test_source_distribution(
         "test-crates/workspace-inheritance/python",
         SdistGenerator::Cargo,
-        vec![
-            "workspace_inheritance-0.1.0/generic_lib/Cargo.toml",
-            "workspace_inheritance-0.1.0/generic_lib/src/lib.rs",
-            "workspace_inheritance-0.1.0/Cargo.toml",
-            "workspace_inheritance-0.1.0/Cargo.lock",
-            "workspace_inheritance-0.1.0/python/Cargo.toml",
-            "workspace_inheritance-0.1.0/python/src/lib.rs",
-            "workspace_inheritance-0.1.0/pyproject.toml",
-            "workspace_inheritance-0.1.0/PKG-INFO",
-        ],
+        expect![[r#"
+            {
+                "workspace_inheritance-0.1.0/Cargo.lock",
+                "workspace_inheritance-0.1.0/Cargo.toml",
+                "workspace_inheritance-0.1.0/PKG-INFO",
+                "workspace_inheritance-0.1.0/generic_lib/Cargo.toml",
+                "workspace_inheritance-0.1.0/generic_lib/src/lib.rs",
+                "workspace_inheritance-0.1.0/pyproject.toml",
+                "workspace_inheritance-0.1.0/python/Cargo.toml",
+                "workspace_inheritance-0.1.0/python/src/lib.rs",
+            }
+        "#]],
         None,
         "sdist-workspace-inheritance",
     ))

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -3,7 +3,7 @@
 use common::{
     develop, errors, get_python_implementation, handle_result, integration, other, test_python_path,
 };
-use indoc::indoc;
+use expect_test::expect;
 use maturin::pyproject_toml::SdistGenerator;
 use maturin::Target;
 use std::env;
@@ -464,8 +464,7 @@ fn workspace_cargo_lock() {
 
 #[test]
 fn workspace_members_non_local_dep_sdist() {
-    let cargo_toml = indoc!(
-        r#"
+    let cargo_toml = expect![[r#"
         [package]
         authors = ["konstin <konstin@mailbox.org>"]
         name = "pyo3-pure"
@@ -480,8 +479,7 @@ fn workspace_members_non_local_dep_sdist() {
         [lib]
         name = "pyo3_pure"
         crate-type = ["cdylib"]
-        "#
-    );
+        "#]];
     handle_result(other::test_source_distribution(
         "test-crates/pyo3-pure",
         SdistGenerator::Cargo,
@@ -509,14 +507,14 @@ fn lib_with_path_dep_sdist() {
         "test-crates/sdist_with_path_dep",
         SdistGenerator::Cargo,
         vec![
-            "sdist_with_path_dep-0.1.0/local_dependencies/some_path_dep/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/local_dependencies/some_path_dep/src/lib.rs",
-            "sdist_with_path_dep-0.1.0/local_dependencies/transitive_path_dep/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/local_dependencies/transitive_path_dep/src/lib.rs",
-            "sdist_with_path_dep-0.1.0/Cargo.toml",
-            "sdist_with_path_dep-0.1.0/Cargo.lock",
+            "sdist_with_path_dep-0.1.0/some_path_dep/Cargo.toml",
+            "sdist_with_path_dep-0.1.0/some_path_dep/src/lib.rs",
+            "sdist_with_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
+            "sdist_with_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
+            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.lock",
+            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/Cargo.toml",
+            "sdist_with_path_dep-0.1.0/sdist_with_path_dep/src/lib.rs",
             "sdist_with_path_dep-0.1.0/pyproject.toml",
-            "sdist_with_path_dep-0.1.0/src/lib.rs",
             "sdist_with_path_dep-0.1.0/PKG-INFO",
         ],
         None,
@@ -525,9 +523,8 @@ fn lib_with_path_dep_sdist() {
 }
 
 #[test]
-fn lib_with_target_path_dep() {
-    let cargo_toml = indoc!(
-        r#"
+fn lib_with_target_path_dep_sdist() {
+    let cargo_toml = expect![[r#"
         [package]
         name = "sdist_with_target_path_dep"
         version = "0.1.0"
@@ -542,25 +539,24 @@ fn lib_with_target_path_dep() {
         pyo3 = { version = "0.19.0", default-features = false, features = ["extension-module"] }
 
         [target.'cfg(not(target_endian = "all-over-the-place"))'.dependencies]
-        some_path_dep = { path = "local_dependencies/some_path_dep" }
-        "#
-    );
+        some_path_dep = { path = "../some_path_dep" }
+    "#]];
     handle_result(other::test_source_distribution(
         "test-crates/sdist_with_target_path_dep",
         SdistGenerator::Cargo,
         vec![
-            "sdist_with_target_path_dep-0.1.0/local_dependencies/some_path_dep/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/local_dependencies/some_path_dep/src/lib.rs",
-            "sdist_with_target_path_dep-0.1.0/local_dependencies/transitive_path_dep/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/local_dependencies/transitive_path_dep/src/lib.rs",
-            "sdist_with_target_path_dep-0.1.0/Cargo.toml",
-            "sdist_with_target_path_dep-0.1.0/Cargo.lock",
+            "sdist_with_target_path_dep-0.1.0/some_path_dep/Cargo.toml",
+            "sdist_with_target_path_dep-0.1.0/some_path_dep/src/lib.rs",
+            "sdist_with_target_path_dep-0.1.0/transitive_path_dep/Cargo.toml",
+            "sdist_with_target_path_dep-0.1.0/transitive_path_dep/src/lib.rs",
+            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.lock",
+            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.toml",
+            "sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/src/lib.rs",
             "sdist_with_target_path_dep-0.1.0/pyproject.toml",
-            "sdist_with_target_path_dep-0.1.0/src/lib.rs",
             "sdist_with_target_path_dep-0.1.0/PKG-INFO",
         ],
         Some((
-            Path::new("sdist_with_target_path_dep-0.1.0/Cargo.toml"),
+            Path::new("sdist_with_target_path_dep-0.1.0/sdist_with_target_path_dep/Cargo.toml"),
             cargo_toml,
         )),
         "sdist-lib-with-target-path-dep",
@@ -670,11 +666,12 @@ fn workspace_sdist() {
         "test-crates/workspace/py",
         SdistGenerator::Cargo,
         vec![
-            "py-0.1.0/Cargo.lock",
             "py-0.1.0/Cargo.toml",
+            "py-0.1.0/Cargo.lock",
+            "py-0.1.0/py/Cargo.toml",
             "py-0.1.0/PKG-INFO",
             "py-0.1.0/pyproject.toml",
-            "py-0.1.0/src/main.rs",
+            "py-0.1.0/py/src/main.rs",
         ],
         None,
         "sdist-workspace",
@@ -687,11 +684,12 @@ fn workspace_with_path_dep_sdist() {
         "test-crates/workspace_with_path_dep/python",
         SdistGenerator::Cargo,
         vec![
-            "workspace_with_path_dep-0.1.0/local_dependencies/generic_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/local_dependencies/generic_lib/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/local_dependencies/transitive_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/local_dependencies/transitive_lib/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/python/Cargo.lock",
+            "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
+            "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
+            "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
+            "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rs",
+            "workspace_with_path_dep-0.1.0/Cargo.toml",
+            "workspace_with_path_dep-0.1.0/Cargo.lock",
             "workspace_with_path_dep-0.1.0/python/Cargo.toml",
             "workspace_with_path_dep-0.1.0/python/src/lib.rs",
             "workspace_with_path_dep-0.1.0/pyproject.toml",
@@ -711,17 +709,9 @@ fn workspace_with_path_dep_git_sdist_generator() {
         "test-crates/workspace_with_path_dep/python",
         SdistGenerator::Git,
         vec![
-            "workspace_with_path_dep-0.1.0/Cargo.lock",
             "workspace_with_path_dep-0.1.0/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/dont_include_in_sdist/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/dont_include_in_sdist/src/main.rs",
-            "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
             "workspace_with_path_dep-0.1.0/pyproject.toml",
-            "workspace_with_path_dep-0.1.0/python/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/python/src/lib.rs",
-            "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
-            "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rs",
+            "workspace_with_path_dep-0.1.0/src/lib.rs",
             "workspace_with_path_dep-0.1.0/PKG-INFO",
         ],
         None,
@@ -736,12 +726,13 @@ fn workspace_inheritance_sdist() {
         "test-crates/workspace-inheritance/python",
         SdistGenerator::Cargo,
         vec![
-            "workspace_inheritance-0.1.0/local_dependencies/generic_lib/Cargo.toml",
-            "workspace_inheritance-0.1.0/local_dependencies/generic_lib/src/lib.rs",
-            "workspace_inheritance-0.1.0/Cargo.lock",
+            "workspace_inheritance-0.1.0/generic_lib/Cargo.toml",
+            "workspace_inheritance-0.1.0/generic_lib/src/lib.rs",
             "workspace_inheritance-0.1.0/Cargo.toml",
+            "workspace_inheritance-0.1.0/Cargo.lock",
+            "workspace_inheritance-0.1.0/python/Cargo.toml",
+            "workspace_inheritance-0.1.0/python/src/lib.rs",
             "workspace_inheritance-0.1.0/pyproject.toml",
-            "workspace_inheritance-0.1.0/src/lib.rs",
             "workspace_inheritance-0.1.0/PKG-INFO",
         ],
         None,


### PR DESCRIPTION
TODO:
- [x] Test on real world packages, especially the ones we had bug reports regarding sdist.
  - [x] resvg-cli
  - [x] polars
  - [x] pyxel
  - [x] ruff
  - [x] pydantic-core
  - [x] ast-grep
  - [x] cryptography (cargo & git sdist generator)
  - [x] typos-cli
  - [x] pyoxigraph
  - [x] geoarrow-rs

Closes #1442