### PR TITLE
Add validation for crate/package name in new/init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trycmd",
+ "unicode-xid",
  "ureq",
  "url",
  "which 6.0.0",
@@ -2359,6 +2360,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ path-slash = "0.2.1"
 pep440_rs = { version = "0.3.6", features = ["serde"] }
 pep508_rs = { version = "0.2.1", features = ["serde"] }
 time = "0.3.17"
+unicode-xid = "0.2.4"
 
 # cli
 clap = { version = "4.0.0", features = ["derive", "env", "wrap_help", "unstable-styles"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod metadata;
 mod module_writer;
 #[cfg(feature = "scaffolding")]
 mod new_project;
+mod package_name_validations;
 mod project_layout;
 pub mod pyproject_toml;
 mod python_interpreter;

--- a/src/new_project.rs
+++ b/src/new_project.rs
@@ -1,4 +1,5 @@
 use crate::ci::GenerateCI;
+use crate::package_name_validations::cargo_check_name;
 use crate::BridgeModel;
 use anyhow::{bail, Context, Result};
 use console::style;
@@ -146,16 +147,11 @@ impl<'a> ProjectGenerator<'a> {
     }
 }
 
-fn validate_name(name: &str) -> Result<String, String> {
-    // TODO: replace with actual cargo rules:
-    // https://github.com/rust-lang/cargo/blob/7b7af3077bff8d60b7f124189bc9de227d3063a9/crates/cargo-util-schemas/src/restricted_names.rs#L42C1-L42C11
-    // +
-    // https://github.com/rust-lang/cargo/blob/master/src/cargo/util/restricted_names.rs#L11
-
+fn validate_name(name: &str) -> anyhow::Result<String> {
     // TODO: add python rules
-    if name.chars().any(|c| c.is_whitespace()) {
-        return Err("Name cannot contain whitespace".to_string());
-    }
+
+    cargo_check_name(name)?;
+
     Ok(name.to_string())
 }
 /// Options common to `maturin new` and `maturin init`.

--- a/src/new_project.rs
+++ b/src/new_project.rs
@@ -148,8 +148,6 @@ impl<'a> ProjectGenerator<'a> {
 }
 
 fn validate_name(name: &str) -> anyhow::Result<String> {
-    // TODO: add python rules
-
     cargo_check_name(name)?;
 
     Ok(name.to_string())

--- a/src/package_name_validations.rs
+++ b/src/package_name_validations.rs
@@ -1,0 +1,128 @@
+// Based on: https://github.com/rust-lang/cargo/blob/e975158c1b542aa3833fd8584746538c17a6ae55/src/cargo/ops/cargo_new.rs#L169
+pub fn cargo_check_name(name: &str) -> anyhow::Result<()> {
+    // Instead of `PackageName::new`, which performs these checks
+    validate_package_name(name)?;
+
+    if is_keyword(name) {
+        anyhow::bail!(
+            "the name `{}` cannot be used as a package name, it is a Rust keyword",
+            name,
+        );
+    }
+    if is_conflicting_artifact_name(name) {
+        anyhow::bail!(
+            "the name `{}` cannot be used as a package name, \
+                it conflicts with cargo's build directory names",
+            name,
+        );
+    }
+    if name == "test" {
+        anyhow::bail!(
+            "the name `test` cannot be used as a package name, \
+            it conflicts with Rust's built-in test library",
+        );
+    }
+    if ["core", "std", "alloc", "proc_macro", "proc-macro"].contains(&name) {
+        //  TODO: shell.warn?
+        println!(
+            "the name `{}` is part of Rust's standard library\n\
+            It is recommended to use a different name to avoid problems.",
+            name,
+        );
+    }
+    if is_windows_reserved(name) {
+        // TODO: ????
+        if cfg!(windows) {
+            anyhow::bail!(
+                "cannot use name `{}`, it is a reserved Windows filename",
+                name,
+            );
+        } else {
+            //  TODO: shell.warn?
+            println!(
+                "the name `{}` is a reserved Windows filename\n\
+                This package will not work on Windows platforms.",
+                name
+            );
+        }
+    }
+    if is_non_ascii_name(name) {
+        //  TODO: shell.warn?
+        println!(
+            "the name `{}` contains non-ASCII characters\n\
+            Non-ASCII crate names are not supported by Rust.",
+            name
+        );
+    }
+    let name_in_lowercase = name.to_lowercase();
+    if name != name_in_lowercase {
+        //  TODO: shell.warn?
+        println!(
+            "the name `{name}` is not snake_case or kebab-case which is recommended for package names, consider `{name_in_lowercase}`"
+        );
+    }
+
+    Ok(())
+}
+
+// The following functions are based on https://github.com/rust-lang/cargo/blob/e975158c1b542aa3833fd8584746538c17a6ae55/src/cargo/util/restricted_names.rs
+
+/// Returns `true` if the name contains non-ASCII characters.
+pub fn is_non_ascii_name(name: &str) -> bool {
+    name.chars().any(|ch| ch > '\x7f')
+}
+
+/// A Rust keyword.
+pub fn is_keyword(name: &str) -> bool {
+    // See https://doc.rust-lang.org/reference/keywords.html
+    [
+        "Self", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
+        "crate", "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if",
+        "impl", "in", "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv",
+        "pub", "ref", "return", "self", "static", "struct", "super", "trait", "true", "try",
+        "type", "typeof", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+    ]
+    .contains(&name)
+}
+
+/// These names cannot be used on Windows, even with an extension.
+pub fn is_windows_reserved(name: &str) -> bool {
+    [
+        "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+        "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+    ]
+    .contains(&name.to_ascii_lowercase().as_str())
+}
+
+/// An artifact with this name will conflict with one of Cargo's build directories.
+pub fn is_conflicting_artifact_name(name: &str) -> bool {
+    ["deps", "examples", "build", "incremental"].contains(&name)
+}
+
+// Based on: https://github.com/rust-lang/cargo/blob/7b7af3077bff8d60b7f124189bc9de227d3063a9/crates/cargo-util-schemas/src/restricted_names.rs#L42
+fn validate_package_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Package names cannot be empty");
+    }
+
+    let mut chars = name.chars();
+    if let Some(ch) = chars.next() {
+        if ch.is_digit(10) {
+            // A specific error for a potentially common case.
+            anyhow::bail!("Package names cannot start with a digit");
+        }
+        if !(unicode_xid::UnicodeXID::is_xid_start(ch) || ch == '_') {
+            anyhow::bail!(
+                "the first character must be a Unicode XID start character (most letters or `_`)"
+            );
+        }
+    }
+    for ch in chars {
+        if !(unicode_xid::UnicodeXID::is_xid_continue(ch) || ch == '-') {
+            anyhow::bail!(
+                "characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)"
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/package_name_validations.rs
+++ b/src/package_name_validations.rs
@@ -61,7 +61,7 @@ fn validate_package_name(name: &str) -> anyhow::Result<()> {
 
     let mut chars = name.chars();
     if let Some(ch) = chars.next() {
-        if ch.is_digit(10) {
+        if ch.is_ascii_digit() {
             // A specific error for a potentially common case.
             anyhow::bail!("Package names cannot start with a digit");
         }


### PR DESCRIPTION
partially solves https://github.com/PyO3/maturin/issues/1398  (only cargo)

The current commit only adds a very basic validation as a POC before implementing the needed cargo / pypi checks
A few questions i have before finishing the implementation

1. The cargo validation seems to be comprised of 2 main parts, 
    a. [Basic validation](https://github.com/rust-lang/cargo/blob/7b7af3077bff8d60b7f124189bc9de227d3063a9/crates/cargo-util-schemas/src/restricted_names.rs#L42C1-L42C11) which is part of the crate [cargo-util-schemas](https://crates.io/crates/cargo-util-schemas/versions), and is not made public outside the crate

    b. [Extra validations](https://github.com/rust-lang/cargo/blob/master/src/cargo/util/restricted_names.rs) that are public from the cargo package

    I believe we should vendor these logics - one is private, and the other requires the cargo package which i believe will add many dependencies to the project 

2. The `generate_project` function is de-facto defining a default value for `GenerateProjectOptions.name` - would it be better to move this logic into `GenerateProjectOptions`?