### PR TITLE
simplified clear-cache github action

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -10,26 +10,10 @@ jobs:
   clear-cache:
     name: Clean Cache
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Clear cache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            while (true) {
-              const caches = await github.rest.actions.getActionsCacheList({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-              if (caches.data.actions_caches.length === 0) {
-                break
-              }
-              for (const cache of caches.data.actions_caches) {
-                console.log('Deleting ' + cache.key)
-                github.rest.actions.deleteActionsCacheById({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  cache_id: cache.id,
-                })
-              }
-            }
-            console.log("Clear cache completed")
+        run: |
+          gh cache delete --all --repo "$GITHUB_REPOSITORY"
+          echo "cache cleared"


### PR DESCRIPTION
I'm investigating the failure in https://github.com/PyO3/maturin/pull/1748 and wanted to clear the cache on my fork.
I hit the API limit of 1000 requests per hour using the action and tried using the github cli instead.

When run locally, `gh cache delete --all` doesn't seem to hit the API limit and I'm able to clear thousands of entries without failing. Unfortunately when called from a github action it still hits the limit, but this workflow might still be an improvement because it's simpler?