### PR TITLE
Keep trailing newlines from templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e436cdb19900a08197c6b874280d24f9289d127275eadc23623276e0f5ec97e9"
+checksum = "80084fa3099f58b7afab51e5f92e24c2c2c68dcad26e96ad104bd6011570461d"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"], optional =
 # project scaffolding, maturin new/init/generate-ci
 dialoguer = { version = "0.10.2", default-features = false, optional = true }
 console = { version = "0.15.4", optional = true }
-minijinja = { version = "1.0.0", optional = true }
+minijinja = { version = "1.0.7", optional = true }
 
 # upload
 bytesize = { version = "1.0.1", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Add unittest skeleton to mixed Python/Rust projects
+* Preserve trailing whitespace in new project files
 
 ## [1.3.0] - 2023-10-02
 

--- a/src/new_project.rs
+++ b/src/new_project.rs
@@ -33,6 +33,7 @@ impl<'a> ProjectGenerator<'a> {
     ) -> Result<Self> {
         let crate_name = project_name.replace('-', "_");
         let mut env = Environment::new();
+        env.set_keep_trailing_newline(true);
         env.add_template(".gitignore", include_str!("templates/.gitignore.j2"))?;
         env.add_template("Cargo.toml", include_str!("templates/Cargo.toml.j2"))?;
         env.add_template(


### PR DESCRIPTION
Both rustfmt and pycodestyle/PEP8 require a trailing newline in code files. These newlines are produced by most code editors and are there in the code templates, however `minijinja` is configured to remove any trailing newlines. This means maturin produces templates that don't adhere to the code styles in both Rust an Python.

This PR

 1. Bumps the `minijinja` requirement to `1.0.7` (that's when the [option was introduced](https://github.com/mitsuhiko/minijinja/commit/53da32be602bc50fde4c3d603aba4dcd74bd314d))
 1. Sets [`Environment::set_keep_trailing_newline(true)`](https://docs.rs/minijinja/latest/minijinja/struct.Environment.html#method.set_keep_trailing_newline)

I'm relatively new to Rust and Cargo, and I am a bit worried by the massive change in `Cargo.lock`. Is this supposed to happen, or did I do something wrong?