### PR TITLE
Add extra note to "Using PyPI's trusted publishing" section.

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -300,5 +300,6 @@ By default, the workflow provided by `generate-ci` will publish the release arti
 To enable it, modify the `release` action in the generated GitHub workflow file:
 - remove `MATURIN_PYPI_TOKEN` from the `env` section to make maturin use trusted publishing
 - add `id-token: write` to the action's `permissions` (see [Configuring OpenID Connect in PyPI](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi) from GitHub's documentation).
+- if `Environment name: release` was set in PyPI, add `environment: release`
 
 Make sure to follow the steps listed in [PyPI's documentation](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to set up your GitHub repository as a trusted publisher in the PyPI project settings before attempting to run the workflow.


### PR DESCRIPTION
Add extra note to "Using PyPI's trusted publishing" section to solve issues publishing to PyPI when "Environment name" is set on PyPI.

Based on: https://github.com/PyO3/maturin/issues/1575#issuecomment-1753785859