### PR TITLE
Fix platform tags when cross-compiling universal2

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -549,7 +549,9 @@ impl BuildOptions {
             };
         }
         if universal2 {
-            target_triple = None;
+            // Ensure that target_triple is valid. This is necessary to properly
+            // infer the platform tags when cross-compiling from Linux.
+            target_triple = Some("aarch64-apple-darwin".to_string());
         }
 
         let mut target = Target::from_target_triple(target_triple)?;


### PR DESCRIPTION
When cross-compiling for `universal2-apple-darwin`, the platform tags of the resulting wheel were not properly derived. This is because with forcing `target_triple` to `None` as before, it was not detected that we are in fact cross-compiling for a different target and thus the wheels were wrongly tagged for the host platform.

To make the inference work, set `target_triple` to a valid triple instead.