### PR TITLE
Fix platform tag for graalpy

### DIFF
--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -520,18 +520,15 @@ impl PythonInterpreter {
                     )
                 }
                 InterpreterKind::GraalPy => {
-                    // GraalPy suffers from pypa/packaging#614, where
-                    // packaging misdetects it as a 32-bit implementation,
-                    // so GraalPy adds the correct platform itself, e.g.
-                    // graalpy 3.10 23.1 => numpy-1.23.5-graalpy310-graalpy231_310_native_x86_64_linux-linux_i686.whl
+                    // GraalPy like PyPy uses its version as part of the ABI
+                    // graalpy 3.10 23.1 => numpy-1.23.5-graalpy310-graalpy231_310_native_manylinux2014_x86_64.whl
                     format!(
-                        "graalpy{major}{minor}-{abi_tag}_{arch}_{os}-{os}_i686",
+                        "graalpy{major}{minor}-{abi_tag}_{platform}",
                         major = self.major,
                         minor = self.minor,
                         abi_tag = calculate_abi_tag(&self.ext_suffix)
                             .expect("GraalPy's syconfig didn't define a valid `EXT_SUFFIX` ಠ_ಠ"),
-                        os = target.get_python_os(),
-                        arch = target.get_python_arch(),
+                        platform = platform,
                     )
                 }
             }


### PR DESCRIPTION
With https://github.com/pypa/packaging/pull/711 merged, GraalPy is now correctly detected as and produces wheels with 64bit platform tags.