### PR TITLE
Show full path in missing readme error message

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -422,8 +422,8 @@ fn add_cargo_package_files_to_sdist(
         })?;
         // Handle possible relative readme field in Cargo.toml
         if let Some(readme) = path_dep.readme.as_ref() {
-            let abs_readme = path_dep_manifest_dir
-                .join(readme)
+            let readme = path_dep_manifest_dir.join(readme);
+            let abs_readme = readme
                 .normalize()
                 .with_context(|| format!("failed to normalize readme path `{}`", readme.display()))?
                 .into_path_buf();
@@ -470,10 +470,10 @@ fn add_cargo_package_files_to_sdist(
     )?;
     // Handle possible relative readme field in Cargo.toml
     if let Some(readme) = main_crate.readme.as_ref() {
-        let abs_readme = abs_manifest_dir
-            .join(readme)
+        let readme = abs_manifest_dir.join(readme);
+        let abs_readme = readme
             .normalize()
-            .with_context(|| format!("failed to normalize readme path `{}`", readme))?
+            .with_context(|| format!("failed to normalize readme path `{}`", readme.display()))?
             .into_path_buf();
         let relative_readme = abs_readme.strip_prefix(&sdist_root).unwrap();
         writer.add_file(root_dir.join(relative_readme), &abs_readme)?;


### PR DESCRIPTION
Old error message:

```console
$ maturin sdist --manifest-path ../mistral.rs/mistralrs-pyo3/Cargo.toml
 🔗 Found pyo3 bindings
 🐍 Found CPython 3.13 at /usr/local/bin/python3
 📡 Using build options features from pyproject.toml
 💥 maturin failed
   Caused by: Failed to build source distribution
   Caused by: failed to normalize readme path `README.md`
   Caused by: No such file or directory (os error 2)
```

New error message:

```console
maturin sdist --manifest-path ../mistral.rs/mistralrs-pyo3/Cargo.toml
🔗 Found pyo3 bindings
🐍 Found CPython 3.13 at /usr/local/bin/python3
📡 Using build options features from pyproject.toml
💥 maturin failed
  Caused by: Failed to build source distribution
  Caused by: failed to normalize readme path `/home/konsti/projects/mistral.rs/mistralrs-core/README.md`
  Caused by: No such file or directory (os error 2)
```

Checking at https://github.com/EricLBuehler/mistral.rs/blob/86599c1adc5e4a07db50e8460676151f736c873f/mistralrs-core/Cargo.toml#L3, there was indeed a missing readme file.

Fixes https://github.com/PyO3/maturin/issues/2060