### PR TITLE
Add support for cross compiling with `cross`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-crates/wheels/
 test-crates/targets/
 test-crates/venvs/
 node_modules
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-options"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e06313830a277c39d563be61cea4e008e32a810984e79ee5e46d9cae544018"
+checksum = "cad71bf996c8e5b9d28ef3472d7ee41f277edf4e38cd597f51ad0438d05d76ea"
 dependencies = [
  "anstyle",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ base64 = "0.21.0"
 glob = "0.3.0"
 cargo-config2 = "0.1.9"
 cargo_metadata = "0.18.0"
-cargo-options = "0.7.1"
+cargo-options = "0.7.2"
 cbindgen = { version = "0.26.0", default-features = false }
 flate2 = "1.0.18"
 goblin = "0.7.1"

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -317,6 +317,10 @@ impl ProjectResolver {
         debug!("Resolving cargo metadata from {:?}", manifest_path);
         let cargo_metadata_extra_args = extract_cargo_metadata_args(cargo_options)?;
         let result = MetadataCommand::new()
+            // Force resolving metadata using cargo instead of instead of $CARGO env var
+            // to avoid getting wrong file path like target directory, for example `cross` would
+            // output paths in docker while we want paths on host.
+            .cargo_path("cargo")
             .manifest_path(manifest_path)
             .verbose(true)
             .other_options(cargo_metadata_extra_args)


### PR DESCRIPTION
Usage: run `maturin` with env var `CARGO=cross`, for example

```bash
CARGO=cross maturin build
```

Closes #1002 