### PR TITLE
pep517: only use base python when `MATURIN_PEP517_USE_BASE_PYTHON` env var is set

### DIFF
--- a/guide/src/environment-variables.md
+++ b/guide/src/environment-variables.md
@@ -14,6 +14,7 @@ See [environment variables Cargo reads](https://doc.rust-lang.org/cargo/referenc
 * `_PYTHON_SYSCONFIGDATA_NAME`: Name of a `sysconfigdata*.py` file
 * `MATURIN_PYPI_TOKEN`: PyPI token for uploading wheels
 * `MATURIN_PASSWORD`: PyPI password for uploading wheels
+* `MATURIN_PEP517_USE_BASE_PYTHON`: Use base Python executable instead of venv Python executable in PEP 517 build to avoid unnecessary rebuilds, should not be set when the sdist build requires packages installed in venv.
 
 ## `pyo3` environment variables
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -46,13 +46,13 @@ def get_maturin_pep517_args(config_settings: Optional[Mapping[str, Any]] = None)
 
 
 def _get_sys_executable() -> str:
-    # Use the base interpreter path when running inside a venv to avoid recompilation
-    # when switching between venvs
-    base_executable = getattr(sys, "_base_executable")
-    if base_executable and os.path.exists(base_executable):
-        executable = os.path.realpath(base_executable)
-    else:
-        executable = sys.executable
+    executable = sys.executable
+    if os.getenv("MATURIN_PEP517_USE_BASE_PYTHON") in {"1", "true"}:
+        # Use the base interpreter path when running inside a venv to avoid recompilation
+        # when switching between venvs
+        base_executable = getattr(sys, "_base_executable")
+        if base_executable and os.path.exists(base_executable):
+            executable = os.path.realpath(base_executable)
     return executable
 
 


### PR DESCRIPTION
Closes #2133 