### PR TITLE
Add instrumentation support for develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,10 @@ faster-tests = []
 # Deprecated features, keep it now for compatibility
 human-panic = []
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 # Without this, compressing the .gz archive becomes notably slow for debug builds
 [profile.dev.package.miniz_oxide]
 opt-level = 3

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -30,6 +30,7 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use tracing::instrument;
 
 /// The way the rust code is used in the wheel
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -199,6 +200,7 @@ pub type BuiltWheelMetadata = (PathBuf, String);
 impl BuildContext {
     /// Checks which kind of bindings we have (pyo3/rust-cypthon or cffi or bin) and calls the
     /// correct builder.
+    #[instrument(skip_all)]
     pub fn build_wheels(&self) -> Result<Vec<BuiltWheelMetadata>> {
         use itertools::Itertools;
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 // This is used for BridgeModel::Bindings("pyo3-ffi") and BridgeModel::Bindings("pyo3").
 // These should be treated almost identically but must be correctly identified
@@ -481,6 +481,7 @@ impl BuildOptions {
     }
 
     /// Tries to fill the missing metadata for a BuildContext by querying cargo and python
+    #[instrument(skip_all)]
     pub fn into_build_context(
         self,
         release: bool,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -13,7 +13,7 @@ use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str;
-use tracing::{debug, trace};
+use tracing::{debug, instrument, trace};
 
 /// The first version of pyo3 that supports building Windows abi3 wheel
 /// without `PYO3_NO_PYTHON` environment variable
@@ -577,6 +577,7 @@ fn compile_target(
 /// to import the module with error if it's missing or named incorrectly
 ///
 /// Currently the check is only run on linux, macOS and Windows
+#[instrument(skip_all)]
 pub fn warn_missing_py_init(artifact: &Path, module_name: &str) -> Result<()> {
     let py_init = format!("PyInit_{module_name}");
     let mut fd = File::open(artifact)?;

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+use tracing::instrument;
 use url::Url;
 
 /// Install the crate as module in the current virtualenv
@@ -76,6 +77,7 @@ fn make_pip_command(python_path: &Path, pip_path: Option<&Path>) -> Command {
     }
 }
 
+#[instrument(skip_all)]
 fn install_dependencies(
     build_context: &BuildContext,
     extras: &[String],
@@ -121,6 +123,7 @@ fn install_dependencies(
     Ok(())
 }
 
+#[instrument(skip_all, fields(wheel_filename = %wheel_filename.display()))]
 fn pip_install_wheel(
     build_context: &BuildContext,
     python: &Path,
@@ -166,6 +169,7 @@ fn pip_install_wheel(
 /// When a maturin package is installed using `pip install -e`, pip takes care of writing the
 /// correct URL, however when a maturin package is installed with `maturin develop`, the URL is
 /// set to the path to the temporary wheel file created during installation.
+#[instrument(skip_all)]
 fn fix_direct_url(
     build_context: &BuildContext,
     python: &Path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ use maturin::{generate_json_schema, GenerateJsonSchemaOptions};
 use maturin::{upload_ui, PublishOpt};
 use std::env;
 use std::path::PathBuf;
-use tracing::debug;
+use tracing::{debug, instrument};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -304,10 +306,8 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
     Ok(())
 }
 
+#[instrument]
 fn run() -> Result<()> {
-    #[cfg(feature = "log")]
-    tracing_subscriber::fmt::init();
-
     #[cfg(feature = "zig")]
     {
         // Allow symlink `maturin` to `ar` to invoke `zig ar`
@@ -463,6 +463,21 @@ fn setup_panic_hook() {
 fn main() {
     #[cfg(not(debug_assertions))]
     setup_panic_hook();
+
+    #[cfg(feature = "log")]
+    {
+        let logger = tracing_subscriber::fmt::layer()
+            // Avoid showing all the details from the spans
+            .compact()
+            // Log the timing of each span
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE);
+
+        tracing_subscriber::registry()
+            // `RUST_LOG` support
+            .with(tracing_subscriber::EnvFilter::from_default_env())
+            .with(logger)
+            .init();
+    }
 
     if let Err(e) = run() {
         eprintln!("💥 maturin failed");

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::str;
 use tempfile::{tempdir, TempDir};
-use tracing::debug;
+use tracing::{debug, instrument};
 use zip::{self, DateTime, ZipWriter};
 
 /// Allows writing the module to a wheel or add it directly to the virtualenv
@@ -706,6 +706,7 @@ fn handle_cffi_call_result(
 
 /// Copies the shared library into the module, which is the only extra file needed with bindings
 #[allow(clippy::too_many_arguments)]
+#[instrument(skip_all)]
 pub fn write_bindings_module(
     writer: &mut impl ModuleWriter,
     project_layout: &ProjectLayout,

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::env;
 use std::io;
 use std::path::{Path, PathBuf};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 const PYPROJECT_TOML: &str = "pyproject.toml";
 
@@ -312,6 +312,7 @@ impl ProjectResolver {
         }
     }
 
+    #[instrument(skip_all)]
     fn resolve_cargo_metadata(
         manifest_path: &Path,
         cargo_options: &CargoOptions,

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::{self, FromStr};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 mod config;
 
@@ -573,6 +573,7 @@ impl PythonInterpreter {
 
     /// Checks whether the given command is a python interpreter and returns a
     /// [PythonInterpreter] if that is the case
+    #[instrument(skip_all, fields(executable = %executable.as_ref().display()))]
     pub fn check_executable(
         executable: impl AsRef<Path>,
         target: &Target,


### PR DESCRIPTION
The main bottleneck in the edit-debug cycle for maturin users is `maturin develop`. I've added tracing instrumentation and a profiling cargo profile to get information what's slow there (besides the obvious rustc/llvm performance). The instrumentation is basic and needs to be adjusted as optimizations are made.

This change allows e.g. running

```bash
NO_COLOR=1 RUST_LOG=maturin=debug cargo run --profile profiling develop --manifest-path test-crates/pyo3-mixed/Cargo.toml | grep close > log.txt
```

to get timing information, here for warm cache pyo3-mixed:

```
2024-04-02T08:20:34.576230Z  INFO run:into_build_context:resolve_cargo_metadata: maturin::project_layout: close time.busy=22.5ms time.idle=405ns
2024-04-02T08:20:34.598489Z  INFO run:into_build_context:resolve_cargo_metadata: maturin::project_layout: close time.busy=22.1ms time.idle=590ns
2024-04-02T08:20:34.625824Z  INFO run:into_build_context:check_executable: maturin::python_interpreter: close time.busy=10.6ms time.idle=903ns executable=/home/konsti/projects/maturin/.venv/bin/python
2024-04-02T08:20:34.625838Z  INFO run:into_build_context: maturin::build_options: close time.busy=72.1ms time.idle=990ns
2024-04-02T08:20:34.637709Z  INFO run:check_executable: maturin::python_interpreter: close time.busy=11.9ms time.idle=669ns executable=/home/konsti/projects/maturin/.venv/bin/python
2024-04-02T08:20:34.819501Z  INFO run:install_dependencies: maturin::develop: close time.busy=182ms time.idle=643ns
2024-04-02T08:20:34.836419Z  INFO run:build_wheels:warn_missing_py_init: maturin::compile: close time.busy=4.92ms time.idle=883ns
2024-04-02T08:20:34.841008Z  INFO run:build_wheels:write_bindings_module: maturin::module_writer: close time.busy=3.47ms time.idle=531ns
2024-04-02T08:20:34.841372Z  INFO run:build_wheels: maturin::build_context: close time.busy=21.9ms time.idle=596ns
2024-04-02T08:20:35.168696Z  INFO run:pip_install_wheel:fix_direct_url: maturin::develop: close time.busy=130ms time.idle=1.60µs wheel_filename=/tmp/.tmpPIBH5Z/pyo3_mixed-2.1.5-cp311-cp311-linux_x86_64.whl
2024-04-02T08:20:35.168708Z  INFO run:pip_install_wheel: maturin::develop: close time.busy=327ms time.idle=285ns wheel_filename=/tmp/.tmpPIBH5Z/pyo3_mixed-2.1.5-cp311-cp311-linux_x86_64.whl
2024-04-02T08:20:35.168869Z  INFO run: maturin: close time.busy=654ms time.idle=1.64µs
```

You can see that surprisingly, `cargo build` isn't the bottleneck for this case. We can use this show the impact of the uv integration :)

An annoying side effect is that tracing subscriber always shows the active spans so the logging gets more verbose.

We can also plug tracing-durations-export into maturin:

![traces](https://github.com/PyO3/maturin/assets/6826232/808188aa-7588-43d4-ac1c-b157b86ebffc)

The `profiling` profile allows using samply, perf or other profilers with maturin.