### PR TITLE
Add trusted publishing section to the user guide

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -289,3 +289,13 @@ Options:
   -h, --help
           Print help information (use `-h` for a summary)
 ```
+
+### Using PyPI's trusted publishing
+
+By default, the workflow provided by `generate-ci` will publish the release artifacts to PyPI using API token authentication. However, maturin also supports [trusted publishing (OpenID Connect)](https://docs.pypi.org/trusted-publishers/).
+
+To enable it, modify the `release` action in the generated GitHub workflow file:
+- remove `MATURIN_PYPI_TOKEN` from the `env` section to make maturin use trusted publishing
+- add `id-token: write` to the action's `permissions` (see [Configuring OpenID Connect in PyPI](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi) from GitHub's documentation).
+
+Make sure to follow the steps listed in [PyPI's documentation](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to set up your GitHub repository as a trusted publisher in the PyPI project settings before attempting to run the workflow.


### PR DESCRIPTION
Hi and thank you for maturin, it's great!

I couldn't figure out how to use the workflow provided by `generate-ci` with PyPI's trusted publishing, but found the solution in issue https://github.com/PyO3/maturin/issues/1575#issuecomment-1702761101. Here's a PR to add a short section about it to the distribution page in the user guide. Feedback is welcome.

PS: I've also toyed with making trusted publishing the default, but I don't know if this is desirable as some users will have different registries than PyPI. If you prefer, I can make a different PR with [those changes](https://github.com/PyO3/maturin/compare/main...Phil-V:maturin:trusted-publishing) after doing some further testing.
