### PR TITLE
Move project metadata from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maturin"
+description = "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages"
+authors = [{ name = "konstin", email = "konstin@mailbox.org" }]
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.7"
+license = {text = "MIT OR Apache-2.0"}
 classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Programming Language :: Rust",
@@ -14,10 +18,6 @@ classifiers = [
 ]
 dependencies = ["tomli>=1.1.0 ; python_version<'3.11'"]
 dynamic = [
-    "authors",
-    "description",
-    "license",
-    "readme",
     "version"
 ]
 
@@ -34,6 +34,9 @@ patchelf = [
 Issues = "https://github.com/PyO3/maturin/issues"
 Documentation = "https://maturin.rs"
 Changelog = "https://maturin.rs/changelog.html"
+
+[tool.setuptools]
+packages = ["maturin"]
 
 [tool.maturin]
 bindings = "bin"

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,6 @@ try:
 except ImportError:
     bdist_wheel = None
 
-with open("README.md", encoding="utf-8", errors="ignore") as fp:
-    long_description = fp.read()
-
 with open("Cargo.toml", "rb") as fp:
     version = tomllib.load(fp)["package"]["version"]
 
@@ -51,8 +48,6 @@ if os.getenv("MATURIN_SETUP_ARGS"):
     cargo_args = shlex.split(os.getenv("MATURIN_SETUP_ARGS", ""))
 
 setup(
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     version=version,
     cmdclass={"bdist_wheel": bdist_wheel},
     rust_extensions=[RustBin("maturin", args=cargo_args, cargo_manifest_args=["--locked"])],

--- a/setup.py
+++ b/setup.py
@@ -51,25 +51,10 @@ if os.getenv("MATURIN_SETUP_ARGS"):
     cargo_args = shlex.split(os.getenv("MATURIN_SETUP_ARGS", ""))
 
 setup(
-    name="maturin",
-    author="konstin",
-    author_email="konstin@mailbox.org",
-    url="https://github.com/pyo3/maturin",
-    description="Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as "
-    "python packages",
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=version,
-    license="MIT OR Apache-2.0",
-    python_requires=">=3.7",
     cmdclass={"bdist_wheel": bdist_wheel},
-    packages=["maturin"],
     rust_extensions=[RustBin("maturin", args=cargo_args, cargo_manifest_args=["--locked"])],
-    classifiers=[
-        "Topic :: Software Development :: Build Tools",
-        "Programming Language :: Rust",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
     zip_safe=False,
 )


### PR DESCRIPTION
As per #2174 , this PR moves the metadata defined under `setup.py` to `pyproject.toml`