### PR TITLE
Remove Python 3.8 from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
         - macos-14
         - windows-latest
       PYTHON_VERSION: |
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
@@ -402,8 +401,8 @@ jobs:
         platform:
           # CPython
           - target: aarch64-unknown-linux-gnu
-            abi: cp38-cp38
-            python: python3.8
+            abi: cp39-cp39
+            python: python3.9
             container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
           - target: armv7-unknown-linux-gnueabihf
             abi: cp39-cp39


### PR DESCRIPTION
Python 3.8 is EOL. We need to add 3.13 in the next step