### PR TITLE
Adjust cbindgen Overrides for CFFI

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -544,18 +544,24 @@ fn cffi_header(crate_dir: &Path, target_dir: &Path, tempdir: &TempDir) -> Result
     } else {
         if crate_dir.join("cbindgen.toml").is_file() {
             eprintln!(
-                "💼 Using the existing cbindgen.toml configuration. \n\
-                 💼 Enforcing the following settings: \n   \
+                "💼 Using the existing cbindgen.toml configuration.\n\
+                 💼 Enforcing the following settings:\n   \
                  - language = \"C\" \n   \
-                 - no_includes = true \n   \
-                 - no include_guard \t (directives are not yet supported) \n   \
-                 - no defines       \t (directives are not yet supported)"
+                 - no_includes = true, sys_includes = []\n     \
+                   (#include is not yet supported by CFFI)\n   \
+                 - defines = [], no include_guard, pragma_once = false, cpp_compat = false\n     \
+                   (#define, #ifdef, etc. is not yet supported by CFFI)\n"
             );
         }
 
         let mut config = cbindgen::Config::from_root_or_default(crate_dir);
+        config.language = cbindgen::Language::C;
+        config.no_includes = true;
+        config.sys_includes = Vec::new();
         config.defines = HashMap::new();
         config.include_guard = None;
+        config.pragma_once = false;
+        config.cpp_compat = false;
 
         let bindings = cbindgen::Builder::new()
             .with_config(config)

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -549,7 +549,7 @@ fn cffi_header(crate_dir: &Path, target_dir: &Path, tempdir: &TempDir) -> Result
                  - language = \"C\" \n   \
                  - no_includes = true, sys_includes = []\n     \
                    (#include is not yet supported by CFFI)\n   \
-                 - defines = [], no include_guard, pragma_once = false, cpp_compat = false\n     \
+                 - defines = [], include_guard = None, pragma_once = false, cpp_compat = false\n     \
                    (#define, #ifdef, etc. is not yet supported by CFFI)\n"
             );
         }


### PR DESCRIPTION
## My Use-case

I'm working on a project for which I'd like to create C/C++ and Python bindings. My gut feeling says that having a simple hand-written C FFI with a C header generated by cbindgen is the best option. On top of that, I'd like to provide user-friendly, idiomatic (hand-written) C++ and Python interfaces. Maturin seems to be a good fit for simplifying the build process of the Python bindings.

## Issue

For a good integration in C/C++ projects, I use cbindgen options such as `sys_includes` (generating `#include <stdlib.h>`, …) `cpp_compat` (`#ifdef __cplusplus` etc.). Currently, Maturin uses the same `cbindgen.toml` modulo the overrides for `defines` and `include_guard`, and passes the resulting header to CFFI. Unfortunately, CFFI's `cdef` method cannot deal with those C preprocessor directives generated under my configuration, resulting in a crash.

## Proposed Change, Alternatives

This PR adds a few more overrides: `sys_includes = []` and `cpp_compat = false` are the relevant ones for my use-case. I also disabled `pragma_once` (I'm not sure if the `#pragma once` can cause issues, though). `language = C` and `no_includes = true` were specified in the `eprintln!` message above but not actually set, so I added them as well. (In my tests, `no_includes = true` does not make `sys_includes = []` obsolete.)

The proposed change does the job for me, but I'm not sure if others might need additional overrides. In the `cbindgen.toml` documentation at https://github.com/mozilla/cbindgen/blob/master/docs.md#cbindgentoml, there are various options that might cause problems, e.g., function attributes such as `NO_RETURN`, which is emitted for Rust functions returning `!`. I could imagine two alternatives/additions to this PR that might help in such situations: (1) Providing an option to manually set the `cbindgen.toml` path or (2) exposing the override settings. I'm not sure if this is needed, though; this PR makes things work out of the box in my scenario.