### PR TITLE
Add uv as develop backend command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1199,7 @@ dependencies = [
  "pyproject-toml",
  "python-pkginfo",
  "regex",
+ "rstest",
  "rustc_version",
  "rustls",
  "rustls-pemfile",
@@ -1419,6 +1515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rfc2047-decoder"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1783,35 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.48",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1940,6 +2077,15 @@ name = "similar"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ pretty_assertions = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 expect-test = "1.4.1"
+rstest = "0.18.2"
 indoc = "2.0.3"
 pretty_assertions = "1.3.0"
 rustversion = "1.0.9"

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -16,21 +16,16 @@ use std::process::Command;
 use tempfile::TempDir;
 use url::Url;
 
-#[derive(PartialEq, Eq, Clone)]
-struct Pip {
-    path: Option<PathBuf>,
-}
-
 #[derive(PartialEq, Eq)]
 enum InstallBackend {
-    Pip(Pip),
+    Pip { path: Option<PathBuf> },
     Uv,
 }
 
 impl InstallBackend {
     fn make_command(&self, python_path: &Path) -> Command {
         match self {
-            InstallBackend::Pip(pip) => match &pip.path {
+            InstallBackend::Pip { path } => match &path {
                 Some(path) => {
                     let mut cmd = Command::new(path);
                     cmd.arg("--python")
@@ -185,7 +180,7 @@ fn pip_install_wheel(
     fix_direct_url(
         build_context,
         python,
-        &InstallBackend::Pip(Pip { path: pip_path }),
+        &InstallBackend::Pip { path: pip_path },
     )?;
     Ok(())
 }
@@ -263,9 +258,9 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
     let install_backend = if uv {
         InstallBackend::Uv
     } else {
-        InstallBackend::Pip(Pip {
+        InstallBackend::Pip {
             path: pip_path.clone(),
-        })
+        }
     };
     let mut target_triple = cargo_options.target.as_ref().map(|x| x.to_string());
     let target = Target::from_target_triple(cargo_options.target)?;

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -53,7 +53,7 @@ Options:
           Outputs a future incompatibility report at the end of the build (unstable)
 
       --uv
-          Use `uv` as develop backend instead of `pip`
+          Use `uv` to install packages instead of `pip`
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -52,6 +52,9 @@ Options:
       --future-incompat-report
           Outputs a future incompatibility report at the end of the build (unstable)
 
+      --uv
+          Use `uv` as develop backend instead of `pip`
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -12,6 +12,7 @@ pub fn test_develop(
     bindings: Option<String>,
     unique_name: &str,
     conda: bool,
+    uv: bool,
 ) -> Result<()> {
     maybe_mock_cargo();
 
@@ -31,6 +32,7 @@ pub fn test_develop(
             "pip",
             "install",
             "--disable-pip-version-check",
+            "uv",
             "cffi",
         ])
         .output()?;
@@ -57,6 +59,7 @@ pub fn test_develop(
             target_dir: Some(PathBuf::from(format!("test-crates/targets/{unique_name}"))),
             ..Default::default()
         },
+        uv,
     };
     develop(develop_options, &venv_dir)?;
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -1,4 +1,6 @@
-use crate::common::{check_installed, create_conda_env, create_virtualenv, maybe_mock_cargo};
+use crate::common::{
+    check_installed, create_conda_env, create_virtualenv, maybe_mock_cargo, TestInstallBackend,
+};
 use anyhow::Result;
 use maturin::{develop, CargoOptions, DevelopOptions};
 use std::path::{Path, PathBuf};
@@ -12,7 +14,7 @@ pub fn test_develop(
     bindings: Option<String>,
     unique_name: &str,
     conda: bool,
-    uv: bool,
+    test_backend: TestInstallBackend,
 ) -> Result<()> {
     maybe_mock_cargo();
 
@@ -45,6 +47,7 @@ pub fn test_develop(
         );
     }
 
+    let uv = matches!(test_backend, TestInstallBackend::Uv);
     let manifest_file = package.join("Cargo.toml");
     let develop_options = DevelopOptions {
         bindings,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,6 +12,11 @@ pub mod errors;
 pub mod integration;
 pub mod other;
 
+pub enum TestInstallBackend {
+    Pip,
+    Uv,
+}
+
 /// Check that the package is either not installed or works correctly
 pub fn check_installed(package: &Path, python: &Path) -> Result<()> {
     let path = if cfg!(windows) {

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -17,6 +17,7 @@ fn develop_pyo3_pure() {
         None,
         "develop-pyo3-pure",
         false,
+        false,
     ));
 }
 
@@ -30,6 +31,7 @@ fn develop_pyo3_pure_conda() {
             None,
             "develop-pyo3-pure-conda",
             true,
+            false,
         ));
     }
 }
@@ -41,6 +43,7 @@ fn develop_pyo3_mixed() {
         None,
         "develop-pyo3-mixed",
         false,
+        false,
     ));
 }
 
@@ -50,6 +53,7 @@ fn develop_pyo3_mixed_include_exclude() {
         "test-crates/pyo3-mixed-include-exclude",
         None,
         "develop-pyo3-mixed-include-exclude",
+        false,
         false,
     ));
 }
@@ -61,6 +65,7 @@ fn develop_pyo3_mixed_submodule() {
         None,
         "develop-pyo3-mixed-submodule",
         false,
+        false,
     ));
 }
 
@@ -70,6 +75,7 @@ fn develop_pyo3_mixed_with_path_dep() {
         "test-crates/pyo3-mixed-with-path-dep",
         None,
         "develop-pyo3-mixed-with-path-dep",
+        false,
         false,
     ));
 }
@@ -81,6 +87,7 @@ fn develop_pyo3_mixed_implicit() {
         None,
         "develop-pyo3-mixed-implicit",
         false,
+        false,
     ));
 }
 
@@ -91,6 +98,7 @@ fn develop_pyo3_mixed_py_subdir() {
         None,
         "develop-pyo3-mixed-py-subdir",
         false,
+        false,
     ));
 }
 
@@ -100,6 +108,7 @@ fn develop_pyo3_mixed_src_layout() {
         "test-crates/pyo3-mixed-src/rust",
         None,
         "develop-pyo3-mixed-src",
+        false,
         false,
     ));
 }
@@ -116,6 +125,7 @@ fn develop_cffi_pure() {
         None,
         "develop-cffi-pure",
         false,
+        false,
     ));
 }
 
@@ -131,6 +141,7 @@ fn develop_cffi_mixed() {
         None,
         "develop-cffi-mixed",
         false,
+        false,
     ));
 }
 
@@ -141,6 +152,7 @@ fn develop_uniffi_pure() {
             "test-crates/uniffi-pure",
             None,
             "develop-uniffi-pure",
+            false,
             false,
         ));
     }
@@ -153,6 +165,7 @@ fn develop_uniffi_pure_proc_macro() {
         None,
         "develop-uniffi-pure-proc-macro",
         false,
+        false,
     ));
 }
 
@@ -163,6 +176,7 @@ fn develop_uniffi_mixed() {
             "test-crates/uniffi-mixed",
             None,
             "develop-uniffi-mixed",
+            false,
             false,
         ));
     }
@@ -175,6 +189,18 @@ fn develop_hello_world() {
         None,
         "develop-hello-world",
         false,
+        false,
+    ));
+}
+
+#[test]
+fn develop_hello_world_uv() {
+    handle_result(develop::test_develop(
+        "test-crates/hello-world",
+        None,
+        "develop-hello-world-uv",
+        false,
+        true,
     ));
 }
 
@@ -184,6 +210,7 @@ fn develop_pyo3_ffi_pure() {
         "test-crates/pyo3-ffi-pure",
         None,
         "develop-pyo3-ffi-pure",
+        false,
         false,
     ));
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,8 +1,12 @@
 //! To speed up the tests, they are tests all collected in a single module
 
-use common::{develop, errors, handle_result, integration, other, test_python_implementation};
+use common::{
+    develop, errors, handle_result, integration, other, test_python_implementation,
+    TestInstallBackend,
+};
 use expect_test::expect;
 use maturin::pyproject_toml::SdistGenerator;
+use rstest::rstest;
 use std::env;
 use std::path::Path;
 use time::macros::datetime;
@@ -17,7 +21,7 @@ fn develop_pyo3_pure() {
         None,
         "develop-pyo3-pure",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -31,7 +35,7 @@ fn develop_pyo3_pure_conda() {
             None,
             "develop-pyo3-pure-conda",
             true,
-            false,
+            TestInstallBackend::Pip,
         ));
     }
 }
@@ -43,7 +47,7 @@ fn develop_pyo3_mixed() {
         None,
         "develop-pyo3-mixed",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -54,7 +58,7 @@ fn develop_pyo3_mixed_include_exclude() {
         None,
         "develop-pyo3-mixed-include-exclude",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -65,7 +69,7 @@ fn develop_pyo3_mixed_submodule() {
         None,
         "develop-pyo3-mixed-submodule",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -76,7 +80,7 @@ fn develop_pyo3_mixed_with_path_dep() {
         None,
         "develop-pyo3-mixed-with-path-dep",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -87,7 +91,7 @@ fn develop_pyo3_mixed_implicit() {
         None,
         "develop-pyo3-mixed-implicit",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -98,7 +102,7 @@ fn develop_pyo3_mixed_py_subdir() {
         None,
         "develop-pyo3-mixed-py-subdir",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -109,7 +113,7 @@ fn develop_pyo3_mixed_src_layout() {
         None,
         "develop-pyo3-mixed-src",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -125,7 +129,7 @@ fn develop_cffi_pure() {
         None,
         "develop-cffi-pure",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -141,7 +145,7 @@ fn develop_cffi_mixed() {
         None,
         "develop-cffi-mixed",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -153,7 +157,7 @@ fn develop_uniffi_pure() {
             None,
             "develop-uniffi-pure",
             false,
-            false,
+            TestInstallBackend::Pip,
         ));
     }
 }
@@ -165,7 +169,7 @@ fn develop_uniffi_pure_proc_macro() {
         None,
         "develop-uniffi-pure-proc-macro",
         false,
-        false,
+        TestInstallBackend::Pip,
     ));
 }
 
@@ -177,41 +181,36 @@ fn develop_uniffi_mixed() {
             None,
             "develop-uniffi-mixed",
             false,
-            false,
+            TestInstallBackend::Pip,
         ));
     }
 }
 
+#[rstest]
+#[case(TestInstallBackend::Pip, "pip")]
+#[case(TestInstallBackend::Uv, "uv")]
 #[test]
-fn develop_hello_world() {
+fn develop_hello_world(#[case] backend: TestInstallBackend, #[case] name: &str) {
     handle_result(develop::test_develop(
         "test-crates/hello-world",
         None,
-        "develop-hello-world",
+        format!("develop-hello-world-{}", name).as_str(),
         false,
-        false,
+        backend,
     ));
 }
 
+#[rstest]
+#[case(TestInstallBackend::Pip, "pip")]
+#[case(TestInstallBackend::Uv, "uv")]
 #[test]
-fn develop_hello_world_uv() {
-    handle_result(develop::test_develop(
-        "test-crates/hello-world",
-        None,
-        "develop-hello-world-uv",
-        false,
-        true,
-    ));
-}
-
-#[test]
-fn develop_pyo3_ffi_pure() {
+fn develop_pyo3_ffi_pure(#[case] backend: TestInstallBackend, #[case] name: &str) {
     handle_result(develop::test_develop(
         "test-crates/pyo3-ffi-pure",
         None,
-        "develop-pyo3-ffi-pure",
+        format!("develop-pyo3-ffi-pure-{}", name).as_str(),
         false,
-        false,
+        backend,
     ));
 }
 


### PR DESCRIPTION
Hi, 
This should close #1959. However, I would like some feedback/help before I imagine this is ready to merge. I plan on adding more tests to see that it works accross crates etc,  but got into a weird test error loop, that I hope someone can help me here.

Basically about making the `develop_hello_world_uv` test pass. If I activate my `venv` then test fails with `no-such file or directory hello-world`. If I dont activate it, then it passes. Sadly, if I `deactivate` then the other tests dont pass as I need `cffi` to have my tests pass, what gives? 

Doing a `/target/debug/maturin develop --uv` on 3-4 crates from `test-crates` worked fine, thus not sure whats with the test harness that doenst make it happy. 

If anyone else more experienced can help me out, it would be great. Maybe not the best place for long comment here but didnt know where else :). Thanks for your time
