### PR TITLE
feat: copy `.pdb` files to `Editable Installation` and `Wheel` for easier debugging on windows

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -202,6 +202,12 @@ pub struct BuildOptions {
     #[arg(long)]
     pub zig: bool,
 
+    /// Include debug information in the Wheel.
+    /// Currently only support `.pdb` files with
+    /// the same name as the binary(`*.exe`/`*.dll`) on `msvc` platform
+    #[arg(long)]
+    pub with_debuginfo: bool,
+
     /// Cargo build options
     #[command(flatten)]
     pub cargo: CargoOptions,
@@ -719,6 +725,7 @@ impl BuildOptions {
             cargo_metadata,
             universal2,
             editable,
+            with_debuginfo: self.with_debuginfo,
             cargo_options,
         })
     }

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -135,6 +135,9 @@ pub struct DevelopOptions {
     /// Use `uv` to install packages instead of `pip`
     #[arg(long)]
     pub uv: bool,
+    /// The same as `--with-debuginfo` in `maturin build`
+    #[arg(long)]
+    pub with_debuginfo: bool,
 }
 
 #[instrument(skip_all)]
@@ -301,6 +304,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         pip_path,
         cargo_options,
         uv,
+        with_debuginfo,
     } = develop_options;
     let mut target_triple = cargo_options.target.as_ref().map(|x| x.to_string());
     let target = Target::from_target_triple(cargo_options.target)?;
@@ -326,6 +330,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         skip_auditwheel: false,
         #[cfg(feature = "zig")]
         zig: false,
+        with_debuginfo,
         cargo: CargoOptions {
             target: target_triple,
             ..cargo_options

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -58,6 +58,10 @@ Options:
           
           Make sure you installed zig with `pip install maturin[zig]`
 
+      --with-debuginfo
+          Include debug information in the Wheel. Currently only support `.pdb` files with the same
+          name as the binary(`*[EXE]`/`*.dll`) on `msvc` platform
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -55,6 +55,9 @@ Options:
       --uv
           Use `uv` to install packages instead of `pip`
 
+      --with-debuginfo
+          The same as `--with-debuginfo` in `maturin build`
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -104,6 +104,10 @@ Options:
           
           Make sure you installed zig with `pip install maturin[zig]`
 
+      --with-debuginfo
+          Include debug information in the Wheel. Currently only support `.pdb` files with the same
+          name as the binary(`*[EXE]`/`*.dll`) on `msvc` platform
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -71,6 +71,7 @@ pub fn test_develop(
             ..Default::default()
         },
         uv,
+        with_debuginfo: false, // TODO testing
     };
     develop(develop_options, &venv_dir)?;
 


### PR DESCRIPTION
## What I Did

I added a `--with-debuginfo` option to both `maturin dev` and `maturin build`. Currently, it only works on `msvc`. When this option is specified:

- `maturin dev` will copy the debug file (e.g., `mylib.pdb`) with the same name as the `artifact` (e.g., `mylib.dll`) to the `editable install` directory.
- `maturin build` will include the debug file in the `wheel`.
- For `bin` bindings, `*.pdb` will be distributed along with `*.exe` in the `Scripts` directory.

Even if developers do not generate debug information, there will be no impact as long as they don't manually specify `--with-debuginfo`.

Specifically, with the following configuration:

```toml
# Cargo.toml

[lib]
name = "lib_name"
```

```toml
# pyproject.toml

python-source = "my_project"
module-name = "my_project._lib_name"
```

The resulting directory structure would look like this:

```tree
my-project
├── pyproject.toml
├── Cargo.toml
├── my_project
│   ├── __init__.py
│   ├── bar.py
│   ├── lib_name.pdb
│   └── _lib_name.cp310-win_amd64.pyd
├── README.md
└── src
    └── lib.rs
```

Please note that the debug file is `lib_name.pdb` instead of `_lib_name.pdb`, due to the linker flag `/PDBALTPATH:%_PDB%`.

---

## Why Didn't I Implement Support for `macOS` and `Linux`?

### `Linux`

On Linux, the default `split-debuginfo` is `off`, so the debug information is included in the `.so` file. Therefore, no additional actions are needed by default.

### `macOS`

Currently, the default value for `split-debuginfo` on macOS is `packed`, but it seems recommended to set it to `unpacked`, see <https://internals.rust-lang.org/t/help-test-faster-incremental-debug-macos-builds-on-nightly/14016>.

I tried to reference [python-build-standalone](https://github.com/indygreg/python-build-standalone)'s approach. I downloaded these three distribution packages:

- [aarch64-apple-darwin-install_only](https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15+20240909-aarch64-apple-darwin-install_only.tar.gz)
- [x86_64-pc-windows-msvc-install_only](https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15+20240909-x86_64-pc-windows-msvc-install_only.tar.gz)
- [x86_64-unknown-linux-gnu-install_only](https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15+20240909-x86_64-unknown-linux-gnu-install_only.tar.gz)

I found that only the `x86_64-pc-windows-msvc-install_only` package contained `.pdb` debug information, while the other two platforms did not have any separate debug information. So, I am unsure how to implement this feature for those platforms.

Most importantly, I do not have experience developing on macOS, nor do I have a macOS machine to perform the necessary testing. Therefore, this will need to be left for others to implement.

---

Next, I will work on writing tests and documentation, but I would like to get your feedback on the current implementation first.
