### PR TITLE
Pass no_deps to cargo metadata

### DIFF
--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -327,6 +327,7 @@ impl ProjectResolver {
             .manifest_path(manifest_path)
             .verbose(true)
             .other_options(cargo_metadata_extra_args)
+            .no_deps()
             .exec();
 
         let cargo_metadata = match result {


### PR DESCRIPTION
I've been trying to debug slow CI builds using Maturin.

On [my Linux builds](https://github.com/orf/pyvector/actions/runs/9045243480/job/24854796594), calling `cargo metadata` appears to cause the entire project to be built. If you're using `sccache` then this suddenly becomes very slow.

```
2024-05-11T17:16:58.211839Z DEBUG maturin::project_layout: Resolving cargo metadata from "/__w/pyvector/pyvector/Cargo.toml"
    Updating crates.io index
    Updating git repository `[https://github.com/vectordotdev/vector.git`](https://github.com/vectordotdev/vector.git%60)
    Updating git repository `[https://github.com/vectordotdev/heim.git`](https://github.com/vectordotdev/heim.git%60)
    Updating git repository `[https://github.com/tokio-rs/tracing`](https://github.com/tokio-rs/tracing%60)
 Downloading crates ...
  Downloaded adler v1.0.2
  Downloaded aead v0.5.2
  Downloaded RustyXML v0.3.0
  Downloaded ahash v0.8.11
```

Passing `--no-deps` to `cargo metadata` does not cause a build. Do we need the dependency information?