### PR TITLE
fixed python 3.7 compatibility

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -18,7 +18,7 @@ import struct
 import subprocess
 import sys
 from subprocess import SubprocessError
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, List, Optional
 
 try:
     import tomllib
@@ -33,8 +33,8 @@ def get_config() -> Dict[str, str]:
 
 
 def get_maturin_pep517_args(
-    config_settings: Mapping[str, Any] | None = None
-) -> list[str]:
+    config_settings: Optional[Mapping[str, Any]] = None
+) -> List[str]:
     build_args = config_settings.get("build-args") if config_settings else None
     if build_args is None:
         env_args = os.getenv("MATURIN_PEP517_ARGS", "")
@@ -50,7 +50,7 @@ def get_maturin_pep517_args(
     return args
 
 
-def _additional_pep517_args() -> list[str]:
+def _additional_pep517_args() -> List[str]:
     # Support building for 32-bit Python on x64 Windows
     if platform.system().lower() == "windows" and platform.machine().lower() == "amd64":
         pointer_width = struct.calcsize("P") * 8
@@ -62,8 +62,8 @@ def _additional_pep517_args() -> list[str]:
 # noinspection PyUnusedLocal
 def _build_wheel(
     wheel_directory: str,
-    config_settings: Mapping[str, Any] | None = None,
-    metadata_directory: str | None = None,
+    config_settings: Optional[Mapping[str, Any]] = None,
+    metadata_directory: Optional[str] = None,
     editable: bool = False,
 ) -> str:
     # PEP 517 specifies that only `sys.executable` points to the correct
@@ -105,15 +105,15 @@ def _build_wheel(
 # noinspection PyUnusedLocal
 def build_wheel(
     wheel_directory: str,
-    config_settings: Mapping[str, Any] | None = None,
-    metadata_directory: str | None = None,
+    config_settings: Optional[Mapping[str, Any]] = None,
+    metadata_directory: Optional[str] = None,
 ) -> str:
     return _build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
 # noinspection PyUnusedLocal
 def build_sdist(
-    sdist_directory: str, config_settings: Mapping[str, Any] | None = None
+    sdist_directory: str, config_settings: Optional[Mapping[str, Any]] = None
 ) -> str:
     command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
 
@@ -133,8 +133,8 @@ def build_sdist(
 
 # noinspection PyUnusedLocal
 def get_requires_for_build_wheel(
-    config_settings: Mapping[str, Any] | None = None
-) -> list[str]:
+    config_settings: Optional[Mapping[str, Any]] = None
+) -> List[str]:
     if get_config().get("bindings") == "cffi":
         return ["cffi"]
     else:
@@ -144,8 +144,8 @@ def get_requires_for_build_wheel(
 # noinspection PyUnusedLocal
 def build_editable(
     wheel_directory: str,
-    config_settings: Mapping[str, Any] | None = None,
-    metadata_directory: str | None = None,
+    config_settings: Optional[Mapping[str, Any]] = None,
+    metadata_directory: Optional[str] = None,
 ) -> str:
     return _build_wheel(
         wheel_directory, config_settings, metadata_directory, editable=True
@@ -158,14 +158,14 @@ get_requires_for_build_editable = get_requires_for_build_wheel
 
 # noinspection PyUnusedLocal
 def get_requires_for_build_sdist(
-    config_settings: Mapping[str, Any] | None = None
-) -> list:
+    config_settings: Optional[Mapping[str, Any]] = None
+) -> List[str]:
     return []
 
 
 # noinspection PyUnusedLocal
 def prepare_metadata_for_build_wheel(
-    metadata_directory: str, config_settings: Mapping[str, Any] | None = None
+    metadata_directory: str, config_settings: Optional[Mapping[str, Any]] = None
 ) -> str:
     print("Checking for Rust toolchain....")
     is_cargo_installed = False

--- a/maturin/__main__.py
+++ b/maturin/__main__.py
@@ -4,9 +4,10 @@ import os
 import sys
 from pathlib import Path
 import sysconfig
+from typing import Optional
 
 
-def get_maturin_path() -> Path | None:
+def get_maturin_path() -> Optional[Path]:
     SCRIPT_NAME = "maturin"
 
     def script_dir(scheme: str) -> str:


### PR DESCRIPTION
in the `pyproject.toml` file, maturin indicates that the minimum supported python version is 3.7 but the code uses

- [subscripted builtins](https://peps.python.org/pep-0585/) (i.e. `list[str]` instead of `typing.List[str]`) which was introduced in python 3.9
- [`|` to denote unions](https://peps.python.org/pep-0604/) (i.e. `str | int` instead of `typing.Union[str, int]`) which was introduced in python 3.10

(the import hook in https://github.com/PyO3/maturin/pull/1748 also aims to be compatible with python 3.7)