### PR TITLE
Only set rustflags when necessary

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -183,6 +183,7 @@ fn cargo_build_command(
     let mut rustflags = cargo_config2::Config::load_with_cwd(manifest_dir)?
         .rustflags(target_triple)?
         .unwrap_or_default();
+    let original_rustflags = rustflags.flags.clone();
 
     // We need to pass --bin / --lib
     let bridge_model = &compile_target.bridge_model;
@@ -358,7 +359,7 @@ fn cargo_build_command(
         // but forwarding stderr is still useful in case there some non-json error
         .stderr(Stdio::inherit());
 
-    if !rustflags.flags.is_empty() {
+    if !rustflags.flags.is_empty() && rustflags.flags != original_rustflags {
         build_command.env("CARGO_ENCODED_RUSTFLAGS", rustflags.encode()?);
     }
 


### PR DESCRIPTION
Similar to https://github.com/PyO3/maturin/pull/887, but handles more cases.

As explained in that PR, explicitly setting rustflags has several side effects.
A concrete example of where this has caused problems is https://github.com/taiki-e/portable-atomic/issues/151, but I know of several other instances where setting rustflags might cause problems: https://github.com/taiki-e/cargo-llvm-cov/issues/332, https://github.com/taiki-e/cargo-llvm-cov/issues/212 (Those are examples from cargo-llvm-cov, but I think similar problems could occur in maturin).