### PR TITLE
docs: update pyo3 to match tutorial

### DIFF
--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -36,7 +36,7 @@ crate-type = ["cdylib"]
 rand = "0.8.4"
 
 [dependencies.pyo3]
-version = "0.20.0"
+version = "0.21.1"
 # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["abi3-py38"]
 ```


### PR DESCRIPTION
The code below has been updated to use `Bound` from PyO3 0.21, but the tutorial still tells you to pin 0.20. That gives a "incorrect number of function parameters" error.
