### PR TITLE
Revert "Auto detect Python 3.13"

### DIFF
--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -21,7 +21,7 @@ mod config;
 const GET_INTERPRETER_METADATA: &str = include_str!("get_interpreter_metadata.py");
 pub const MINIMUM_PYTHON_MINOR: usize = 7;
 /// Be liberal here to include preview versions
-pub const MAXIMUM_PYTHON_MINOR: usize = 13;
+pub const MAXIMUM_PYTHON_MINOR: usize = 12;
 pub const MAXIMUM_PYPY_MINOR: usize = 10;
 
 /// Identifies conditions where we do not want to build wheels
@@ -988,19 +988,19 @@ mod tests {
         let target =
             Target::from_target_triple(Some("x86_64-unknown-linux-gnu".to_string())).unwrap();
         let pythons = PythonInterpreter::find_by_target(&target, None);
-        assert_eq!(pythons.len(), 11);
+        assert_eq!(pythons.len(), 10);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.7").unwrap()),
         );
-        assert_eq!(pythons.len(), 11);
+        assert_eq!(pythons.len(), 10);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.10").unwrap()),
         );
-        assert_eq!(pythons.len(), 5);
+        assert_eq!(pythons.len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
Reverts PyO3/maturin#1810

Closes #1960 

Going forward we can only detect preview versions that has pyo3 offcial support.