### PR TITLE
Add free-threaded Python support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,10 @@ jobs:
           - macos-14
           - windows-latest
         python-version:
-          - '3.9'
-          - '3.13'
-          - 'pypy3.10'
+          - "3.9"
+          - "3.13"
+          - "3.13t"
+          - "pypy3.10"
         exclude:
           # Skip PyPy on macOS M1 runner because they are built for x86_64
           - os: macos-14
@@ -81,7 +82,7 @@ jobs:
           auto-activate-base: "false"
           activate-environment: ""
           miniconda-version: "latest"
-      - uses: actions/setup-python@v5
+      - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set PYTHON_VERSION env var
@@ -96,7 +97,10 @@ jobs:
         run: |
           uv tool install virtualenv
           uv tool install twine
-          uv pip install --system "ziglang>=0.10.0,<0.13.0" uniffi-bindgen==0.28.0
+          uv tool install uniffi-bindgen==0.28.0
+      - uses: mlugg/setup-zig@v1
+        with:
+          version: 0.12.1
       - uses: dtolnay/rust-toolchain@stable
         id: rustup
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.action }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,11 +85,6 @@ jobs:
       - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get interpreter metadata for dev
-        shell: bash
-        run: |
-          python src/python_interpreter/get_interpreter_metadata.py
-          python -m pip debug --verbose
       - name: Set PYTHON_VERSION env var
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,11 @@ jobs:
       - uses: Quansight-Labs/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Get interpreter metadata for dev
+        shell: bash
+        run: |
+          python src/python_interpreter/get_interpreter_metadata.py
+          python -m pip debug --verbose
       - name: Set PYTHON_VERSION env var
         shell: bash
         run: |

--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -17,7 +17,7 @@ use std::{fmt, io};
 use thiserror::Error;
 
 static IS_LIBPYTHON: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^libpython3\.\d+m?u?\.so\.\d+\.\d+$").unwrap());
+    Lazy::new(|| Regex::new(r"^libpython3\.\d+m?u?t?\.so\.\d+\.\d+$").unwrap());
 
 /// Error raised during auditing an elf file for manylinux/musllinux compatibility
 #[derive(Error, Debug)]

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -274,6 +274,10 @@ impl BuildOptions {
                             .get("ABIFLAGS")
                             .map(ToString::to_string)
                             .unwrap_or_default();
+                        let gil_disabled = sysconfig_data
+                            .get("Py_GIL_DISABLED")
+                            .map(|x| x == "1")
+                            .unwrap_or_default();
                         let ext_suffix = sysconfig_data
                             .get("EXT_SUFFIX")
                             .context("syconfig didn't define an `EXT_SUFFIX` ಠ_ಠ")?;
@@ -299,6 +303,7 @@ impl BuildOptions {
                                 abiflags,
                                 ext_suffix: ext_suffix.to_string(),
                                 pointer_width: None,
+                                gil_disabled,
                             },
                             executable: PathBuf::new(),
                             platform: None,
@@ -376,6 +381,7 @@ impl BuildOptions {
                                 abiflags: "".to_string(),
                                 ext_suffix: ".pyd".to_string(),
                                 pointer_width: None,
+                                gil_disabled: false,
                             },
                             executable: PathBuf::new(),
                             platform: None,
@@ -402,6 +408,7 @@ impl BuildOptions {
                                 abiflags: "".to_string(),
                                 ext_suffix: ".pyd".to_string(),
                                 pointer_width: None,
+                                gil_disabled: false,
                             },
                             executable: PathBuf::new(),
                             platform: None,
@@ -441,6 +448,7 @@ impl BuildOptions {
                                 abiflags: "".to_string(),
                                 ext_suffix: "".to_string(),
                                 pointer_width: None,
+                                gil_disabled: false,
                             },
                             executable: PathBuf::new(),
                             platform: None,

--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -52,6 +52,7 @@ KEYS = [
     "ABIFLAGS",
     "EXT_SUFFIX",
     "SOABI",
+    "Py_GIL_DISABLED",
 ]
 for key in KEYS:
     print(key, build_time_vars.get(key, ""))

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -35,6 +35,7 @@ metadata = {
     "system": platform.system().lower(),
     # This one is for generating a config file for pyo3
     "pointer_width": struct.calcsize("P") * 8,
+    "gil_disabled": sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
 }
 
 print(json.dumps(metadata))

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -448,7 +448,7 @@ impl PythonInterpreter {
             false
         } else {
             match self.interpreter_kind {
-                InterpreterKind::CPython => true,
+                InterpreterKind::CPython => !(self.config.abiflags.starts_with("t")),
                 InterpreterKind::PyPy | InterpreterKind::GraalPy => false,
             }
         }

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -245,7 +245,13 @@ fn find_all_windows(
     Ok(interpreter)
 }
 
-fn windows_python_info(executable: &Path) -> Result<Option<InterpreterConfig>> {
+struct WindowsPythonInfo {
+    major: usize,
+    minor: usize,
+    pointer_width: Option<usize>,
+}
+
+fn windows_python_info(executable: &Path) -> Result<Option<WindowsPythonInfo>> {
     let python_info = Command::new(executable)
         .arg("-c")
         .arg("import sys; print(sys.version)")
@@ -276,12 +282,9 @@ fn windows_python_info(executable: &Path) -> Result<Option<InterpreterConfig>> {
         } else {
             32
         };
-        Ok(Some(InterpreterConfig {
+        Ok(Some(WindowsPythonInfo {
             major,
             minor,
-            interpreter_kind: InterpreterKind::CPython,
-            abiflags: String::new(),
-            ext_suffix: String::new(),
             pointer_width: Some(pointer_width),
         }))
     } else {
@@ -353,6 +356,7 @@ struct InterpreterMetadataMessage {
     // comes from `platform.system()`
     system: String,
     soabi: Option<String>,
+    gil_disabled: bool,
 }
 
 /// The location and version of an interpreter
@@ -425,19 +429,19 @@ fn fun_with_abiflags(
         if matches!(message.abiflags.as_deref(), Some("") | None) {
             Ok("".to_string())
         } else {
-            bail!("A python 3 interpreter on windows does not define abiflags in its sysconfig ಠ_ಠ")
+            bail!("A python 3 interpreter on Windows does not define abiflags in its sysconfig ಠ_ಠ")
         }
     } else if let Some(ref abiflags) = message.abiflags {
         if message.minor >= 8 {
             // for 3.8, "builds with and without pymalloc are ABI compatible" and the flag dropped
             Ok(abiflags.to_string())
         } else if (abiflags != "m") && (abiflags != "dm") {
-            bail!("A python 3 interpreter on linux or mac os must have 'm' or 'dm' as abiflags ಠ_ಠ")
+            bail!("A python 3 interpreter on Linux or macOS must have 'm' or 'dm' as abiflags ಠ_ಠ")
         } else {
             Ok(abiflags.to_string())
         }
     } else {
-        bail!("A python 3 interpreter on linux or mac os must define abiflags in its sysconfig ಠ_ಠ")
+        bail!("A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig ಠ_ಠ")
     }
 }
 
@@ -448,7 +452,8 @@ impl PythonInterpreter {
             false
         } else {
             match self.interpreter_kind {
-                InterpreterKind::CPython => !(self.config.abiflags.starts_with("t")),
+                // Free-threaded python does not have stable api support yet
+                InterpreterKind::CPython => !self.config.gil_disabled,
                 InterpreterKind::PyPy | InterpreterKind::GraalPy => false,
             }
         }
@@ -695,6 +700,7 @@ impl PythonInterpreter {
                     .ext_suffix
                     .context("syconfig didn't define an `EXT_SUFFIX` ಠ_ಠ")?,
                 pointer_width: None,
+                gil_disabled: message.gil_disabled,
             },
             executable,
             platform,
@@ -923,11 +929,6 @@ impl PythonInterpreter {
         } else {
             venv_base.as_ref().join("Lib").join("site-packages")
         }
-    }
-
-    /// Is this a free threaded python interpreter
-    pub fn is_free_threaded(&self) -> bool {
-        self.abiflags == "t"
     }
 }
 

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -924,6 +924,11 @@ impl PythonInterpreter {
             venv_base.as_ref().join("Lib").join("site-packages")
         }
     }
+
+    /// Is this a free threaded python interpreter
+    pub fn is_free_threaded(&self) -> bool {
+        self.abiflags == "t"
+    }
 }
 
 impl fmt::Display for PythonInterpreter {
@@ -989,19 +994,19 @@ mod tests {
         let target =
             Target::from_target_triple(Some("x86_64-unknown-linux-gnu".to_string())).unwrap();
         let pythons = PythonInterpreter::find_by_target(&target, None);
-        assert_eq!(pythons.len(), 11);
+        assert_eq!(pythons.len(), 12);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.8").unwrap()),
         );
-        assert_eq!(pythons.len(), 9);
+        assert_eq!(pythons.len(), 10);
 
         let pythons = PythonInterpreter::find_by_target(
             &target,
             Some(&VersionSpecifiers::from_str(">=3.10").unwrap()),
         );
-        assert_eq!(pythons.len(), 5);
+        assert_eq!(pythons.len(), 6);
     }
 
     #[test]
@@ -1010,6 +1015,7 @@ mod tests {
             (".cpython-37m-x86_64-linux-gnu.so", Some("cp37m")),
             (".cpython-310-x86_64-linux-gnu.so", Some("cp310")),
             (".cpython-310-darwin.so", Some("cp310")),
+            (".cpython-313t-darwin.so", Some("cp313t")),
             (".cp310-win_amd64.pyd", Some("cp310")),
             (".cp39-mingw_x86_64.pyd", Some("cp39")),
             (".cpython-312-wasm32-wasi.so", Some("cp312")),

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -94,7 +94,6 @@ pub fn test_integration(
         let file = File::create(venvs_dir.join("cffi-provider.lock"))?;
         file.file().lock_exclusive()?;
         if !dbg!(venvs_dir.join(cffi_provider)).is_dir() {
-            println!("CRAETAITROAPTGIIDSOGRKADS");
             dbg!(create_virtualenv_name(
                 cffi_provider,
                 python_interp.clone().map(PathBuf::from)


### PR DESCRIPTION
Implementation details:

* Free-threaded support is determined by the `Py_GIL_DISABLED` build flag for runnable Python interpreters
* We also accept `python3.13t` when cross compiling

Closes #2298
Closes #2315
