### PR TITLE
Add a global verbose option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Add a global `-v` option [#2080](https://github.com/PyO3/maturin/pull/2080)
+
 ## [1.5.1] - 2024-03-21
 
 * Fix usage of `--compatibility` when run as a PEP517 backend in [#1992](https://github.com/PyO3/maturin/pull/1992)

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -94,6 +94,7 @@ pub struct CargoOptions {
     pub ignore_rust_version: bool,
 
     /// Use verbose output (-vv very verbose/build.rs output)
+    // Note that this duplicates the global option, but clap seems to be fine with that.
     #[arg(short = 'v', long, action = clap::ArgAction::Count)]
     pub verbose: u8,
 

--- a/tests/cmd/generate-ci.stdout
+++ b/tests/cmd/generate-ci.stdout
@@ -13,6 +13,15 @@ Options:
   -m, --manifest-path <PATH>
           Path to Cargo.toml
 
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
   -o, --output <PATH>
           Output path
           

--- a/tests/cmd/init.stdout
+++ b/tests/cmd/init.stdout
@@ -3,12 +3,32 @@ Create a new cargo project in an existing directory
 Usage: maturin[EXE] init [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Project path
+  [PATH]
+          Project path
 
 Options:
-      --name <NAME>          Set the resulting package name, defaults to the directory name
-      --mixed                Use mixed Rust/Python project layout
-      --src                  Use Python first src layout for mixed Rust/Python project
-  -b, --bindings <BINDINGS>  Which kind of bindings to use [possible values: pyo3, cffi, uniffi,
-                             bin]
-  -h, --help                 Print help
+      --name <NAME>
+          Set the resulting package name, defaults to the directory name
+
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
+      --mixed
+          Use mixed Rust/Python project layout
+
+      --src
+          Use Python first src layout for mixed Rust/Python project
+
+  -b, --bindings <BINDINGS>
+          Which kind of bindings to use
+          
+          [possible values: pyo3, cffi, uniffi, bin]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/cmd/list-python.stdout
+++ b/tests/cmd/list-python.stdout
@@ -3,5 +3,17 @@ Search and list the available python installations
 Usage: maturin[EXE] list-python [OPTIONS]
 
 Options:
-      --target <TARGET>  
-  -h, --help             Print help
+      --target <TARGET>
+          
+
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/cmd/maturin.stdout
+++ b/tests/cmd/maturin.stdout
@@ -1,7 +1,7 @@
 Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python
 packages
 
-Usage: maturin[EXE] <COMMAND>
+Usage: maturin[EXE] [OPTIONS] <COMMAND>
 
 Commands:
   build        Build the crate into python packages
@@ -16,7 +16,19 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 Visit https://maturin.rs to learn more about maturin.

--- a/tests/cmd/new.stdout
+++ b/tests/cmd/new.stdout
@@ -3,12 +3,32 @@ Create a new cargo project
 Usage: maturin[EXE] new [OPTIONS] <PATH>
 
 Arguments:
-  <PATH>  Project path
+  <PATH>
+          Project path
 
 Options:
-      --name <NAME>          Set the resulting package name, defaults to the directory name
-      --mixed                Use mixed Rust/Python project layout
-      --src                  Use Python first src layout for mixed Rust/Python project
-  -b, --bindings <BINDINGS>  Which kind of bindings to use [possible values: pyo3, cffi, uniffi,
-                             bin]
-  -h, --help                 Print help
+      --name <NAME>
+          Set the resulting package name, defaults to the directory name
+
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
+      --mixed
+          Use mixed Rust/Python project layout
+
+      --src
+          Use Python first src layout for mixed Rust/Python project
+
+  -b, --bindings <BINDINGS>
+          Which kind of bindings to use
+          
+          [possible values: pyo3, cffi, uniffi, bin]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/cmd/sdist.stdout
+++ b/tests/cmd/sdist.stdout
@@ -10,6 +10,15 @@ Options:
   -m, --manifest-path <MANIFEST_PATH>
           The path to the Cargo.toml
 
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
   -o, --out <OUT>
           The directory to store the built wheels in. Defaults to a new "wheels" directory in the
           project's target directory

--- a/tests/cmd/upload.stdout
+++ b/tests/cmd/upload.stdout
@@ -18,6 +18,15 @@ Options:
           [env: MATURIN_REPOSITORY=]
           [default: pypi]
 
+  -v, --verbose...
+          Use verbose output.
+          
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
       --repository-url <REPOSITORY_URL>
           The URL of the registry where the wheels are uploaded to. This overrides --repository.
           


### PR DESCRIPTION
Debugging https://github.com/PyO3/maturin/discussions/2079 i realized that we currently require `RUST_LOG` for users to debug issues like missing inclusions. I added a global counting `-v` flag to allow users to get more verbose logging from maturin to help them diagnose their problems.

We currently use `-v` to configure cargo verbosity level. For simplicity, it now configures both at the same time. Fine-grained control is still possible by setting `RUST_LOG`.

The levels:
* Default: Show build information and `cargo build` output.
* `-v`: Use `cargo build -v`.
* `-vv`: Show debug logging and use `cargo build -vv`.
* `-vvv`: Show trace logging.

This can be extended to support a quiet option.