### PR TITLE
Update to Metadata 2.3 to create reliable source dist metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>", "messense <messense@icloud.com>"]
 name = "maturin"
-version = "1.4.0"
+version = "1.5.0"
 description = "Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
 exclude = [
     "test-crates/**/*",

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Bump metadata version from 2.1 to 2.3 in [#1960](https://github.com/PyO3/maturin/pull/1960). Source distributions created by maturin now have reliable metadata, meaning tool such as pip, uv and poetry could skip building them for version resolution.
+
 ## [1.4.0] - 2023-12-02
 
 * Bump MSRV to 1.67.0 in [#1847](https://github.com/PyO3/maturin/pull/1847)

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -494,7 +494,7 @@ impl BuildOptions {
             pyproject_toml_path,
             pyproject_toml,
             module_name,
-            metadata21,
+            metadata23,
             mut cargo_options,
             cargo_metadata,
             mut pyproject_toml_maturin_options,
@@ -564,7 +564,7 @@ impl BuildOptions {
                 &bridge,
                 &[],
                 &target,
-                metadata21.requires_python.as_ref(),
+                metadata23.requires_python.as_ref(),
                 generate_import_lib,
             )?
         } else {
@@ -678,7 +678,7 @@ impl BuildOptions {
             project_layout,
             pyproject_toml_path,
             pyproject_toml,
-            metadata21,
+            metadata23,
             crate_name,
             module_name,
             manifest_path: cargo_toml_path,

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -82,9 +82,9 @@ fn install_dependencies(
     interpreter: &PythonInterpreter,
     pip_path: Option<&Path>,
 ) -> Result<()> {
-    if !build_context.metadata21.requires_dist.is_empty() {
+    if !build_context.metadata23.requires_dist.is_empty() {
         let mut args = vec!["install".to_string()];
-        args.extend(build_context.metadata21.requires_dist.iter().map(|x| {
+        args.extend(build_context.metadata23.requires_dist.iter().map(|x| {
             let mut pkg = x.clone();
             // Remove extra marker to make it installable with pip
             // Keep in sync with `Metadata21::merge_pyproject_toml()`!
@@ -175,7 +175,7 @@ fn fix_direct_url(
     let mut pip_cmd = make_pip_command(python, pip_path);
     let output = pip_cmd
         .args(["show", "--files"])
-        .arg(&build_context.metadata21.name)
+        .arg(&build_context.metadata23.name)
         .output()
         .context(format!(
             "pip show failed (ran {:?} with {:?})",
@@ -292,7 +292,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
             )?;
             eprintln!(
                 "🛠 Installed {}-{}",
-                build_context.metadata21.name, build_context.metadata21.version
+                build_context.metadata23.name, build_context.metadata23.version
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::build_options::{BuildOptions, CargoOptions};
 pub use crate::cargo_toml::CargoToml;
 pub use crate::compile::{compile, BuildArtifact};
 pub use crate::develop::{develop, DevelopOptions};
-pub use crate::metadata::{Metadata21, WheelMetadata};
+pub use crate::metadata::{Metadata23, WheelMetadata};
 pub use crate::module_writer::{
     write_dist_info, ModuleWriter, PathWriter, SDistWriter, WheelWriter,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,8 +262,8 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
             };
 
             let mut writer = PathWriter::from_path(metadata_directory);
-            write_dist_info(&mut writer, &context.metadata21, &tags)?;
-            println!("{}", context.metadata21.get_dist_info_dir().display());
+            write_dist_info(&mut writer, &context.metadata23, &tags)?;
+            println!("{}", context.metadata23.get_dist_info_dir().display());
         }
         Pep517Command::BuildWheel {
             build_options,

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -1,5 +1,5 @@
 use crate::build_options::{extract_cargo_metadata_args, CargoOptions};
-use crate::{CargoToml, Metadata21, PyProjectToml};
+use crate::{CargoToml, Metadata23, PyProjectToml};
 use anyhow::{bail, format_err, Context, Result};
 use cargo_metadata::{Metadata, MetadataCommand};
 use normpath::PathExt as _;
@@ -45,8 +45,8 @@ pub struct ProjectResolver {
     pub pyproject_toml: Option<PyProjectToml>,
     /// Rust module name
     pub module_name: String,
-    /// Python Package Metadata 2.1
-    pub metadata21: Metadata21,
+    /// Python Package Metadata 2.3
+    pub metadata23: Metadata23,
     /// Cargo options
     pub cargo_options: CargoOptions,
     /// Cargo.toml as resolved by [cargo_metadata]
@@ -107,11 +107,11 @@ impl ProjectResolver {
 
         let cargo_metadata = Self::resolve_cargo_metadata(&manifest_file, &cargo_options)?;
 
-        let mut metadata21 = Metadata21::from_cargo_toml(manifest_dir, &cargo_metadata)
+        let mut metadata23 = Metadata23::from_cargo_toml(manifest_dir, &cargo_metadata)
             .context("Failed to parse Cargo.toml into python metadata")?;
         if let Some(pyproject) = pyproject {
             let pyproject_dir = pyproject_file.parent().unwrap();
-            metadata21.merge_pyproject_toml(pyproject_dir, pyproject)?;
+            metadata23.merge_pyproject_toml(pyproject_dir, pyproject)?;
         }
 
         let crate_name = &cargo_toml.package.name;
@@ -193,7 +193,7 @@ impl ProjectResolver {
             pyproject_toml_path: pyproject_file,
             pyproject_toml,
             module_name,
-            metadata21,
+            metadata23,
             cargo_options,
             cargo_metadata,
             pyproject_toml_maturin_options,

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -612,12 +612,12 @@ pub fn source_distribution(
             )
         })?
         .into_path_buf();
-    let metadata21 = &build_context.metadata21;
-    let mut writer = SDistWriter::new(&build_context.out, metadata21, excludes)?;
+    let metadata23 = &build_context.metadata23;
+    let mut writer = SDistWriter::new(&build_context.out, metadata23, excludes)?;
     let root_dir = PathBuf::from(format!(
         "{}-{}",
-        &metadata21.get_distribution_escaped(),
-        &metadata21.get_version_escaped()
+        &metadata23.get_distribution_escaped(),
+        &metadata23.get_version_escaped()
     ));
 
     match pyproject.sdist_generator() {
@@ -684,7 +684,7 @@ pub fn source_distribution(
 
     writer.add_bytes(
         root_dir.join("PKG-INFO"),
-        metadata21.to_file_contents()?.as_bytes(),
+        metadata23.to_file_contents()?.as_bytes(),
     )?;
 
     add_data(&mut writer, build_context.project_layout.data.as_deref())?;

--- a/test-crates/pyo3-mixed/Cargo.lock
+++ b/test-crates/pyo3-mixed/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-mixed"
-version = "2.1.3"
+version = "2.1.5"
 dependencies = [
  "pyo3",
 ]

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>"]
 name = "pyo3-mixed"
-version = "2.1.3"
+version = "2.1.5"
 description = "Implements a dummy function combining rust and python"
 edition = "2021"
 


### PR DESCRIPTION
Source distributions contain a `PKG-INFO` file at root level with metadata in the same format as wheel metadata. Unlike wheel metadata, this file was previously unreliably, the metadata did not need to (and often did not) match the metadata of the built wheel.

[PEP 643](https://peps.python.org/pep-0643/) introduces Metadata 2.2, where fields can either be static (default) or marked as dynamic. When a source distribution uses `Metadata-Version: 2.3` in its PKG-INFO file, all static fields in the source distribution metadata must match the metadata of a built wheel ([spec](https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-format)). This means that e.g. when requirements and extras are not marked as dynamic, a version resolver can read the metadata directly from the source dist without a PEP 517 invocation. This is both a huge speedup and makes python packaging more reliable.

This PR bumps the metadata version maturin uses to 2.3 ([PEP 685](https://peps.python.org/pep-0685/) – Comparison of extra names for optional distribution dependencies). It does not add support for dynamic, instead maturin writes static metadata for all of its source dists. If possible, i'd like to keep maturin to emit purely static metadata, it has advantages both for the python packaging ecosystem and by enforcing a better project structure. If you want a single source of truth for the package version, i recommend storing the version in pyproject.toml `project.version` and using `importlib.metadata.version` in the python code.

I bump the version to 1.5.0 since it's a significant behaviour change, but doesn't justify a 2.0 release.