### PR TITLE
in pep517 build default compatibility to off instead of always specifying

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+* Fix usage of `--compatibility` when run as a PEP517 backend in [#1992](https://github.com/PyO3/maturin/pull/1992)
+
 ## [1.5.0] - 2024-03-05
 
 * Bump metadata version from 2.1 to 2.3 in [#1965](https://github.com/PyO3/maturin/pull/1965). Source distributions created by maturin now have reliable metadata, meaning tool such as pip, uv and poetry could skip building them for version resolution.

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -77,7 +77,7 @@ def _build_wheel(
     if pep517_args:
         options.extend(pep517_args)
 
-    if "--compatibility" not in options:
+    if "--compatibility" not in options and "--manylinux" not in options:
         # default to off if not otherwise specified
         options = ["--compatibility", "off", *options]
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -77,7 +77,7 @@ def _build_wheel(
     if pep517_args:
         options.extend(pep517_args)
 
-    if "--compatibility" not in command:
+    if "--compatibility" not in options:
         # default to off if not otherwise specified
         options = ["--compatibility", "off", *options]
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -81,7 +81,7 @@ def _build_wheel(
         # default to off if not otherwise specified
         options = ["--compatibility", "off", *options]
 
-    command = [base_command, *options]
+    command = [*base_command, *options]
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -62,22 +62,26 @@ def _build_wheel(
 ) -> str:
     # PEP 517 specifies that only `sys.executable` points to the correct
     # python interpreter
-    command = [
+    base_command = [
         "maturin",
         "pep517",
         "build-wheel",
         "-i",
         sys.executable,
-        "--compatibility",
-        "off",
     ]
-    command.extend(_additional_pep517_args())
+    options = _additional_pep517_args()
     if editable:
-        command.append("--editable")
+        options.append("--editable")
 
     pep517_args = get_maturin_pep517_args(config_settings)
     if pep517_args:
-        command.extend(pep517_args)
+        options.extend(pep517_args)
+
+    if "--compatibility" not in command:
+        # default to off if not otherwise specified
+        options = ["--compatibility", "off", *options]
+
+    command = [base_command, *options]
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()


### PR DESCRIPTION
I specified 2014 via `MATURIN_PEP517_ARGS` but the duplicate specification resulted in this error

https://github.com/Chia-Network/chia_rs/actions/runs/8253603665/job/22575880171?pr=428#step:8:578
```
💥 maturin failed
  Caused by: Expected only one platform tag but found 2
Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/tmp/build-env-g63n6la_/bin/python', '--compatibility', 'off', '--compatibility', '2014'] returned non-zero exit status 1
```

I'll go test this PR against that and see if it works.