### PR TITLE
Fix rust 1.80 clippy errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,10 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
+      - name: Enable long paths
+        if: startsWith(matrix.platform.os, 'windows')
+        run: |
+          reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
       - name: Cleanup Disk
         if: ${{ !startsWith(matrix.platform.os, 'windows') }}
         run: |

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1363,7 +1363,7 @@ mod test {
     #[test]
     fn test_find_bridge_pyo3() {
         let pyo3_mixed = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/pyo3-mixed").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/pyo3-mixed").join("Cargo.toml"))
             .exec()
             .unwrap();
 
@@ -1380,7 +1380,7 @@ mod test {
     #[test]
     fn test_find_bridge_pyo3_abi3() {
         let pyo3_pure = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/pyo3-pure").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/pyo3-pure").join("Cargo.toml"))
             .exec()
             .unwrap();
 
@@ -1397,14 +1397,14 @@ mod test {
     #[test]
     fn test_find_bridge_pyo3_feature() {
         let pyo3_pure = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/pyo3-feature").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/pyo3-feature").join("Cargo.toml"))
             .exec()
             .unwrap();
 
         assert!(find_bridge(&pyo3_pure, None).is_err());
 
         let pyo3_pure = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/pyo3-feature").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/pyo3-feature").join("Cargo.toml"))
             .other_options(vec!["--features=pyo3".to_string()])
             .exec()
             .unwrap();
@@ -1418,7 +1418,7 @@ mod test {
     #[test]
     fn test_find_bridge_cffi() {
         let cffi_pure = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/cffi-pure").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/cffi-pure").join("Cargo.toml"))
             .exec()
             .unwrap();
 
@@ -1434,7 +1434,7 @@ mod test {
     #[test]
     fn test_find_bridge_bin() {
         let hello_world = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/hello-world").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/hello-world").join("Cargo.toml"))
             .exec()
             .unwrap();
 
@@ -1450,7 +1450,7 @@ mod test {
         assert!(find_bridge(&hello_world, Some("pyo3")).is_err());
 
         let pyo3_bin = MetadataCommand::new()
-            .manifest_path(&Path::new("test-crates/pyo3-bin").join("Cargo.toml"))
+            .manifest_path(Path::new("test-crates/pyo3-bin").join("Cargo.toml"))
             .exec()
             .unwrap();
         assert!(matches!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@
 //! - upload: Uses ureq to add the upload command.
 //!
 //! - rustls: Makes ureq use the rustls stack so that we can build maturin in a CentOS 6
-//! docker container and which maturin itself manylinux compliant.
+//!   docker container and which maturin itself manylinux compliant.
 //!
 //! - native-tls: Makes ureq use the platform native tls stack
 //!
 //! - password-storage (off by default): Uses the keyring package to store the password. keyring
-//! pulls in a lot of shared libraries and outdated dependencies, so this is off by default, except
-//! for the build on the github releases page.
-//! (https://github.com/hwchen/secret-service-rs/issues/9)
+//!   pulls in a lot of shared libraries and outdated dependencies, so this is off by default, except
+//!   for the build on the github releases page.
+//!   (https://github.com/hwchen/secret-service-rs/issues/9)
 
 #![deny(missing_docs)]
 

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -853,7 +853,7 @@ pub fn write_bindings_module(
         writer.add_directory(&module)?;
         // Reexport the shared library as if it were the top level module
         writer.add_bytes(
-            &module.join("__init__.py"),
+            module.join("__init__.py"),
             None,
             format!(
                 r#"from .{ext_name} import *
@@ -867,10 +867,10 @@ if hasattr({ext_name}, "__all__"):
         let type_stub = project_layout.rust_module.join(format!("{ext_name}.pyi"));
         if type_stub.exists() {
             eprintln!("📖 Found type stub file at {ext_name}.pyi");
-            writer.add_file(&module.join("__init__.pyi"), type_stub)?;
-            writer.add_bytes(&module.join("py.typed"), None, b"")?;
+            writer.add_file(module.join("__init__.pyi"), type_stub)?;
+            writer.add_bytes(module.join("py.typed"), None, b"")?;
         }
-        writer.add_file_with_permissions(&module.join(so_filename), artifact, 0o755)?;
+        writer.add_file_with_permissions(module.join(so_filename), artifact, 0o755)?;
     }
 
     Ok(())
@@ -931,20 +931,20 @@ pub fn write_cffi_module(
             .join(format!("{module_name}.pyi"));
         if type_stub.exists() {
             eprintln!("📖 Found type stub file at {module_name}.pyi");
-            writer.add_file(&module.join("__init__.pyi"), type_stub)?;
-            writer.add_bytes(&module.join("py.typed"), None, b"")?;
+            writer.add_file(module.join("__init__.pyi"), type_stub)?;
+            writer.add_bytes(module.join("py.typed"), None, b"")?;
         }
     };
 
     if !editable || project_layout.python_module.is_none() {
         writer.add_bytes(
-            &module.join("__init__.py"),
+            module.join("__init__.py"),
             None,
             cffi_init_file(&project_layout.extension_name).as_bytes(),
         )?;
-        writer.add_bytes(&module.join("ffi.py"), None, cffi_declarations.as_bytes())?;
+        writer.add_bytes(module.join("ffi.py"), None, cffi_declarations.as_bytes())?;
         writer.add_file_with_permissions(
-            &module.join(format!(
+            module.join(format!(
                 "{extension_name}.so",
                 extension_name = &project_layout.extension_name
             )),
@@ -1174,18 +1174,18 @@ pub fn write_uniffi_module(
             .join(format!("{module_name}.pyi"));
         if type_stub.exists() {
             eprintln!("📖 Found type stub file at {module_name}.pyi");
-            writer.add_file(&module.join("__init__.pyi"), type_stub)?;
-            writer.add_bytes(&module.join("py.typed"), None, b"")?;
+            writer.add_file(module.join("__init__.pyi"), type_stub)?;
+            writer.add_bytes(module.join("py.typed"), None, b"")?;
         }
     };
 
     if !editable || project_layout.python_module.is_none() {
-        writer.add_bytes(&module.join("__init__.py"), None, py_init.as_bytes())?;
+        writer.add_bytes(module.join("__init__.py"), None, py_init.as_bytes())?;
         writer.add_file(
             module.join(binding_name).with_extension("py"),
             uniffi_binding,
         )?;
-        writer.add_file_with_permissions(&module.join(cdylib), artifact, 0o755)?;
+        writer.add_file_with_permissions(module.join(cdylib), artifact, 0o755)?;
     }
 
     Ok(())
@@ -1208,7 +1208,7 @@ pub fn write_bin(
     writer.add_directory(&data_dir)?;
 
     // We can't use add_file since we need to mark the file as executable
-    writer.add_file_with_permissions(&data_dir.join(bin_name), artifact, 0o755)?;
+    writer.add_file_with_permissions(data_dir.join(bin_name), artifact, 0o755)?;
     Ok(())
 }
 
@@ -1353,13 +1353,13 @@ pub fn write_dist_info(
     writer.add_directory(&dist_info_dir)?;
 
     writer.add_bytes(
-        &dist_info_dir.join("METADATA"),
+        dist_info_dir.join("METADATA"),
         None,
         metadata23.to_file_contents()?.as_bytes(),
     )?;
 
     writer.add_bytes(
-        &dist_info_dir.join("WHEEL"),
+        dist_info_dir.join("WHEEL"),
         None,
         wheel_file(tags)?.as_bytes(),
     )?;
@@ -1376,7 +1376,7 @@ pub fn write_dist_info(
     }
     if !entry_points.is_empty() {
         writer.add_bytes(
-            &dist_info_dir.join("entry_points.txt"),
+            dist_info_dir.join("entry_points.txt"),
             None,
             entry_points.as_bytes(),
         )?;

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -412,7 +412,7 @@ fn add_cargo_package_files_to_sdist(
         add_crate_to_source_distribution(
             writer,
             &path_dep.manifest_path,
-            &root_dir.join(relative_path_dep_manifest_dir),
+            root_dir.join(relative_path_dep_manifest_dir),
             &known_path_deps,
             false,
             skip_cargo_toml,

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -511,13 +511,12 @@ fn abi3_without_version() {
         target_os = "linux",
         target_env = "gnu",
         any(
-            target_arch = "i686",
+            target_arch = "x86",
             target_arch = "x86_64",
             target_arch = "aarch64",
             target_arch = "powerpc64",
-            target_arch = "powerpc64le",
             target_arch = "s390x",
-            target_arch = "armv7"
+            target_arch = "arm"
         )
     )),
     ignore


### PR DESCRIPTION
Was hitting a bunch of weird errors that had no relation to the code changes in #2158, looks like they were related to a recent rust 1.80 release.