### PR TITLE
include timestamps in the suggested log format

### DIFF
--- a/guide/src/import_hook.md
+++ b/guide/src/import_hook.md
@@ -152,7 +152,7 @@ information from maturin.
 
 ```python
 import logging
-logging.basicConfig(format='%(name)s [%(levelname)s] %(message)s', level=logging.DEBUG)
+logging.basicConfig(format='%(asctime)s %(name)s [%(levelname)s] %(message)s', level=logging.DEBUG)
 import maturin_import_hook
 maturin_import_hook.reset_logger()
 maturin_import_hook.install()


### PR DESCRIPTION
When asking for bug reports including the timestamps may be useful to determine if a component is taking longer than expected.