### PR TITLE
Warn about incorrect version in `build-system.requires`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Warning about incorrect maturin version pyproject.toml `[build-system] requires`
+
 ## [1.2.3] - 2023-08-17
 
 * Fix sdist build failure with workspace path dependencies by HerringtonDarkholme in [#1739](https://github.com/PyO3/maturin/pull/1739)

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -90,7 +90,7 @@ impl ProjectResolver {
         let manifest_dir = manifest_file.parent().unwrap();
         let pyproject_toml: Option<PyProjectToml> = if pyproject_file.is_file() {
             let pyproject = PyProjectToml::new(&pyproject_file)?;
-            pyproject.warn_missing_maturin_version();
+            pyproject.warn_bad_maturin_version();
             pyproject.warn_missing_build_backend();
             Some(pyproject)
         } else {


### PR DESCRIPTION
Maturin should warn if the version in the pyproject.toml build system requirements is incompatible with the one that is currently running (#1792). We only warn instead of erroring to allow e.g. testing a prerelease version of maturin with a project without having to edit the requires.

pyproject.toml:

```toml
[build-system]
requires = ["maturin==0.0.1"]
build-backend = "maturin"
```

Output:

```
⚠️  Warning: You specified maturin ==0.0.1 in pyproject.toml under `build-system.requires`, but the current maturin version is 1.2.3
```

Fixes #1792.