### PR TITLE
Don't add duplicate files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustversion",
+ "same-file",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ normpath = "1.1.1"
 path-slash = "0.2.1"
 pep440_rs = { version = "0.5.0", features = ["serde", "tracing"] }
 pep508_rs = { version = "0.4.2", features = ["serde", "tracing"] }
+same-file = "1.0.6"
 time = "0.3.17"
 url = "2.5.0"
 unicode-xid = { version = "0.2.4", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Don't add files to an archive more than once [#2125](https://github.com/PyO3/maturin/issues/2125)
+
 ## [1.6.0] - 2024-06-04
 
 * Detect compiling from Linux gnu to Linux musl as cross compiling in [#2010](https://github.com/PyO3/maturin/pull/2010)

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -218,7 +218,11 @@ fn add_crate_to_source_distribution(
 
     if root_crate {
         let rewritten_cargo_toml = rewrite_cargo_toml(manifest_path, known_path_deps)?;
-        writer.add_bytes(cargo_toml_path, rewritten_cargo_toml.as_bytes())?;
+        writer.add_bytes(
+            cargo_toml_path,
+            Some(manifest_path),
+            rewritten_cargo_toml.as_bytes(),
+        )?;
     } else if !skip_cargo_toml {
         writer.add_file(cargo_toml_path, manifest_path)?;
     }
@@ -520,9 +524,10 @@ fn add_cargo_package_files_to_sdist(
                     readme: None,
                 },
             );
-            let workspace_cargo_toml = rewrite_cargo_toml(workspace_manifest_path, &deps_to_keep)?;
+            let workspace_cargo_toml = rewrite_cargo_toml(&workspace_manifest_path, &deps_to_keep)?;
             writer.add_bytes(
                 root_dir.join(relative_workspace_cargo_toml),
+                Some(workspace_manifest_path.as_std_path()),
                 workspace_cargo_toml.as_bytes(),
             )?;
         }
@@ -545,6 +550,7 @@ fn add_cargo_package_files_to_sdist(
         )?;
         writer.add_bytes(
             root_dir.join("pyproject.toml"),
+            Some(pyproject_toml_path),
             rewritten_pyproject_toml.as_bytes(),
         )?;
     } else {
@@ -684,6 +690,7 @@ pub fn source_distribution(
 
     writer.add_bytes(
         root_dir.join("PKG-INFO"),
+        None,
         metadata23.to_file_contents()?.as_bytes(),
     )?;
 

--- a/test-crates/pyo3-mixed/pyo3_mixed/assets/asset.txt
+++ b/test-crates/pyo3-mixed/pyo3_mixed/assets/asset.txt
@@ -1,0 +1,3 @@
+This file is included twice, once implicitly by in the python root and once explicitly in pyproject.toml
+and checks that it gets deduplicated, see https://github.com/PyO3/maturin/issues/2106 and
+https://github.com/PyO3/maturin/issues/2066.

--- a/test-crates/pyo3-mixed/pyproject.toml
+++ b/test-crates/pyo3-mixed/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = ["boltons"]
 [project.scripts]
 get_42 = "pyo3_mixed:get_42"
 print_cli_args = "pyo3_mixed:print_cli_args"
+
+[tool.maturin]
+include = ["pyo3_mixed/assets/*"]

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -176,7 +176,12 @@ pub fn test_source_distribution(
         }
     }
     expected_files.assert_debug_eq(&files);
-    assert_eq!(file_count, files.len(), "duplicated files found in sdist");
+    assert_eq!(
+        file_count,
+        files.len(),
+        "duplicated files found in sdist: {:?}",
+        files
+    );
 
     if let Some((cargo_toml_path, expected)) = expected_cargo_toml {
         let cargo_toml = cargo_toml


### PR DESCRIPTION
Add a file tracker for writing archives that checks that each path in the archive can't be added more than once. If the same file would be added twice, it's ignored the second time, if a different file would be added, it errors.

Fixes #2066
Fixes #2106