### PR TITLE
Add chardetng-py to Examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ maturin itself is manylinux compliant when compiled for the musl target.
 ## Examples
 
 * [ballista-python](https://github.com/apache/arrow-ballista-python) - A Python library that binds to Apache Arrow distributed query engine Ballista
+* [chardetng-py](https://github.com/john-parton/chardetng-py) - Python binding for the chardetng character encoding detector.
 * [connector-x](https://github.com/sfu-db/connector-x/tree/main/connectorx-python) - ConnectorX enables you to load data from databases into Python in the fastest and most memory efficient way
 * [datafusion-python](https://github.com/apache/arrow-datafusion-python) - a Python library that binds to Apache Arrow in-memory query engine DataFusion
 * [deltalake-python](https://github.com/delta-io/delta-rs/tree/main/python) - Native Delta Lake Python binding based on delta-rs with Pandas integration


### PR DESCRIPTION
chardetng-py is a Python binding for the chardetng character encoding detector.

I'm not the author of the original chardet library, and normally I would say these sorts of bindings are kind of "trivial" and uninteresting, but it's worth noting that two biggest similar libraries in the python ecosystem are:

* cChardet - CPU optimized and very fast, but only supports x86 and Python 3.8 and earlier (no Pypy, no Python3.9+, and so on)
* charset-normalizer - pure Python, so very good platform support, but easily 10x slower than cChardet (and chardetng)

So with maturin I was able to build a package that is supported on practically every version of python, every os, every architecture that someone is likely to need it on, and still get the performance bonus of optimized machine code.

Great job everyone. I'm very impressed with this project