### PR TITLE
Initial iOS support

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -22,6 +22,7 @@ pub enum Os {
     Linux,
     Windows,
     Macos,
+    Ios,
     FreeBsd,
     NetBsd,
     OpenBsd,
@@ -40,6 +41,7 @@ impl fmt::Display for Os {
             Os::Linux => write!(f, "Linux"),
             Os::Windows => write!(f, "Windows"),
             Os::Macos => write!(f, "macOS"),
+            Os::Ios => write!(f, "iOS"),
             Os::FreeBsd => write!(f, "FreeBSD"),
             Os::NetBsd => write!(f, "NetBSD"),
             Os::OpenBsd => write!(f, "OpenBSD"),
@@ -155,6 +157,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
         ],
         Os::Windows => vec![Arch::X86, Arch::X86_64, Arch::Aarch64],
         Os::Macos => vec![Arch::Aarch64, Arch::X86_64],
+        Os::Ios => vec![Arch::Aarch64],
         Os::FreeBsd | Os::NetBsd => vec![
             Arch::Aarch64,
             Arch::Armv6L,
@@ -239,6 +242,7 @@ impl Target {
             OperatingSystem::Linux => Os::Linux,
             OperatingSystem::Windows => Os::Windows,
             OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin => Os::Macos,
+            OperatingSystem::Ios => Os::Ios,
             OperatingSystem::Netbsd => Os::NetBsd,
             OperatingSystem::Freebsd => Os::FreeBsd,
             OperatingSystem::Openbsd => Os::OpenBsd,
@@ -370,6 +374,7 @@ impl Target {
             Os::Windows => "windows",
             Os::Linux => "linux",
             Os::Macos => "darwin",
+            Os::Ios => "darwin",
             Os::FreeBsd => "freebsd",
             Os::NetBsd => "netbsd",
             Os::OpenBsd => "openbsd",
@@ -455,6 +460,7 @@ impl Target {
             Os::Windows => false,
             Os::Linux
             | Os::Macos
+            | Os::Ios
             | Os::FreeBsd
             | Os::NetBsd
             | Os::OpenBsd

--- a/src/target.rs
+++ b/src/target.rs
@@ -157,7 +157,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
         ],
         Os::Windows => vec![Arch::X86, Arch::X86_64, Arch::Aarch64],
         Os::Macos => vec![Arch::Aarch64, Arch::X86_64],
-        Os::Ios => vec![Arch::Aarch64],
+        Os::Ios => vec![Arch::Aarch64, Arch::X86_64],
         Os::FreeBsd | Os::NetBsd => vec![
             Arch::Aarch64,
             Arch::Armv6L,


### PR DESCRIPTION
This PR adds minimal iOS support to Maturin.

Related issue: #1742

Solution is merely based on https://github.com/PyO3/maturin/issues/1742 by @holzschu

It works! I've been able to build [pydantic-core](https://pypi.org/project/pydantic-core/) package for iOS and simulator using [crossenv](https://pypi.org/project/crossenv/).

The only issue is wheel tag which is always `-cp312-cp312-ios_23_5_0_arm64.whl` for all three triples passed to `CARGO_BUILD_TARGET`:
* `aarch64-apple-ios`
* `aarch64-apple-ios-sim`
* `x86_64-apple-ios`

though binaries inside `.whl` have correct architecture.

`_PYTHON_HOST_PLATFORM` is also set, but is not respected.

I'd like to improve that in this PR as well (if that's possible), but don't know where to dig. Some hint/guidance would be appreciated.

