### PR TITLE
Don't set `MACOSX_DEPLOYMENT_TARGET` for editable builds by default

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -419,8 +419,8 @@ fn compile_target(
         build_command.env("PYO3_CROSS_LIB_DIR", lib_dir);
     }
 
-    // Set default macOS deployment target version
-    if target.is_macos() && env::var_os("MACOSX_DEPLOYMENT_TARGET").is_none() {
+    // Set default macOS deployment target version for non-editable builds
+    if !context.editable && target.is_macos() && env::var_os("MACOSX_DEPLOYMENT_TARGET").is_none() {
         use crate::build_context::rustc_macosx_target_version;
 
         let target_config = context


### PR DESCRIPTION
Closes #1804 