### PR TITLE
feat: add skip attestation option to maturin ci github

### DIFF
--- a/tests/cmd/generate-ci.stdout
+++ b/tests/cmd/generate-ci.stdout
@@ -46,5 +46,8 @@ Options:
       --zig
           Use zig to do cross compilation
 
+      --skip-attestation
+          Skip artifact attestation
+
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
for private, non-enterprise repositories, attestation of github artifacts is not available. this commit adds the option to generate a ci file which skips the attestation step