### PR TITLE
Use virtual env for pytest in github actions

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -383,6 +383,8 @@ jobs:\n",
         shell: bash
         run: |
           set -e
+          python3 -m venv venv
+          source ./venv/bin/activate
           pip install {project_name} --find-links dist --force-reinstall
           pip install pytest
           {chdir}pytest
@@ -415,6 +417,8 @@ jobs:\n",
         shell: bash
         run: |
           set -e
+          python3 -m venv venv
+          source ./venv/bin/activate
           pip install {project_name} --find-links dist --force-reinstall
           pip install pytest
           {chdir}pytest
@@ -426,6 +430,8 @@ jobs:\n",
                             "      - name: pytest
         run: |
           set -e
+          python3 -m venv venv
+          source ./venv/bin/activate
           pip install {project_name} --find-links dist --force-reinstall
           pip install pytest
           {chdir}pytest
@@ -909,6 +915,8 @@ mod tests {
                     shell: bash
                     run: |
                       set -e
+                      python3 -m venv venv
+                      source ./venv/bin/activate
                       pip install example --find-links dist --force-reinstall
                       pip install pytest
                       pytest
@@ -959,6 +967,8 @@ mod tests {
                     shell: bash
                     run: |
                       set -e
+                      python3 -m venv venv
+                      source ./venv/bin/activate
                       pip install example --find-links dist --force-reinstall
                       pip install pytest
                       pytest
@@ -991,6 +1001,8 @@ mod tests {
                   - name: pytest
                     run: |
                       set -e
+                      python3 -m venv venv
+                      source ./venv/bin/activate
                       pip install example --find-links dist --force-reinstall
                       pip install pytest
                       pytest


### PR DESCRIPTION
fixes #1951 

This PR modifies the github actio generation logic to use virtual environment to install and run pytest. 