### PR TITLE
Preserve file permission when copying

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1210,8 +1210,12 @@ pub fn write_python_part(
                         continue;
                     }
                 }
+                #[cfg(unix)]
+                let mode = absolute.metadata()?.permissions().mode();
+                #[cfg(not(unix))]
+                let mode = 0o644;
                 writer
-                    .add_file(relative, &absolute)
+                    .add_file_with_permissions(relative, &absolute, mode)
                     .context(format!("File to add file from {}", absolute.display()))?;
             }
         }


### PR DESCRIPTION
Would like to put symlink in a python module, so it will be copied to wheel package. (I know `data` should be used, but it's was not working as I expected - #2068)

This commit will use permission from the source file, then fallback with 0o644