### PR TITLE
Replace `--skip-auditwheel` with `--auditwheel` option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -826,7 +826,7 @@ With this release, the name of this project changes from _pyo3-pack_ to _maturin
 
 ### Changed
 
- * The `--skip-auditwheel` flag has been deprecated in favor of `--manxlinux=[1|1-unchecked|2010|2010-unchecked|off]`.
+ * The `--skip-auditwheel` flag has been deprecated in favor of `--manylinux=[1|1-unchecked|2010|2010-unchecked|off]`.
  * Switched to rustls. This means the upload feature can be used from the docker container and builds of maturin itself are manylinux compliant when compiled with the musl target.
 
 ## [0.4.2] - 2018-12-15

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -46,7 +46,9 @@ exclude = []
 bindings = "pyo3"
 # Control the platform tag on linux
 compatibility = "manylinux2014"
-# Don't check for manylinux compliance
+# auditwheel mode, possible values are repair, check and skip
+auditwheel = "repair"
+# Don't check for manylinux compliance, deprecated in favor of auditwheel = "audit"
 skip-auditwheel = false
 # Python source directory
 python-source = "src"

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -107,8 +107,13 @@ Options:
   -o, --out <OUT>
           The directory to store the built wheels in. Defaults to a new "wheels" directory in the project's target directory
 
-      --skip-auditwheel
-          Don't check for manylinux compliance
+      --auditwheel <AUDITWHEEL>
+          Audit wheel for manylinux compliance
+
+          Possible values:
+          - repair: Audit and repair wheel for manylinux compliance
+          - check:  Check wheel for manylinux compliance, but do not repair
+          - skip:   Don't check for manylinux compliance
 
       --zig
           For manylinux targets, use zig to ensure compliance for the chosen manylinux version

--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -11,6 +11,17 @@
         "null"
       ]
     },
+    "auditwheel": {
+      "description": "Audit wheel mode",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AuditWheelMode"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "bindings": {
       "description": "Bindings type",
       "type": [
@@ -194,6 +205,32 @@
     }
   },
   "definitions": {
+    "AuditWheelMode": {
+      "description": "Auditwheel mode",
+      "oneOf": [
+        {
+          "description": "Audit and repair wheel for manylinux compliance",
+          "type": "string",
+          "enum": [
+            "repair"
+          ]
+        },
+        {
+          "description": "Check wheel for manylinux compliance, but do not repair",
+          "type": "string",
+          "enum": [
+            "check"
+          ]
+        },
+        {
+          "description": "Don't check for manylinux compliance",
+          "type": "string",
+          "enum": [
+            "skip"
+          ]
+        }
+      ]
+    },
     "CargoTarget": {
       "description": "Cargo compile target",
       "type": "object",

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -1,3 +1,4 @@
+use crate::auditwheel::AuditWheelMode;
 use crate::build_options::CargoOptions;
 use crate::target::detect_arch_from_python;
 use crate::BuildContext;
@@ -321,6 +322,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         find_interpreter: false,
         bindings,
         out: Some(wheel_dir.path().to_path_buf()),
+        auditwheel: Some(AuditWheelMode::Skip),
         skip_auditwheel: false,
         #[cfg(feature = "zig")]
         zig: false,

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -1,5 +1,6 @@
 //! A pyproject.toml as specified in PEP 517
 
+use crate::auditwheel::AuditWheelMode;
 use crate::PlatformTag;
 use anyhow::{Context, Result};
 use fs_err as fs;
@@ -142,6 +143,8 @@ pub struct ToolMaturin {
     /// Platform compatibility
     #[serde(alias = "manylinux")]
     pub compatibility: Option<PlatformTag>,
+    /// Audit wheel mode
+    pub auditwheel: Option<AuditWheelMode>,
     /// Skip audit wheel
     #[serde(default)]
     pub skip_auditwheel: bool,
@@ -252,6 +255,13 @@ impl PyProjectToml {
     /// Returns the value of `[tool.maturin.compatibility]` in pyproject.toml
     pub fn compatibility(&self) -> Option<PlatformTag> {
         self.maturin()?.compatibility
+    }
+
+    /// Returns the value of `[tool.maturin.auditwheel]` in pyproject.toml
+    pub fn auditwheel(&self) -> Option<AuditWheelMode> {
+        self.maturin()
+            .map(|maturin| maturin.auditwheel)
+            .unwrap_or_default()
     }
 
     /// Returns the value of `[tool.maturin.skip-auditwheel]` in pyproject.toml

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -43,8 +43,13 @@ Options:
           The directory to store the built wheels in. Defaults to a new "wheels" directory in the
           project's target directory
 
-      --skip-auditwheel
-          Don't check for manylinux compliance
+      --auditwheel <AUDITWHEEL>
+          Audit wheel for manylinux compliance
+
+          Possible values:
+          - repair: Audit and repair wheel for manylinux compliance
+          - check:  Check wheel for manylinux compliance, but do not repair
+          - skip:   Don't check for manylinux compliance
 
       --zig
           For manylinux targets, use zig to ensure compliance for the chosen manylinux version

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -89,8 +89,13 @@ Options:
           The directory to store the built wheels in. Defaults to a new "wheels" directory in the
           project's target directory
 
-      --skip-auditwheel
-          Don't check for manylinux compliance
+      --auditwheel <AUDITWHEEL>
+          Audit wheel for manylinux compliance
+
+          Possible values:
+          - repair: Audit and repair wheel for manylinux compliance
+          - check:  Check wheel for manylinux compliance, but do not repair
+          - skip:   Don't check for manylinux compliance
 
       --zig
           For manylinux targets, use zig to ensure compliance for the chosen manylinux version

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -123,7 +123,7 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
             .source()
             .ok_or_else(|| format_err!("{}", err))?
             .to_string();
-        assert_eq!(err_string, "manylinux_2_99 compatibility policy is not defined by auditwheel yet, pass `--skip-auditwheel` to proceed anyway");
+        assert_eq!(err_string, "manylinux_2_99 compatibility policy is not defined by auditwheel yet, pass `--auditwheel=skip` to proceed anyway");
     } else {
         bail!("Should have errored");
     }


### PR DESCRIPTION
Error message example

```
🖨️ Your library is not manylinux/musllinux compliant because it requires copying the following libraries:
    libcrypto.so.3 => /usr/lib/x86_64-linux-gnu/libcrypto.so.3
    libssl.so.3 => /usr/lib/x86_64-linux-gnu/libssl.so.3
💥 maturin failed
  Caused by: Can not repair the wheel because `--auditwheel=check` is specified, re-run with `--auditwheel=repair` to copy the libraries.
```

Closes #2045 