### PR TITLE
Stop testing Python 3.7 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
         - macos-13
         - windows-latest
       PYTHON_VERSION: |
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
@@ -357,8 +356,8 @@ jobs:
         platform:
           # CPython
           - target: aarch64-unknown-linux-gnu
-            abi: cp37-cp37m
-            python: python3.7
+            abi: cp38-cp38
+            python: python3.8
             container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
           - target: armv7-unknown-linux-gnueabihf
             abi: cp39-cp39

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,17 +39,17 @@ FROM base-$TARGETARCH
 
 ENV PATH /root/.cargo/bin:$PATH
 # Add all supported python versions
-ENV PATH /opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:$PATH
+ENV PATH /opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH
 # Otherwise `cargo new` errors
 ENV USER root
 
 RUN curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && yum install -y libffi-devel openssh-clients \
-    && python3.7 -m pip install --no-cache-dir cffi \
     && python3.8 -m pip install --no-cache-dir cffi \
     && python3.9 -m pip install --no-cache-dir cffi \
     && python3.10 -m pip install --no-cache-dir cffi \
     && python3.11 -m pip install --no-cache-dir cffi \
+    && python3.12 -m pip install --no-cache-dir cffi \
     && mkdir /io
 
 COPY --from=builder /usr/bin/maturin /usr/bin/maturin

--- a/guide/src/platform_support.md
+++ b/guide/src/platform_support.md
@@ -33,7 +33,7 @@ supported by [manylinux](https://github.com/pypa/manylinux).
 
 ## Python Support
 
-CPython 3.7 to 3.10 are supported and tested on CI, though the entire 3.x series should work.
+CPython 3.8 to 3.10 are supported and tested on CI, though the entire 3.x series should work.
 This will be changed as new python versions are released and others have their end of life.
 
 PyPy 3.6 and later also works, as does GraalPy 23.0 and later.

--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -36,8 +36,8 @@ crate-type = ["cdylib"]
 rand = "0.8.4"
 
 [dependencies.pyo3]
-version = "0.18.0"
-# "abi3-py37" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.7
+version = "0.19.0"
+# "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["abi3-py37"]
 ```
 
@@ -76,7 +76,7 @@ Options:
 ```
 
 The above process can be achieved by running `maturin new -b pyo3 guessing_game`
-then edit `Cargo.toml` to add `abi3-py37` feature.
+then edit `Cargo.toml` to add `abi3-py38` feature.
 
 ## Install and configure maturin (in a virtual environment)
 
@@ -88,7 +88,7 @@ ferris@rustbox [~/src/rust/guessing-game] % python3 -m venv .venv
 ferris@rustbox [~/src/rust/guessing-game] % source .venv/bin/activate
 (.venv) ferris@rustbox [~/src/rust/guessing-game] % pip install -U pip maturin
 (.venv) ferris@rustbox [~/src/rust/guessing-game] % pip freeze
-maturin==0.14.0
+maturin==1.3.0
 tomli==2.0.1
 ```
 
@@ -200,7 +200,7 @@ So let's use maturin to build and install in our current environment.
 
 ```shell
 (.venv) ferris@rustbox [~/src/rust/guessing-game] % maturin develop
-🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
+🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.8
 🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
    Compiling pyo3-build-config v0.18.0
    Compiling libc v0.2.119
@@ -276,10 +276,10 @@ wheels compatible with a wide range of Linux distros.
 
 ```shell
 (.venv) ferris@rustbox [~/src/rust/guessing-game] % maturin build
-🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
+🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.8
 🐍 Not using a specific python interpreter (With abi3, an interpreter is only required on windows)
     Finished dev [unoptimized + debuginfo] target(s) in 7.32s
-📦 Built wheel for abi3 Python ≥ 3.7 to /Users/ferris/src/rust/guessing-game/target/wheels/guessing_game-0.1.0-cp37-abi3-macosx_10_7_x86_64.whl
+📦 Built wheel for abi3 Python ≥ 3.8 to /Users/ferris/src/rust/guessing-game/target/wheels/guessing_game-0.1.0-cp37-abi3-macosx_10_7_x86_64.whl
 ```
 
 maturin can even publish wheels directly to [PyPI](https://pypi.org) with

--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "{{ name }}"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/tests/manylinux_compliant.sh
+++ b/tests/manylinux_compliant.sh
@@ -3,6 +3,6 @@ set -e
 
 which cargo > /dev/null 2>&1 || curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
-for PYBIN in /opt/python/cp3[789]*/bin; do
+for PYBIN in /opt/python/cp3[89]*/bin; do
   cargo run -- build -m test-crates/pyo3-mixed/Cargo.toml --target-dir test-crates/targets -i "${PYBIN}/python" --manylinux $1 -o dist
 done


### PR DESCRIPTION
Python 3.7 is EOL, we might also drop support later.