### PR TITLE
Add MacOS m1 Runner & move target aarch64 to this runner

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -281,6 +281,7 @@ Options:
           - linux:      Linux
           - windows:    Windows
           - macos:      macOS
+          - macosarm64: macOS(Arm64)
           - emscripten: Emscripten
 
       --pytest

--- a/tests/cmd/generate-ci.stdout
+++ b/tests/cmd/generate-ci.stdout
@@ -21,7 +21,7 @@ Options:
       --platform <platform>...
           Platform support
           
-          [default: linux windows macos]
+          [default: linux windows macos macosarm64]
 
           Possible values:
           - all:        All
@@ -29,6 +29,7 @@ Options:
           - windows:    Windows
           - macos:      macOS
           - emscripten: Emscripten
+          - macosarm64: macOS(Arm64)
 
       --pytest
           Enable pytest


### PR DESCRIPTION
fixes #1952 

This PR enhances the `generate-ci` command for github actions. Specifically, it addes a new CI job to be running on macos m1 runner, and move away cross compilation to aarch64 from the original mac runner.

