### PR TITLE
Put dynamic field under project instead of project.optional-dependencies

### DIFF
--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -13,13 +13,13 @@ classifiers = [
 {% if bindings == "cffi" -%}
 dependencies = ["cffi"]
 {% endif -%}
+dynamic = ["version"]
 {% if mixed_non_src -%}
 [project.optional-dependencies]
 tests = [
     "pytest",
 ]
 {% endif -%}
-dynamic = ["version"]
 
 {% if bindings in ["bin", "cffi", "pyo3", "rust-cpython"] or mixed_non_src -%}
 [tool.maturin]


### PR DESCRIPTION
Noticed when running `maturin init --mixed` that the `dynamic = ["version"]` line was under `[project.optional-dependencies]`, when it should be under `[project]` instead.

References:
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#static-vs-dynamic-metadata

Patches the incorrect merge handling between https://github.com/PyO3/maturin/pull/1807 and https://github.com/PyO3/maturin/commit/2074b111db7648760ce8f7b53702fdd1a8e2c31c