### PR TITLE
Use external `uniffi-bindgen` if no root package is configured

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -872,11 +872,14 @@ fn uniffi_bindgen_command(crate_dir: &Path) -> Result<Command> {
         .no_deps()
         .verbose(true)
         .exec()?;
-    let root_pkg = cargo_metadata.root_package().unwrap();
+    let root_pkg = cargo_metadata.root_package();
     let has_uniffi_bindgen_target = root_pkg
-        .targets
-        .iter()
-        .any(|target| target.name == "uniffi-bindgen" && target.is_bin());
+        .map(|pkg| {
+            pkg.targets
+                .iter()
+                .any(|target| target.name == "uniffi-bindgen" && target.is_bin())
+        })
+        .unwrap_or(false);
     let command = if has_uniffi_bindgen_target {
         let mut command = Command::new("cargo");
         command.args(["run", "--bin", "uniffi-bindgen", "--manifest-path"]);


### PR DESCRIPTION
A "root package" in Cargo exists in a workspace if the workspace Cargo.toml also has a `[package]` section.
In that case maturin tries to find a binary target called `uniffi-bindgen` to use.

But if there's no root package to begin with it should fall back to an external `uniffi-bindgen` instead of panicking.

Fixes #1796 

---

Note that this new behavior does not seem to be documented yet.
I'm not sure how common a root package is really.