### PR TITLE
use just `licenses` as the license directory in a wheel

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1392,7 +1392,7 @@ pub fn write_dist_info(
     }
 
     if !metadata23.license_files.is_empty() {
-        let license_files_dir = dist_info_dir.join("license_files");
+        let license_files_dir = dist_info_dir.join("licenses");
         writer.add_directory(&license_files_dir)?;
         for path in &metadata23.license_files {
             let filename = path.file_name().with_context(|| {


### PR DESCRIPTION
https://github.com/PyO3/maturin/issues/2180
