### PR TITLE
Auto detect Python 3.13

### DIFF
--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -21,7 +21,7 @@ mod config;
 const GET_INTERPRETER_METADATA: &str = include_str!("get_interpreter_metadata.py");
 pub const MINIMUM_PYTHON_MINOR: usize = 7;
 /// Be liberal here to include preview versions
-pub const MAXIMUM_PYTHON_MINOR: usize = 12;
+pub const MAXIMUM_PYTHON_MINOR: usize = 13;
 pub const MAXIMUM_PYPY_MINOR: usize = 10;
 
 /// Identifies conditions where we do not want to build wheels

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -989,19 +989,19 @@ mod tests {
         let target =
             Target::from_target_triple(Some("x86_64-unknown-linux-gnu".to_string())).unwrap();
         let pythons = PythonInterpreter::find_by_target(&target, None);
-        assert_eq!(pythons.len(), 10);
+        assert_eq!(pythons.len(), 11);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.7").unwrap()),
         );
-        assert_eq!(pythons.len(), 10);
+        assert_eq!(pythons.len(), 11);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.10").unwrap()),
         );
-        assert_eq!(pythons.len(), 4);
+        assert_eq!(pythons.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
Now that Python 3.13 has an alpha release.