### PR TITLE
Added --pip-path argument to develop

### DIFF
--- a/guide/src/develop.md
+++ b/guide/src/develop.md
@@ -34,6 +34,12 @@ Options:
 
           Only works with mixed Rust/Python project layout
 
+       --pip-path <PIP_PATH>
+           Use a specific pip installation instead of the default one.
+           
+           This can be used to supply the path to a pip executable when the current virtualenv does
+           not provide one.
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -28,6 +28,12 @@ Options:
           
           Only works with mixed Rust/Python project layout
 
+       --pip-path <PIP_PATH>
+           Use a specific pip installation instead of the default one.
+           
+           This can be used to supply the path to a pip executable when the current virtualenv does
+           not provide one.
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -28,11 +28,11 @@ Options:
           
           Only works with mixed Rust/Python project layout
 
-       --pip-path <PIP_PATH>
-           Use a specific pip installation instead of the default one.
-           
-           This can be used to supply the path to a pip executable when the current virtualenv does
-           not provide one.
+      --pip-path <PIP_PATH>
+          Use a specific pip installation instead of the default one.
+          
+          This can be used to supply the path to a pip executable when the current virtualenv does
+          not provide one.
 
   -q, --quiet
           Do not print cargo log messages

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -50,6 +50,7 @@ pub fn test_develop(
         strip: false,
         extras: Vec::new(),
         skip_install: false,
+        pip_path: None,
         cargo_options: CargoOptions {
             manifest_path: Some(manifest_file),
             quiet: true,


### PR DESCRIPTION
This changes `develop` so that `--pip-path` can be passed to use a different pip. Example with rye:

```
maturin develop --pip-path ~/.rye/self/bin/pip
```

Fixes #1752 