### PR TITLE
Revert "generate-ci: use ubuntu 24.04 with uraimo/run-on-arch-action"

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -430,7 +430,7 @@ jobs:\n",
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{{{ matrix.platform.target }}}}
-          distro: ubuntu24.04
+          distro: ubuntu22.04
           githubToken: ${{{{ github.token }}}}
           install: |
             apt-get update
@@ -1074,7 +1074,7 @@ mod tests {
                     uses: uraimo/run-on-arch-action@v2
                     with:
                       arch: ${{ matrix.platform.target }}
-                      distro: ubuntu24.04
+                      distro: ubuntu22.04
                       githubToken: ${{ github.token }}
                       install: |
                         apt-get update


### PR DESCRIPTION
Reverts PyO3/maturin#2231

Unfortunately run-on-arch-action doesn't have Ubuntu 24.04 images yet.

https://github.com/uraimo/run-on-arch-action?tab=readme-ov-file#usage