### PR TITLE
Detect target based on interpreter for pep517 build-wheel

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -551,7 +551,16 @@ impl BuildOptions {
             target_triple = None;
         }
 
-        let target = Target::from_target_triple(target_triple)?;
+        let mut target = Target::from_target_triple(target_triple)?;
+        if !target.user_specified && !universal2 {
+            if let Some(interpreter) = self.interpreter.first() {
+                if let Some(detected_target) =
+                    crate::target::detect_arch_from_python(interpreter, &target)
+                {
+                    target = Target::from_target_triple(Some(detected_target))?;
+                }
+            }
+        }
 
         let wheel_dir = match self.out {
             Some(ref dir) => dir.clone(),

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -1,5 +1,5 @@
 use crate::build_options::CargoOptions;
-use crate::target::Arch;
+use crate::target::detect_arch_from_python;
 use crate::BuildContext;
 use crate::BuildOptions;
 use crate::PlatformTag;
@@ -307,22 +307,8 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 
     // check python platform and architecture
     if !target.user_specified {
-        match Command::new(&python)
-            .arg("-c")
-            .arg("import sysconfig; print(sysconfig.get_platform(), end='')")
-            .output()
-        {
-            Ok(output) if output.status.success() => {
-                let platform = String::from_utf8_lossy(&output.stdout);
-                if platform.contains("macos") {
-                    if platform.contains("x86_64") && target.target_arch() != Arch::X86_64 {
-                        target_triple = Some("x86_64-apple-darwin".to_string());
-                    } else if platform.contains("arm64") && target.target_arch() != Arch::Aarch64 {
-                        target_triple = Some("aarch64-apple-darwin".to_string());
-                    }
-                }
-            }
-            _ => eprintln!("⚠️  Warning: Failed to determine python platform"),
+        if let Some(detected_target) = detect_arch_from_python(&python, &target) {
+            target_triple = Some(detected_target);
         }
     }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 use std::str;
 use target_lexicon::{Architecture, Environment, Triple};
 use tracing::error;
@@ -617,4 +618,25 @@ fn rustc_version_meta() -> Result<VersionMeta> {
         err => anyhow!(err).context("Failed to run rustc to get the host target"),
     })?;
     Ok(meta)
+}
+
+pub(crate) fn detect_arch_from_python(python: &PathBuf, target: &Target) -> Option<String> {
+    match Command::new(python)
+        .arg("-c")
+        .arg("import sysconfig; print(sysconfig.get_platform(), end='')")
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let platform = String::from_utf8_lossy(&output.stdout);
+            if platform.contains("macos") {
+                if platform.contains("x86_64") && target.target_arch() != Arch::X86_64 {
+                    return Some("x86_64-apple-darwin".to_string());
+                } else if platform.contains("arm64") && target.target_arch() != Arch::Aarch64 {
+                    return Some("aarch64-apple-darwin".to_string());
+                }
+            }
+        }
+        _ => eprintln!("⚠️  Warning: Failed to determine python platform"),
+    }
+    None
 }


### PR DESCRIPTION
(re-creation of prematurely-closed https://github.com/PyO3/maturin/pull/2086)

This PR detects the desired target based on the python interpreter for pep517 commands, similar to the detection already in place for maturin develop.

This fixes maturin pep517 build-wheel building for the host architecture, even when the current python interpreter is a different architecture, ie. when using an x86_64 python on arm64 macos host.

Related issue: https://github.com/PyO3/maturin/issues/2041