### PR TITLE
Add Interpreter Argument for pep517 sdist Generation

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -94,7 +94,7 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels for, given as the executables of interpreters such as `python3.9` or `/usr/bin/python3.8`
+          The python versions to build wheels or an sdist for, given as the executables of interpreters such as `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter
           Find interpreters from the host machine

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -121,7 +121,7 @@ def build_wheel(
 
 # noinspection PyUnusedLocal
 def build_sdist(sdist_directory: str, config_settings: Optional[Mapping[str, Any]] = None) -> str:
-    command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
+    command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory, "--interpreter", _get_sys_executable()]
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -121,7 +121,15 @@ def build_wheel(
 
 # noinspection PyUnusedLocal
 def build_sdist(sdist_directory: str, config_settings: Optional[Mapping[str, Any]] = None) -> str:
-    command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory, "--interpreter", _get_sys_executable()]
+    command = [
+        "maturin",
+        "pep517",
+        "write-sdist",
+        "--sdist-directory",
+        sdist_directory,
+        "--interpreter",
+        _get_sys_executable(),
+    ]
 
     print("Running `{}`".format(" ".join(command)))
     sys.stdout.flush()

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1200,7 +1200,7 @@ fn find_interpreter_in_sysconfig(
                 bail!("Unsupported Python interpreter for cross-compilation: {}; supported interpreters are pypy, graalpy, and python (cpython)", python);
             }
         };
-        if python_ver.is_empty() {
+        if python_ver.is_empty() || !python_ver.contains('.') {
             continue;
         }
         let (ver_major, ver_minor) = python_ver

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -167,7 +167,7 @@ pub struct BuildOptions {
     )]
     pub platform_tag: Vec<PlatformTag>,
 
-    /// The python versions to build wheels for, given as the executables of
+    /// The python versions to build wheels or an sdist for, given as the executables of
     /// interpreters such as `python3.9` or `/usr/bin/python3.8`.
     #[arg(short, long, num_args = 0.., action = clap::ArgAction::Append)]
     pub interpreter: Vec<PathBuf>,
@@ -1200,7 +1200,7 @@ fn find_interpreter_in_sysconfig(
                 bail!("Unsupported Python interpreter for cross-compilation: {}; supported interpreters are pypy, graalpy, and python (cpython)", python);
             }
         };
-        if python_ver.is_empty() || !python_ver.contains('.') {
+        if python_ver.is_empty() {
             continue;
         }
         let (ver_major, ver_minor) = python_ver

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,9 @@ enum Pep517Command {
         #[arg(short = 'm', long = "manifest-path", value_name = "PATH")]
         /// The path to the Cargo.toml
         manifest_path: Option<PathBuf>,
-        /// The interpreter to use when building an sdist
+        /// The interpreter to use when building an sdist. If empty, maturin
+        /// will attempt to find an interpreter from the virtual environment
+        /// or system environment.
         #[arg(short = 'i', long = "interpreter", value_name = "PATH")]
         interpreter: Option<PathBuf>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,9 @@ enum Pep517Command {
         #[arg(short = 'm', long = "manifest-path", value_name = "PATH")]
         /// The path to the Cargo.toml
         manifest_path: Option<PathBuf>,
+        /// The interpreter to use when building an sdist
+        #[arg(short = 'i', long = "interpreter", value_name = "PATH")]
+        interpreter: Option<PathBuf>,
     },
 }
 
@@ -306,6 +309,7 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
         Pep517Command::WriteSDist {
             sdist_directory,
             manifest_path,
+            interpreter,
         } => {
             let build_options = BuildOptions {
                 out: Some(sdist_directory),
@@ -316,6 +320,7 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
                     all_features: true,
                     ..Default::default()
                 },
+                interpreter: interpreter.map_or_else(Vec::new, |interp| vec![interp]),
                 ..Default::default()
             };
             let build_context = build_options.into_build_context(false, false, false)?;

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -28,8 +28,8 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels or an sdist for, given as the executables of interpreters such as
-          `python3.9` or `/usr/bin/python3.8`
+          The python versions to build wheels or an sdist for, given as the executables of 
+          interpreters such as `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter
           Find interpreters from the host machine

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -28,7 +28,7 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels or an sdist for, given as the executables of 
+          The python versions to build wheels or an sdist for, given as the executables of
           interpreters such as `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -28,7 +28,7 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels for, given as the executables of interpreters such as
+          The python versions to build wheels or an sdist for, given as the executables of interpreters such as
           `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -74,7 +74,7 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels for, given as the executables of interpreters such as
+          The python versions to build wheels or an sdist for, given as the executables of interpreters such as
           `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -74,7 +74,7 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels or an sdist for, given as the executables of 
+          The python versions to build wheels or an sdist for, given as the executables of
           interpreters such as `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -74,8 +74,8 @@ Options:
           This option is ignored on all non-linux platforms
 
   -i, --interpreter [<INTERPRETER>...]
-          The python versions to build wheels or an sdist for, given as the executables of interpreters such as
-          `python3.9` or `/usr/bin/python3.8`
+          The python versions to build wheels or an sdist for, given as the executables of 
+          interpreters such as `python3.9` or `/usr/bin/python3.8`
 
   -f, --find-interpreter
           Find interpreters from the host machine


### PR DESCRIPTION
- Fixes #2245 
- Adds an interpreter argument to maturin's pep517 sdist generation, causing maturin to skip the interpreter resolution step.
- Adds `--interpreter _get_sys_interpreter()` to the __init__.py command invoking the maturin binary to ensure sdist generation uses the interpreter maturin was invoked with.