### PR TITLE
Match dependency readmes by package id

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -302,7 +302,7 @@ impl WheelWriter {
                 .normalize()
                 .with_context(|| {
                     format!(
-                        "failed to normalize path `{}`",
+                        "failed to normalize python dir path `{}`",
                         project_layout.python_dir.display()
                     )
                 })?

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -209,7 +209,7 @@ impl ProjectResolver {
         if let Some(path) = cargo_manifest_path {
             let path = path
                 .normalize()
-                .with_context(|| format!("failed to normalize path `{}`", path.display()))?
+                .with_context(|| format!("failed to normalize manifest path `{}`", path.display()))?
                 .into_path_buf();
             debug!(
                 "Using cargo manifest path from command line argument: {:?}",
@@ -248,7 +248,9 @@ impl ProjectResolver {
                 debug!("Using cargo manifest path from pyproject.toml {:?}", path);
                 return Ok((
                     path.normalize()
-                        .with_context(|| format!("failed to normalize path `{}`", path.display()))?
+                        .with_context(|| {
+                            format!("failed to normalize manifest path `{}`", path.display())
+                        })?
                         .into_path_buf(),
                     pyproject_file,
                 ));


### PR DESCRIPTION
We have a project which depends on a vendored version of `pep440_rs`, while some of our dependencies depend on the crates.io version. The published version uses `Readme.md`, while the vendored one follows a different convention and uses `README.md`. This causes `maturin sdist` to fail:

```
🍹 Building a mixed python/rust project
🔗 Found bin bindings
📡 Using build options bindings from pyproject.toml
💥 maturin failed
  Caused by: Failed to build source distribution
  Caused by: failed to normalize path `Readme.md`
  Caused by: No such file or directory (os error 2)
  ```

Internally, maturin uses the package name to match dependencies with their resolved readme. This failed in our cased since the second entry for `pep440_rs` with the crates.io readme was overwriting the first entry with the project local readme.

The fix is to match by package id instead. The implementation is somewhat awkward, since there's no API to get the package id directly (https://github.com/rust-lang/cargo/issues/7289), so we have to get list of dependency package ids and dependency `Dependency`s and match them by name, assuming in a single `[dependency]` each package name must be unique.

I also made the error message more distinct so easier to map a failure back to its source code origin.

<details>
  <summary>Relevant `cargo metadata` excerpt</summary>

  ```json
  [
    {
      "name": "pep440_rs",
      "version": "0.3.12",
      "id": "pep440_rs 0.3.12 (path+file:///home/konsti/projects/internal/crates/pep440-rs)",
      "license": "Apache-2.0 OR BSD-2-Clause",
      "license_file": null,
      "description": "A library for python version numbers and specifiers, implementing PEP 440",
      "source": null,
      "dependencies": ["..."],
      "targets": ["..."],
      "features": {
        "...": [
          "..."
        ]
      },
      "manifest_path": "/home/konsti/projects/internal/crates/pep440-rs/Cargo.toml",
      "metadata": null,
      "publish": null,
      "authors": [
        "Puffin"
      ],
      "categories": [],
      "keywords": [],
      "readme": "README.md",
      "repository": "https://github.com/astral-sh/internal",
      "homepage": "https://pypi.org/project/internal-alpha/",
      "documentation": "https://pypi.org/project/internal-alpha/",
      "edition": "2021",
      "links": null,
      "default_run": null,
      "rust_version": "1.74"
    },
    {
      "name": "pep440_rs",
      "version": "0.3.12",
      "id": "pep440_rs 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
      "license": "Apache-2.0 OR BSD-2-Clause",
      "license_file": null,
      "description": "A library for python version numbers and specifiers, implementing PEP 440",
      "source": "registry+https://github.com/rust-lang/crates.io-index",
      "dependencies": ["..."],
      "targets": ["..."],
      "features": {
        "...": [
          "..."
        ]
      },
      "manifest_path": "/home/konsti/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pep440_rs-0.3.12/Cargo.toml",
      "metadata": null,
      "publish": null,
      "authors": [],
      "categories": [],
      "keywords": [],
      "readme": "Readme.md",
      "repository": "https://github.com/konstin/pep440-rs",
      "homepage": null,
      "documentation": null,
      "edition": "2021",
      "links": null,
      "default_run": null,
      "rust_version": null
    }
  ]
  ```

</details>