### PR TITLE
Use modern stripping option

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -275,9 +275,10 @@ fn cargo_build_command(
     }
 
     if context.strip {
+        // https://doc.rust-lang.org/rustc/codegen-options/index.html#strip
         cargo_rustc
             .args
-            .extend(["-C".to_string(), "link-arg=-s".to_string()]);
+            .extend(["-C".to_string(), "strip=symbols".to_string()]);
     }
 
     let mut build_command = if target.is_msvc() && target.cross_compiling() {


### PR DESCRIPTION
Use `-C strip=symbols` instead of `-C link-arg=-s`. Still broken due to https://github.com/rust-lang/cargo/issues/14346, but i think it's the right modernization anyway.