### PR TITLE
Replace "." with "/" in module_name

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -480,12 +480,12 @@ impl BuildContext {
         }
 
         // Currently artifact .so file always resides at ${module_name}/${module_name}.so
-        let artifact_dir = Path::new(&self.module_name);
+        let artifact_dir = self.module_name.split(".").collect::<PathBuf>();
         for artifact in artifacts {
             let mut new_rpaths = patchelf::get_rpath(&artifact.path)?;
             // TODO: clean existing rpath entries if it's not pointed to a location within the wheel
             // See https://github.com/pypa/auditwheel/blob/353c24250d66951d5ac7e60b97471a6da76c123f/src/auditwheel/repair.py#L160
-            let new_rpath = Path::new("$ORIGIN").join(relpath(&libs_dir, artifact_dir));
+            let new_rpath = Path::new("$ORIGIN").join(relpath(&libs_dir, &artifact_dir));
             new_rpaths.push(new_rpath.to_str().unwrap().to_string());
             let new_rpath = new_rpaths.join(":");
             patchelf::set_rpath(&artifact.path, &new_rpath)?;


### PR DESCRIPTION
If a "." is used in module_name, this should be replaced by joining a path, as it represents a subdirectory.

Fixes #2218.