### PR TITLE
Update goblin to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,11 +724,11 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fat-macho"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4c93f393add03d72bc10dd3dea43a1610ecb29e0c0a6459c70b53b82931adf"
+checksum = "4c9c45caa6c6edfaee4cb3bd84ea9686e115df7f0efb530e15fb466eccb0b345"
 dependencies = [
- "goblin 0.8.2",
+ "goblin",
 ]
 
 [[package]]
@@ -939,17 +939,6 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
-name = "goblin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
@@ -1126,13 +1115,13 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lddtree"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735dc8281e12cf7450b3a343c50bccdb15625f41b127d1bd7063949fe367847d"
+checksum = "470645aa69c87af88557f2b87e0b0894b0843a2b059b4661d892414a89c24169"
 dependencies = [
  "fs-err",
  "glob",
- "goblin 0.8.2",
+ "goblin",
 ]
 
 [[package]]
@@ -1246,7 +1235,7 @@ dependencies = [
  "fs-err",
  "fs2",
  "glob",
- "goblin 0.9.2",
+ "goblin",
  "ignore",
  "indexmap 2.5.0",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4c93f393add03d72bc10dd3dea43a1610ecb29e0c0a6459c70b53b82931adf"
 dependencies = [
- "goblin",
+ "goblin 0.8.2",
 ]
 
 [[package]]
@@ -949,6 +949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,7 +1132,7 @@ checksum = "735dc8281e12cf7450b3a343c50bccdb15625f41b127d1bd7063949fe367847d"
 dependencies = [
  "fs-err",
  "glob",
- "goblin",
+ "goblin 0.8.2",
 ]
 
 [[package]]
@@ -1235,7 +1246,7 @@ dependencies = [
  "fs-err",
  "fs2",
  "glob",
- "goblin",
+ "goblin 0.9.2",
  "ignore",
  "indexmap 2.5.0",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ cargo_metadata = "0.18.0"
 cargo-options = "0.7.2"
 cbindgen = { version = "0.26.0", default-features = false }
 flate2 = "1.0.18"
-goblin = "0.8.0"
+goblin = "0.9.0"
 platform-info = "2.0.2"
 regex = "1.7.0"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
The breaking change from 0.8.0 appears to be the addition of a value to a pub enum associated with TE (terse executable) support; this does not look like it should affect maturin’s usage of goblin since it doesn’t match exhaustively on this enum.

https://github.com/m4b/goblin/blob/d096260201158ed34d64728fd1ab0ca125e2f956/CHANGELOG.md#092----2024-10-26

I’ve also filed PR’s for both of the crates that are still asking for goblin 0.8.0 in `maturin`’s dependency tree:

- https://github.com/messense/fat-macho-rs/pull/20
- https://github.com/messense/lddtree-rs/pull/12