### PR TITLE
Normalize `REPOSITORY_URL`

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -322,8 +322,8 @@ fn complete_registry(opt: &PublishOpt) -> Result<Registry> {
     {
         let normalized_url = PublishOpt::normalize_url(repository_url);
         let name = match normalized_url {
-            normalized if normalized == PublishOpt::DEFAULT_REPOSITORY_URL => Some("pypi"),
-            normalized if normalized == PublishOpt::TEST_REPOSITORY_URL => Some("testpypi"),
+            PublishOpt::DEFAULT_REPOSITORY_URL => Some("pypi"),
+            PublishOpt::TEST_REPOSITORY_URL => Some("testpypi"),
             _ => None,
         };
         (name, repository_url.to_string())

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -59,8 +59,8 @@ pub struct PublishOpt {
 }
 
 impl PublishOpt {
-    const DEFAULT_REPOSITORY_URL: &'static str = "https://upload.pypi.org/legacy/";
-    const TEST_REPOSITORY_URL: &'static str = "https://test.pypi.org/legacy/";
+    const DEFAULT_REPOSITORY_URL: &'static str = "https://upload.pypi.org/legacy";
+    const TEST_REPOSITORY_URL: &'static str = "https://test.pypi.org/legacy";
 
     /// Set to non interactive mode if we're running on CI
     pub fn non_interactive_on_ci(&mut self) {
@@ -322,16 +322,8 @@ fn complete_registry(opt: &PublishOpt) -> Result<Registry> {
     {
         let normalized_url = PublishOpt::normalize_url(repository_url);
         let name = match normalized_url {
-            normalized
-                if normalized == PublishOpt::normalize_url(PublishOpt::DEFAULT_REPOSITORY_URL) =>
-            {
-                Some("pypi")
-            }
-            normalized
-                if normalized == PublishOpt::normalize_url(PublishOpt::TEST_REPOSITORY_URL) =>
-            {
-                Some("testpypi")
-            }
+            normalized if normalized == PublishOpt::DEFAULT_REPOSITORY_URL => Some("pypi"),
+            normalized if normalized == PublishOpt::TEST_REPOSITORY_URL => Some("testpypi"),
             _ => None,
         };
         (name, repository_url.to_string())

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -69,10 +69,6 @@ impl PublishOpt {
             self.non_interactive = true;
         }
     }
-    /// Helper function to normalize URLs by removing trailing slashes
-    fn normalize_url(url: &str) -> &str {
-        url.trim_end_matches('/')
-    }
 }
 
 /// Error type for different types of errors that can happen when uploading a
@@ -320,8 +316,8 @@ fn complete_registry(opt: &PublishOpt) -> Result<Registry> {
     let pypirc = load_pypirc();
     let (registry_name, registry_url) = if let Some(repository_url) = opt.repository_url.as_deref()
     {
-        let normalized_url = PublishOpt::normalize_url(repository_url);
-        let name = match normalized_url {
+        // to normalize URLs by removing trailing slashes
+        let name = match repository_url.trim_end_matches('/') {
             PublishOpt::DEFAULT_REPOSITORY_URL => Some("pypi"),
             PublishOpt::TEST_REPOSITORY_URL => Some("testpypi"),
             _ => None,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -69,6 +69,10 @@ impl PublishOpt {
             self.non_interactive = true;
         }
     }
+    /// Helper function to normalize URLs by removing trailing slashes
+    fn normalize_url(url: &str) -> &str {
+        url.trim_end_matches('/')
+    }
 }
 
 /// Error type for different types of errors that can happen when uploading a
@@ -316,9 +320,18 @@ fn complete_registry(opt: &PublishOpt) -> Result<Registry> {
     let pypirc = load_pypirc();
     let (registry_name, registry_url) = if let Some(repository_url) = opt.repository_url.as_deref()
     {
-        let name = match repository_url {
-            PublishOpt::DEFAULT_REPOSITORY_URL => Some("pypi"),
-            PublishOpt::TEST_REPOSITORY_URL => Some("testpypi"),
+        let normalized_url = PublishOpt::normalize_url(repository_url);
+        let name = match normalized_url {
+            normalized
+                if normalized == PublishOpt::normalize_url(PublishOpt::DEFAULT_REPOSITORY_URL) =>
+            {
+                Some("pypi")
+            }
+            normalized
+                if normalized == PublishOpt::normalize_url(PublishOpt::TEST_REPOSITORY_URL) =>
+            {
+                Some("testpypi")
+            }
             _ => None,
         };
         (name, repository_url.to_string())


### PR DESCRIPTION
Normalize URLs before comparison to ensure consistent matching, regardless of trailing slashes.

This approach standardizes the URLs by either consistently adding or removing the trailing slash, allowing for flexible and accurate comparisons irrespective of user input.

For example, 

```
const TEST_REPOSITORY_URL: &'static str = "https://test.pypi.org/legacy/";
```
should be the same as
```
const TEST_REPOSITORY_URL: &'static str = "https://test.pypi.org/legacy";
```
no matter there's a trailing slash at the end of url or not.