### PR TITLE
Metadata: escape display name in email addresses

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -828,4 +828,43 @@ mod test {
         assert_eq!(metadata.license_files[2], manifest_dir.join("NOTICE.md"));
         assert_eq!(metadata.license_files[3], manifest_dir.join("AUTHORS.txt"));
     }
+
+    #[test]
+    fn test_escape_email_with_display_name_without_special_characters() {
+        let display_name = "Foo Bar !#$%&'*+-/=?^_`{|}~ 123";
+        let email = "foobar-123@example.com";
+        let result = escape_email_with_display_name(display_name, email);
+        assert_eq!(
+            result,
+            "Foo Bar !#$%&'*+-/=?^_`{|}~ 123 <foobar-123@example.com>"
+        );
+    }
+
+    #[test]
+    fn test_escape_email_with_display_name_with_special_characters() {
+        let tests = [
+            ("Foo ( Bar", "\"Foo ( Bar\""),
+            ("Foo ) Bar", "\"Foo ) Bar\""),
+            ("Foo < Bar", "\"Foo < Bar\""),
+            ("Foo > Bar", "\"Foo > Bar\""),
+            ("Foo @ Bar", "\"Foo @ Bar\""),
+            ("Foo , Bar", "\"Foo , Bar\""),
+            ("Foo ; Bar", "\"Foo ; Bar\""),
+            ("Foo : Bar", "\"Foo : Bar\""),
+            ("Foo \\ Bar", "\"Foo \\\\ Bar\""),
+            ("Foo \" Bar", "\"Foo \\\" Bar\""),
+            ("Foo . Bar", "\"Foo . Bar\""),
+            ("Foo [ Bar", "\"Foo [ Bar\""),
+            ("Foo ] Bar", "\"Foo ] Bar\""),
+            ("Foo ) Bar", "\"Foo ) Bar\""),
+            ("Foo ) Bar", "\"Foo ) Bar\""),
+            ("Foo, Bar", "\"Foo, Bar\""),
+        ];
+        for (display_name, expected_name) in tests {
+            let email = "foobar-123@example.com";
+            let result = escape_email_with_display_name(display_name, email);
+            let expected = format!("{expected_name} <{email}>");
+            assert_eq!(result, expected);
+        }
+    }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -226,7 +226,7 @@ impl Metadata21 {
                 for author in authors {
                     match (&author.name, &author.email) {
                         (Some(name), Some(email)) => {
-                            emails.push(format!("{name} <{email}>"));
+                            emails.push(format_email_with_display_name(name, email));
                         }
                         (Some(name), None) => {
                             names.push(name.as_str());
@@ -251,7 +251,7 @@ impl Metadata21 {
                 for maintainer in maintainers {
                     match (&maintainer.name, &maintainer.email) {
                         (Some(name), Some(email)) => {
-                            emails.push(format!("{name} <{email}>"));
+                            emails.push(format_email_with_display_name(name, email));
                         }
                         (Some(name), None) => {
                             names.push(name.as_str());
@@ -553,6 +553,23 @@ impl Metadata21 {
             &self.get_version_escaped()
         ))
     }
+}
+
+/// Escape email addresses with display name if necessary
+/// according to RFC 822 Section 3.3. "specials".
+fn format_email_with_display_name(display_name: &str, email: &str) -> String {
+    if display_name.chars().any(|c| {
+        matches!(
+            c,
+            '(' | ')' | '<' | '>' | '@' | ',' | ';' | ':' | '\\' | '"' | '.' | '[' | ']'
+        )
+    }) {
+        return format!(
+            "\"{}\" <{email}>",
+            display_name.replace('\\', "\\\\").replace('\"', "\\\"")
+        );
+    }
+    format!("{display_name} <{email}>")
 }
 
 /// Fold long header field according to RFC 5322 section 2.2.3

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -226,7 +226,7 @@ impl Metadata21 {
                 for author in authors {
                     match (&author.name, &author.email) {
                         (Some(name), Some(email)) => {
-                            emails.push(format_email_with_display_name(name, email));
+                            emails.push(escape_email_with_display_name(name, email));
                         }
                         (Some(name), None) => {
                             names.push(name.as_str());
@@ -251,7 +251,7 @@ impl Metadata21 {
                 for maintainer in maintainers {
                     match (&maintainer.name, &maintainer.email) {
                         (Some(name), Some(email)) => {
-                            emails.push(format_email_with_display_name(name, email));
+                            emails.push(escape_email_with_display_name(name, email));
                         }
                         (Some(name), None) => {
                             names.push(name.as_str());
@@ -557,7 +557,7 @@ impl Metadata21 {
 
 /// Escape email addresses with display name if necessary
 /// according to RFC 822 Section 3.3. "specials".
-fn format_email_with_display_name(display_name: &str, email: &str) -> String {
+fn escape_email_with_display_name(display_name: &str, email: &str) -> String {
     if display_name.chars().any(|c| {
         matches!(
             c,


### PR DESCRIPTION
This follows the way setuptools handles email addresses from `pyproject.toml` files.

See [here](https://github.com/pypa/setuptools/blob/v68.2.2/setuptools/config/_apply_pyprojecttoml.py#L192-L193) where it utilizes the std lib package `email`, which in turn escapes email addresses [here](https://github.com/python/cpython/blob/v3.12.0/Lib/email/headerregistry.py#L89-L90) and then [here](https://github.com/python/cpython/blob/v3.12.0/Lib/email/_header_value_parser.py#L97).

I noticed this bug when I tried to upload a package to PyPI with something like this in my `pyproject.toml`:
```toml
[project]
# ...
authors = [
    {name = "FooBar, Inc.", email = "contact@foobar.com"}
]
# ...
```

PyPI rejected the package:
```
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
'FooBar, Inc. <contact@nfoobar.com>' is an invalid value for Author-email.
Error: Use a valid email address See
https://packaging.python.org/specifications/core-metadata for more
information.
```

As a workaround, I changed my pyproject.toml to
```toml
[project]
# ...
authors = [
    {email = "\"FooBar, Inc.\" <contact@foobar.com>"}
]
# ...
```