### PR TITLE
docs: Add bleuscore in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ maturin itself is manylinux compliant when compiled for the musl target.
 ## Examples
 
 - [ballista-python](https://github.com/apache/arrow-ballista-python) - A Python library that binds to Apache Arrow distributed query engine Ballista
+- [bleuscore](https://github.com/shenxiangzhuang/bleuscore) - A BLEU score calculation library, written in pure Rust
 - [chardetng-py](https://github.com/john-parton/chardetng-py) - Python binding for the chardetng character encoding detector.
 - [connector-x](https://github.com/sfu-db/connector-x/tree/main/connectorx-python) - ConnectorX enables you to load data from databases into Python in the fastest and most memory efficient way
 - [datafusion-python](https://github.com/apache/arrow-datafusion-python) - a Python library that binds to Apache Arrow in-memory query engine DataFusion


### PR DESCRIPTION
I want to thank the maturin project, it's very easy to use and convenient.

This PR will add bleuscore in examples.  It's a pretty simple project and I'm not sure if this should be added in the examples. So feel free to close the PR if it's not suitable.