### PR TITLE
Pytest skeleton in mixed template

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add unittest skeleton to mixed Python/Rust projects
+
 ## [1.3.0] - 2023-10-02
 
 * Refactor Cargo sdist generator to avoid rewriting local dependencies in [#1741](https://github.com/PyO3/maturin/pull/1741)

--- a/src/new_project.rs
+++ b/src/new_project.rs
@@ -43,6 +43,7 @@ impl<'a> ProjectGenerator<'a> {
         env.add_template("main.rs", include_str!("templates/main.rs.j2"))?;
         env.add_template("build.rs", include_str!("templates/build.rs.j2"))?;
         env.add_template("__init__.py", include_str!("templates/__init__.py.j2"))?;
+        env.add_template("test_all.py", include_str!("templates/test_all.py.j2"))?;
         env.add_template("example.udl", include_str!("templates/example.udl.j2"))?;
 
         let bridge_model = match bindings.as_str() {
@@ -85,6 +86,10 @@ impl<'a> ProjectGenerator<'a> {
                 let python_project = python_dir.join(&self.crate_name);
                 fs::create_dir_all(&python_project)?;
                 self.write_project_file(&python_project, "__init__.py")?;
+
+                let test_dir = python_dir.join("tests");
+                fs::create_dir_all(&test_dir)?;
+                self.write_project_file(&test_dir, "test_all.py")?;
 
                 if src {
                     project_path.join("rust")

--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -13,6 +13,12 @@ classifiers = [
 {% if bindings == "cffi" -%}
 dependencies = ["cffi"]
 {% endif -%}
+{% if mixed_non_src -%}
+[project.optional-dependencies]
+tests = [
+    "pytest",
+]
+{% endif -%}
 dynamic = ["version"]
 
 {% if bindings in ["bin", "cffi", "pyo3", "rust-cpython"] or mixed_non_src -%}

--- a/src/templates/test_all.py.j2
+++ b/src/templates/test_all.py.j2
@@ -1,0 +1,6 @@
+import pytest
+import {{ crate_name }}
+
+
+def test_sum_as_string():
+    assert {{ crate_name }}.sum_as_string(1, 1) == "2"


### PR DESCRIPTION
I believe it's a good practice to nudge people towards best practices, and having unit tests is definitely a best practice that should be embraced.

This PR adds a small Pytest skeleton to projects created with `maturin init --mixed`, so that people know where to place their Python unit tests, and are nudged towards writing them. The resulting structure is as follows:

```
├── Cargo.toml
├── pyproject.toml
├── python
│   ├── asd
│   │   └── __init__.py
│   └── tests
│       └── test_all.py
└── src
    └── lib.rs
```