### PR TITLE
Cross building fixes

### DIFF
--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -425,6 +425,14 @@ mod test {
         );
 
         let sysconfig = InterpreterConfig::lookup_one(
+            &Target::from_target_triple(Some("powerpc-unknown-linux-gnu".to_string())).unwrap(),
+            InterpreterKind::CPython,
+            (3, 10),
+        )
+        .unwrap();
+        assert_eq!(sysconfig.ext_suffix, ".cpython-310-powerpc-linux-gnu.so");
+
+        let sysconfig = InterpreterConfig::lookup_one(
             &Target::from_target_triple(Some("s390x-unknown-linux-gnu".to_string())).unwrap(),
             InterpreterKind::CPython,
             (3, 10),

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -433,6 +433,25 @@ mod test {
         assert_eq!(sysconfig.ext_suffix, ".cpython-310-powerpc-linux-gnu.so");
 
         let sysconfig = InterpreterConfig::lookup_one(
+            &Target::from_target_triple(Some("mips64-unknown-linux-gnu".to_string())).unwrap(),
+            InterpreterKind::CPython,
+            (3, 10),
+        )
+        .unwrap();
+        assert_eq!(
+            sysconfig.ext_suffix,
+            ".cpython-310-mips64-linux-gnuabi64.so"
+        );
+
+        let sysconfig = InterpreterConfig::lookup_one(
+            &Target::from_target_triple(Some("mips-unknown-linux-gnu".to_string())).unwrap(),
+            InterpreterKind::CPython,
+            (3, 10),
+        )
+        .unwrap();
+        assert_eq!(sysconfig.ext_suffix, ".cpython-310-mips-linux-gnu.so");
+
+        let sysconfig = InterpreterConfig::lookup_one(
             &Target::from_target_triple(Some("s390x-unknown-linux-gnu".to_string())).unwrap(),
             InterpreterKind::CPython,
             (3, 10),

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -306,7 +306,7 @@ impl InterpreterConfig {
                     format!(
                         ".cpython-{}-{}-{}-{}.{}",
                         abi_tag,
-                        target.get_python_arch(),
+                        target.get_python_ext_arch(interpreter_kind),
                         target.get_python_os(),
                         target_env,
                         file_ext,
@@ -319,7 +319,7 @@ impl InterpreterConfig {
                         major,
                         minor,
                         abi_tag,
-                        target.get_python_arch(),
+                        target.get_python_ext_arch(interpreter_kind),
                         target.get_python_os(),
                         target_env,
                         file_ext,
@@ -330,7 +330,7 @@ impl InterpreterConfig {
                     format!(
                         ".{}-{}-{}.{}",
                         abi_tag.replace('_', "-"),
-                        target.get_python_arch(),
+                        target.get_python_ext_arch(interpreter_kind),
                         target.get_python_os(),
                         file_ext,
                     )
@@ -341,7 +341,7 @@ impl InterpreterConfig {
                 format!(
                     ".cpython-{}-{}-{}.{}",
                     abi_tag,
-                    target.get_python_arch(),
+                    target.get_python_ext_arch(interpreter_kind),
                     target.get_python_os(),
                     file_ext
                 )

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -47,15 +47,7 @@ impl InterpreterConfig {
             // Python 2 is not supported
             return None;
         }
-        let python_arch = if matches!(target.target_arch(), Arch::Armv6L | Arch::Armv7L) {
-            "arm"
-        } else if matches!(target.target_arch(), Arch::Powerpc64Le) && python_impl == PyPy {
-            "ppc_64"
-        } else if matches!(target.target_arch(), Arch::X86) && python_impl == PyPy {
-            "x86"
-        } else {
-            target.get_python_arch()
-        };
+        let python_ext_arch = target.get_python_ext_arch(python_impl);
         // See https://github.com/pypa/auditwheel/issues/349
         let target_env = match python_impl {
             CPython => {
@@ -77,7 +69,7 @@ impl InterpreterConfig {
                 let ldversion = format!("{}{}{}", major, minor, abiflags);
                 let ext_suffix = format!(
                     ".cpython-{}-{}-linux-{}.so",
-                    ldversion, python_arch, target_env
+                    ldversion, python_ext_arch, target_env
                 );
                 Some(Self {
                     major,
@@ -90,7 +82,8 @@ impl InterpreterConfig {
             }
             (Os::Linux, PyPy) => {
                 let abi_tag = format!("pypy{}{}-{}", major, minor, PYPY_ABI_TAG);
-                let ext_suffix = format!(".{}-{}-linux-{}.so", abi_tag, python_arch, target_env);
+                let ext_suffix =
+                    format!(".{}-{}-linux-{}.so", abi_tag, python_ext_arch, target_env);
                 Some(Self {
                     major,
                     minor,
@@ -204,7 +197,8 @@ impl InterpreterConfig {
             }
             (Os::Emscripten, CPython) => {
                 let ldversion = format!("{}{}", major, minor);
-                let ext_suffix = format!(".cpython-{}-{}-emscripten.so", ldversion, python_arch);
+                let ext_suffix =
+                    format!(".cpython-{}-{}-emscripten.so", ldversion, python_ext_arch);
                 Some(Self {
                     major,
                     minor,

--- a/src/target.rs
+++ b/src/target.rs
@@ -396,7 +396,9 @@ impl Target {
         match python_impl {
             CPython => {
                 // For musl handling see https://github.com/pypa/auditwheel/issues/349
-                if python_version >= (3, 11) {
+                if matches!(self.target_arch(), Arch::Mips64 | Arch::Mips64el) && self.is_linux() {
+                    "gnuabi64".to_string()
+                } else if python_version >= (3, 11) {
                     self.target_env().to_string()
                 } else {
                     self.target_env().to_string().replace("musl", "gnu")

--- a/src/target.rs
+++ b/src/target.rs
@@ -380,6 +380,8 @@ impl Target {
             "ppc_64"
         } else if matches!(self.target_arch(), Arch::X86) && python_impl == InterpreterKind::PyPy {
             "x86"
+        } else if matches!(self.target_arch(), Arch::Powerpc) {
+            "powerpc"
         } else {
             self.get_python_arch()
         }

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,4 +1,5 @@
 use crate::cross_compile::is_cross_compiling;
+use crate::python_interpreter::InterpreterKind;
 use crate::PlatformTag;
 use anyhow::{anyhow, bail, format_err, Result};
 use platform_info::*;
@@ -365,6 +366,21 @@ impl Target {
             Arch::Mipsel | Arch::Mips => "mips",
             Arch::Sparc64 => "sparc64",
             Arch::LoongArch64 => "loongarch64",
+        }
+    }
+
+    /// Returns the extension architecture name python uses in `ext_suffix` for this architecture.
+    pub fn get_python_ext_arch(&self, python_impl: InterpreterKind) -> &str {
+        if matches!(self.target_arch(), Arch::Armv6L | Arch::Armv7L) {
+            "arm"
+        } else if matches!(self.target_arch(), Arch::Powerpc64Le)
+            && python_impl == InterpreterKind::PyPy
+        {
+            "ppc_64"
+        } else if matches!(self.target_arch(), Arch::X86) && python_impl == InterpreterKind::PyPy {
+            "x86"
+        } else {
+            self.get_python_arch()
         }
     }
 


### PR DESCRIPTION
This fixes several cross building issues noticed with Yocto Project.

Fixes:
- https://github.com/PyO3/maturin/issues/2203

Did the same tests as in the issue but with the commits here applied.

Test results:

| MACHINE | RUST_TARGET_SYS | get_platform() | EXT_SUFFIX | so file in target | OK? |
| --- | --- | --- | --- | --- | --- |
| `qemuarm` | `armv7-poky-linux-gnueabihf` | `linux-armv7l` | `.cpython-312-arm-linux-gnueabihf.so` | `rpds.cpython-312-arm-linux-gnueabihf.so` | OK |
| `qemuarm64` | `aarch64-poky-linux-gnu` | `linux-aarch64` | `.cpython-312-aarch64-linux-gnu.so` | `rpds.cpython-312-aarch64-linux-gnu.so` | OK |
| `qemumips` | `mips-poky-linux-gnu` | `linux-mips` | `.cpython-312-mips-linux-gnu.so` | `rpds.cpython-312-mips-linux-gnu.so` | OK |
| `qemumips64` | `mips64-poky-linux-gnu` | `linux-mips64` | `.cpython-312-mips64-linux-gnuabi64.so` | `rpds.cpython-312-mips64-linux-gnuabi64.so` | OK |
| `qemuppc` | `powerpc-poky-linux-gnu` | `linux-ppc` | `.cpython-312-powerpc-linux-gnu.so` | `rpds.cpython-312-powerpc-linux-gnu.so` | OK |
| `qemux86` | `i686-poky-linux-gnu` | `linux-i686` | `.cpython-312-i386-linux-gnu.so` | `rpds.cpython-312-i386-linux-gnu.so` | OK |
| `qemux86-64` | x86_64-poky-linux-gnu` | `linux-x86_64` | `.cpython-312-x86_64-linux-gnu.so` | `rpds.cpython-312-x86_64-linux-gnu.so` | OK |




