### PR TITLE
Switch macos x86_64 to macos14 in generate-ci

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -264,18 +264,13 @@ jobs:\n",
                         target,
                     })
                     .collect(),
-                Platform::Macos => {
-                    vec![
-                        MatrixPlatform {
-                            runner: "macos-12",
-                            target: "x86_64",
-                        },
-                        MatrixPlatform {
-                            runner: "macos-14",
-                            target: "aarch64",
-                        },
-                    ]
-                }
+                Platform::Macos => ["x86_64", "aarch64"]
+                    .into_iter()
+                    .map(|target| MatrixPlatform {
+                        runner: "macos-14",
+                        target,
+                    })
+                    .collect(),
                 Platform::Emscripten => vec![MatrixPlatform {
                     runner: "ubuntu-latest",
                     target: "wasm32-unknown-emscripten",
@@ -767,7 +762,7 @@ mod tests {
                 strategy:
                   matrix:
                     platform:
-                      - runner: macos-12
+                      - runner: macos-14
                         target: x86_64
                       - runner: macos-14
                         target: aarch64
@@ -956,7 +951,7 @@ mod tests {
                 strategy:
                   matrix:
                     platform:
-                      - runner: macos-12
+                      - runner: macos-14
                         target: x86_64
                       - runner: macos-14
                         target: aarch64
@@ -1204,7 +1199,7 @@ mod tests {
                 strategy:
                   matrix:
                     platform:
-                      - runner: macos-12
+                      - runner: macos-14
                         target: x86_64
                       - runner: macos-14
                         target: aarch64
@@ -1391,7 +1386,7 @@ mod tests {
                 strategy:
                   matrix:
                     platform:
-                      - runner: macos-12
+                      - runner: macos-14
                         target: x86_64
                       - runner: macos-14
                         target: aarch64


### PR DESCRIPTION
The macos12 images [are deprecated and will be decommissioned by december](https://github.com/actions/runner-images/issues/10721), jobs have started triggering warnings and brownouts are planned.

In my understanding this means the x86_64 wheels will be cross-compiled from the arm64 runners, but I understand cross compilation works fine. The x86_64 cross compilation is slower than the ARM64 compilation, but on my test project it's faster than the macos13 x86_64 build so that doesn't seem like a massive concern I feel?