### PR TITLE
Enable `--all-features` when building source distribution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,9 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
                 out: Some(sdist_directory),
                 cargo: CargoOptions {
                     manifest_path,
+                    // Enable all features to ensure all optional path dependencies are packaged
+                    // into source distribution
+                    all_features: true,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -417,6 +420,9 @@ fn run() -> Result<()> {
                 out,
                 cargo: CargoOptions {
                     manifest_path,
+                    // Enable all features to ensure all optional path dependencies are packaged
+                    // into source distribution
+                    all_features: true,
                     ..Default::default()
                 },
                 ..Default::default()


### PR DESCRIPTION
When building sdist, `cargo metadata` command should output all dependencies including optional ones, otherwise the resulting sdist file may not compile when building with optional features activated.

Enabling `--all-features` ensure that all optional path dependencies to be packaged into sdist, which should help with #2117.