### PR TITLE
Add support for `wasm32-wasip1` and `wasm32-wasip2` targets

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -246,7 +246,7 @@ impl Target {
             OperatingSystem::Illumos => Os::Illumos,
             OperatingSystem::Haiku => Os::Haiku,
             OperatingSystem::Emscripten => Os::Emscripten,
-            OperatingSystem::Wasi => Os::Wasi,
+            OperatingSystem::Wasi | OperatingSystem::WasiP1 | OperatingSystem::WasiP2 => Os::Wasi,
             OperatingSystem::Aix => Os::Aix,
             unsupported => bail!("The operating system {:?} is not supported", unsupported),
         };


### PR DESCRIPTION
https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html