### PR TITLE
generate-ci: use ubuntu 24.04 with uraimo/run-on-arch-action

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -430,7 +430,7 @@ jobs:\n",
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{{{ matrix.platform.target }}}}
-          distro: ubuntu22.04
+          distro: ubuntu24.04
           githubToken: ${{{{ github.token }}}}
           install: |
             apt-get update
@@ -1058,7 +1058,7 @@ mod tests {
                     uses: uraimo/run-on-arch-action@v2
                     with:
                       arch: ${{ matrix.platform.target }}
-                      distro: ubuntu22.04
+                      distro: ubuntu24.04
                       githubToken: ${{ github.token }}
                       install: |
                         apt-get update


### PR DESCRIPTION
related to https://github.com/PyO3/maturin/issues/2227

[GitHub just began migrating its `ubuntu-latest` runner from 22.04 to 24.04](https://github.com/actions/runner-images/issues/10636) and is expected to finish in October. It would make sense to follow suit and use Ubuntu 24.04 with `uraimo/run-on-arch-action` instead of 22.04.

As it happens, 24.04 has Python 3.12 in its stock repository so this change would solve the above ticket (at least until Python 3.13 comes out).