### PR TITLE
Add GitHub Actions attestation support to generate-ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,27 +210,36 @@ jobs:
 
   release-pypi:
     permissions:
-      # Used to sign the release's artifacts with sigstore-python
+      # Used to sign the release's artifacts
       # and upload to PyPI using trusted publisher.
       id-token: write
       # Used to upload release artifacts.
       contents: write
+      # Use to generate artifact attestation.
+      attestations: write
     name: Publish to PyPI
     runs-on: ubuntu-latest
     environment:
       name: PyPI
       url: ${{ steps.set_url.outputs.env_url }}
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build, build-musl]
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           merge-multiple: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            ./*.tar.gz
+            ./*.whl
       - uses: actions/setup-python@v5
+        if: "startsWith(github.ref, 'refs/tags/')"
         with:
           python-version: "3.10"
       - name: Publish
+        if: "startsWith(github.ref, 'refs/tags/')"
         run: |
           pip install maturin
           maturin upload --skip-existing *
@@ -239,47 +248,37 @@ jobs:
         run: |
           VERSION=$(echo $GITHUB_REF | sed -e "s#refs/tags/v##g")
           echo "env_url=https://pypi.org/project/maturin/$VERSION" >> $GITHUB_OUTPUT
-      - name: Sigstore Sign
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
-        with:
-          inputs: ./*.tar.gz ./*.whl
-          upload-signing-artifacts: true
-      - name: Release signing artifacts
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            *.sig
-            *.crt
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
-          generate_release_notes: true
 
   release-github:
     permissions:
-      # Used to sign the release's artifacts with sigstore-python.
+      # Used to sign the release's artifacts.
       id-token: write
       # Used to upload release artifacts.
       contents: write
+      # Use to generate artifact attestation.
+      attestations: write
     name: Publish to GitHub releases
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build, build-musl]
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: binaries-*
           merge-multiple: true
-      - name: Sigstore Sign
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
         with:
-          inputs: ./*.tar.gz ./*.zip ./*.deb
-          upload-signing-artifacts: true
+          subject-path: |
+            ./*.tar.gz
+            ./*.zip
+            ./*.deb
       - name: Release
+        if: "startsWith(github.ref, 'refs/tags/')"
         uses: softprops/action-gh-release@v2
         with:
           files: |
             *.tar.gz
             *.zip
             *.deb
-            *.sigstore
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           generate_release_notes: true

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -576,7 +576,6 @@ jobs:\n",
             r#"  release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [{needs}]
 "#,
             needs = needs.join(", ")
@@ -584,15 +583,24 @@ jobs:\n",
         if platforms.contains(&Platform::Emscripten) {
             conf.push_str(
                 r#"    permissions:
+      # Use to sign the release artifacts
+      id-token: write
       # Used to upload release artifacts
       contents: write
+      # Used to generate artifact attestation
+      attestations: write
 "#,
             );
         }
         conf.push_str(
             r#"    steps:
       - uses: actions/download-artifact@v4
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'wheels-*/*'
       - name: Publish to PyPI
+        if: "startsWith(github.ref, 'refs/tags/')"
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -798,11 +806,15 @@ mod tests {
               release:
                 name: Release
                 runs-on: ubuntu-latest
-                if: "startsWith(github.ref, 'refs/tags/')"
                 needs: [linux, musllinux, windows, macos, sdist]
                 steps:
                   - uses: actions/download-artifact@v4
+                  - name: Generate artifact attestation
+                    uses: actions/attest-build-provenance@v1
+                    with:
+                      subject-path: 'wheels-*/*'
                   - name: Publish to PyPI
+                    if: "startsWith(github.ref, 'refs/tags/')"
                     uses: PyO3/maturin-action@v1
                     env:
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -960,11 +972,15 @@ mod tests {
               release:
                 name: Release
                 runs-on: ubuntu-latest
-                if: "startsWith(github.ref, 'refs/tags/')"
                 needs: [linux, musllinux, windows, macos]
                 steps:
                   - uses: actions/download-artifact@v4
+                  - name: Generate artifact attestation
+                    uses: actions/attest-build-provenance@v1
+                    with:
+                      subject-path: 'wheels-*/*'
                   - name: Publish to PyPI
+                    if: "startsWith(github.ref, 'refs/tags/')"
                     uses: PyO3/maturin-action@v1
                     env:
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -1219,11 +1235,15 @@ mod tests {
               release:
                 name: Release
                 runs-on: ubuntu-latest
-                if: "startsWith(github.ref, 'refs/tags/')"
                 needs: [linux, musllinux, windows, macos, sdist]
                 steps:
                   - uses: actions/download-artifact@v4
+                  - name: Generate artifact attestation
+                    uses: actions/attest-build-provenance@v1
+                    with:
+                      subject-path: 'wheels-*/*'
                   - name: Publish to PyPI
+                    if: "startsWith(github.ref, 'refs/tags/')"
                     uses: PyO3/maturin-action@v1
                     env:
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -1383,11 +1403,15 @@ mod tests {
               release:
                 name: Release
                 runs-on: ubuntu-latest
-                if: "startsWith(github.ref, 'refs/tags/')"
                 needs: [linux, musllinux, windows, macos, sdist]
                 steps:
                   - uses: actions/download-artifact@v4
+                  - name: Generate artifact attestation
+                    uses: actions/attest-build-provenance@v1
+                    with:
+                      subject-path: 'wheels-*/*'
                   - name: Publish to PyPI
+                    if: "startsWith(github.ref, 'refs/tags/')"
                     uses: PyO3/maturin-action@v1
                     env:
                       MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Switch from sigstore to GitHub Actions attestation in maturin release workflow.
