### PR TITLE
Bump version of cargo-config2 to 0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-config2"
-version = "0.1.19"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7fb69d74d76f8c254afd1c0e76aca40c305707b28aebe3c5a0fd2ee62aeeeb"
+checksum = "88d9bdc858a15454c2d0a5138d8dcf4bcabc06fde679abdea8330393fbc0ef05"
 dependencies = [
  "home",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ name = "maturin"
 anyhow = "1.0.80"
 base64 = "0.21.0"
 glob = "0.3.0"
-cargo-config2 = "0.1.19"
+cargo-config2 = "0.1.24"
 cargo_metadata = "0.18.0"
 cargo-options = "0.7.2"
 cbindgen = { version = "0.26.0", default-features = false }


### PR DESCRIPTION
Picks up the fix to https://github.com/taiki-e/cargo-config2/issues/17 which was leading to spurious recompiles.