### PR TITLE
check for free-threaded ABI flag in stable API check

### DIFF
--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -448,7 +448,7 @@ impl PythonInterpreter {
             false
         } else {
             match self.interpreter_kind {
-                InterpreterKind::CPython => true,
+                InterpreterKind::CPython => !(self.config.abiflags.starts_with("t")),
                 InterpreterKind::PyPy | InterpreterKind::GraalPy => false,
             }
         }


### PR DESCRIPTION
After updating the test crates to point at a local clone of PyO3 with https://github.com/PyO3/pyo3/pull/4719/files applied, I'm seeing many more of the tests pass on my local dev setup with this change.

The remaining failures are all related to sdist generation, something is breaking there and it's not clear to me what's wrong.

```
     Summary [  31.343s] 104 tests run: 96 passed, 8 failed, 5 skipped
        FAIL [   1.625s] maturin::run lib_with_path_dep_sdist
        FAIL [   1.735s] maturin::run lib_with_target_path_dep_sdist
        FAIL [   2.014s] maturin::run pyo3_mixed_include_exclude_sdist
        FAIL [   1.743s] maturin::run pyo3_mixed_src_layout_sdist
        FAIL [   1.689s] maturin::run workspace_inheritance_sdist
        FAIL [   1.619s] maturin::run workspace_members_beneath_pyproject_sdist
        FAIL [   1.642s] maturin::run workspace_members_non_local_dep_sdist
        FAIL [   1.568s] maturin::run workspace_with_path_dep_sdist
error: test run failed
```

The full error for one of these failures:

<details>

```
error: expect test failed
   --> tests/run.rs:861:9

You can update all `expect!` tests by running:

    env UPDATE_EXPECT=1 cargo test

To update a single test, place the cursor on `expect` token and use `run` feature of rust-analyzer.

Expect:
----
{
    "workspace_with_path_dep-0.1.0/Cargo.lock",
    "workspace_with_path_dep-0.1.0/Cargo.toml",
    "workspace_with_path_dep-0.1.0/PKG-INFO",
    "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyproject.toml",
    "workspace_with_path_dep-0.1.0/python/Cargo.toml",
    "workspace_with_path_dep-0.1.0/python/src/lib.rs",
    "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rs",
}

----

Actual:
----
{
    "workspace_with_path_dep-0.1.0/PKG-INFO",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/Cargo.lock",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/generic_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/generic_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/python/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/python/src/lib.rs",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/transitive_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/transitive_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/.netlify/build.sh",
    "workspace_with_path_dep-0.1.0/pyo3/.netlify/internal_banner.html",
    "workspace_with_path_dep-0.1.0/pyo3/.towncrier.template.md",
    "workspace_with_path_dep-0.1.0/pyo3/Architecture.md",
    "workspace_with_path_dep-0.1.0/pyo3/CHANGELOG.md",
    "workspace_with_path_dep-0.1.0/pyo3/CITATION.cff",
    "workspace_with_path_dep-0.1.0/pyo3/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/Code-of-Conduct.md",
    "workspace_with_path_dep-0.1.0/pyo3/Contributing.md",
    "workspace_with_path_dep-0.1.0/pyo3/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/Releasing.md",
    "workspace_with_path_dep-0.1.0/pyo3/assets/script.py",
    "workspace_with_path_dep-0.1.0/pyo3/branding/favicon/pyo3_16x16.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/favicon/pyo3_32x32.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyo3logo.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyo3logo.svg",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyotr.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyotr.svg",
    "workspace_with_path_dep-0.1.0/pyo3/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/.gitignore",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/Makefile",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/emscripten_patches/0001-Add-_gxx_personality_v0-stub-to-library.js.patch",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/env.sh",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/pybuilddir.txt",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/runner.py",
    "workspace_with_path_dep-0.1.0/pyo3/guide/book.toml",
    "workspace_with_path_dep-0.1.0/pyo3/guide/pyclass-parameters.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/pyo3_version.py",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/SUMMARY.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/advanced.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/async-await.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/building-and-distribution.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/building-and-distribution/multiple-python-versions.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/changelog.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/call.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/numeric.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/object.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/protocols.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/thread-safety.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/contributing.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions/tables.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions/traits.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/debugging.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem/async-await.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem/logging.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/exception.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/faq.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/features.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/free-threading.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function-calls.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function/error-handling.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function/signature.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/getting-started.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/index.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/migration.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/module.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/parallelism.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/performance.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust/calling-existing-code.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust/function-calls.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-typing-hints.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/rust-from-python.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/trait-bounds.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/types.md",
    "workspace_with_path_dep-0.1.0/pyo3/netlify.toml",
    "workspace_with_path_dep-0.1.0/pyo3/newsfragments/.gitignore",
    "workspace_with_path_dep-0.1.0/pyo3/newsfragments/4719.fixed.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/errors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/import_lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/ACKNOWLEDGEMENTS",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/examples/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/abstract_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bltinmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/boolobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bytearrayobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bytesobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/ceval.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/codecs.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_10.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_13.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_9.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compile.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/complexobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/context.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/abstract_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/bytesobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/ceval.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/compile.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/complexobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/critical_section.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/descrobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/dictobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/floatobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/frameobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/funcobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/genobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/initconfig.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/listobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/lock.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/longobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/methodobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/objimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pydebug.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pyerrors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pyframe.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pylifecycle.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pymem.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pystate.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pythonrun.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/tupleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/unicodeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/weakrefobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/descrobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/dictobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/enumobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/fileobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/fileutils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/floatobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/impl_/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/intrcheck.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/iterobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/listobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/longobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/marshal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/memoryobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/methodobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/modsupport.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/moduleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/objimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/osmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyarena.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pybuffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pycapsule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyerrors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyframe.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyhash.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pylifecycle.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pymem.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyport.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pystate.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pystrtod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pythonrun.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/rangeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/setobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/sliceobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/structmember.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/structseq.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/sysmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/traceback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/tupleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/typeslots.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/unicodeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/warnings.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/weakrefobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/attributes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/deprecations.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/intopyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/konst.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/method.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/params.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyfunction/signature.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pymethod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyversions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/quotes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/utils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/pyproject.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/src/pyo3_runtime/__init__.py",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/tests/__init__.py",
    "workspace_with_path_dep-0.1.0/pyo3/src/buffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversion.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/anyhow.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/chrono.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/chrono_tz.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/either.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/eyre.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/hashbrown.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/indexmap.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_bigint.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_complex.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_rational.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/rust_decimal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/serde.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/smallvec.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/array.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/cell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/ipaddr.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/map.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/num.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/option.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/osstr.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/path.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/set.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/slice.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/time.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/vec.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine/cancel.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine/waker.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/err_state.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/impls.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi/tests.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi_ptr_ext.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/gil.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/callback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/extract_argument.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/freelist.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/not_send.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/panic.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pycell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/assertions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/lazy_type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/probes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass_init.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pymodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/trampoline.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/wrap.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/inspect/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/inspect/types.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/instance.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal/get_slot.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal_tricks.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/macros.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/marker.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/marshal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/panic.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/prelude.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/py_result_ext.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pybacked.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pycell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pycell/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass/create_type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass/gc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass_init.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/sealed.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/sync.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/test_utils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/common.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/misc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pymodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/any.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/boolobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/bytearray.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/bytes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/capsule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/complex.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/dict.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/ellipsis.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/float.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/frame.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/frozenset.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/function.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/iterator.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/list.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mapping.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mappingproxy.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/memoryview.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/none.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/notimplemented.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/num.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/pysuper.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/sequence.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/set.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/slice.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/traceback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/tuple.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/typeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/anyref.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/proxy.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/reference.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/version.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_anyhow.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_append_to_inittab.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_arithmetics.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_buffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_buffer_protocol.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_bytes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_attributes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_basics.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_comparisons.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_conversion.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_formatting.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_new.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_datetime_import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_declarative_module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_default_impls.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_enum.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_field_cfg.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_frompy_intopy_roundtrip.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_gc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_getter_setter.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_inheritance.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_intopyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_macro_docs.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_macros.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_mapping.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_methods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_multiple_pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_proto_methods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_pyself.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_sequence.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_serde.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_static_slots.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_super.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_text_signature.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_variable_arguments.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_various.rs",
    "workspace_with_path_dep-0.1.0/pyproject.toml",
}

----

Diff:
----
{
    "workspace_with_path_dep-0.1.0/PKG-INFO",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/Cargo.lock",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/Cargo.toml",
    "workspace_with_path_dep-0.1.0/PKG-INFO",
    "workspace_with_path_dep-0.1.0/generic_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/generic_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyproject.toml",
    "workspace_with_path_dep-0.1.0/python/Cargo.toml",
    "workspace_with_path_dep-0.1.0/python/src/lib.rs",
    "workspace_with_path_dep-0.1.0/transitive_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/transitive_lib/src/lib.rsmaturin/test-crates/workspace_with_path_dep/generic_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/generic_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/python/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/python/src/lib.rs",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/transitive_lib/Cargo.toml",
    "workspace_with_path_dep-0.1.0/maturin/test-crates/workspace_with_path_dep/transitive_lib/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/.netlify/build.sh",
    "workspace_with_path_dep-0.1.0/pyo3/.netlify/internal_banner.html",
    "workspace_with_path_dep-0.1.0/pyo3/.towncrier.template.md",
    "workspace_with_path_dep-0.1.0/pyo3/Architecture.md",
    "workspace_with_path_dep-0.1.0/pyo3/CHANGELOG.md",
    "workspace_with_path_dep-0.1.0/pyo3/CITATION.cff",
    "workspace_with_path_dep-0.1.0/pyo3/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/Code-of-Conduct.md",
    "workspace_with_path_dep-0.1.0/pyo3/Contributing.md",
    "workspace_with_path_dep-0.1.0/pyo3/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/Releasing.md",
    "workspace_with_path_dep-0.1.0/pyo3/assets/script.py",
    "workspace_with_path_dep-0.1.0/pyo3/branding/favicon/pyo3_16x16.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/favicon/pyo3_32x32.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyo3logo.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyo3logo.svg",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyotr.png",
    "workspace_with_path_dep-0.1.0/pyo3/branding/pyotr.svg",
    "workspace_with_path_dep-0.1.0/pyo3/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/.gitignore",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/Makefile",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/emscripten_patches/0001-Add-_gxx_personality_v0-stub-to-library.js.patch",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/env.sh",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/pybuilddir.txt",
    "workspace_with_path_dep-0.1.0/pyo3/emscripten/runner.py",
    "workspace_with_path_dep-0.1.0/pyo3/guide/book.toml",
    "workspace_with_path_dep-0.1.0/pyo3/guide/pyclass-parameters.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/pyo3_version.py",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/SUMMARY.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/advanced.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/async-await.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/building-and-distribution.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/building-and-distribution/multiple-python-versions.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/changelog.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/call.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/numeric.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/object.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/protocols.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/class/thread-safety.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/contributing.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions/tables.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/conversions/traits.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/debugging.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem/async-await.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/ecosystem/logging.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/exception.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/faq.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/features.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/free-threading.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function-calls.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function/error-handling.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/function/signature.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/getting-started.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/index.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/migration.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/module.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/parallelism.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/performance.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust/calling-existing-code.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-from-rust/function-calls.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/python-typing-hints.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/rust-from-python.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/trait-bounds.md",
    "workspace_with_path_dep-0.1.0/pyo3/guide/src/types.md",
    "workspace_with_path_dep-0.1.0/pyo3/netlify.toml",
    "workspace_with_path_dep-0.1.0/pyo3/newsfragments/.gitignore",
    "workspace_with_path_dep-0.1.0/pyo3/newsfragments/4719.fixed.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/errors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/import_lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-build-config/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/ACKNOWLEDGEMENTS",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/examples/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/abstract_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bltinmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/boolobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bytearrayobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/bytesobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/ceval.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/codecs.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_10.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_13.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compat/py_3_9.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/compile.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/complexobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/context.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/abstract_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/bytesobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/ceval.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/compile.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/complexobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/critical_section.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/descrobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/dictobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/floatobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/frameobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/funcobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/genobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/initconfig.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/listobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/lock.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/longobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/methodobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/objimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pydebug.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pyerrors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pyframe.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pylifecycle.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pymem.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pystate.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/pythonrun.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/tupleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/unicodeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/cpython/weakrefobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/descrobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/dictobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/enumobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/fileobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/fileutils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/floatobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/impl_/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/intrcheck.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/iterobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/listobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/longobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/marshal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/memoryobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/methodobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/modsupport.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/moduleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/objimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/osmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyarena.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pybuffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pycapsule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyerrors.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyframe.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyhash.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pylifecycle.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pymem.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pyport.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pystate.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pystrtod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/pythonrun.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/rangeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/setobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/sliceobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/structmember.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/structseq.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/sysmodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/traceback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/tupleobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/typeslots.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/unicodeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/warnings.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-ffi/src/weakrefobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/build.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/attributes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/deprecations.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/intopyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/konst.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/method.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/params.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyfunction/signature.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyimpl.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pymethod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/pyversions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/quotes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros-backend/src/utils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/Cargo.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-macros/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/LICENSE-APACHE",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/LICENSE-MIT",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/README.md",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/pyproject.toml",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/src/pyo3_runtime/__init__.py",
    "workspace_with_path_dep-0.1.0/pyo3/pyo3-runtime/tests/__init__.py",
    "workspace_with_path_dep-0.1.0/pyo3/src/buffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversion.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/anyhow.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/chrono.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/chrono_tz.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/either.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/eyre.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/hashbrown.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/indexmap.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_bigint.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_complex.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/num_rational.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/rust_decimal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/serde.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/smallvec.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/array.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/cell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/ipaddr.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/map.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/num.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/option.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/osstr.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/path.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/set.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/slice.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/time.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/conversions/std/vec.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine/cancel.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/coroutine/waker.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/err_state.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/impls.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/err/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi/tests.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/ffi_ptr_ext.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/gil.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/callback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/extract_argument.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/freelist.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/not_send.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/panic.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pycell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/assertions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/lazy_type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass/probes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyclass_init.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/pymodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/trampoline.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/impl_/wrap.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/inspect/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/inspect/types.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/instance.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal/get_slot.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/internal_tricks.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/lib.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/macros.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/marker.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/marshal.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/panic.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/prelude.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/py_result_ext.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pybacked.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pycell.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pycell/impl_.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass/create_type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass/gc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/pyclass_init.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/sealed.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/sync.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/test_utils.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/common.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/misc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pyclass.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/hygiene/pymodule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/tests/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/type_object.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/any.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/boolobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/bytearray.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/bytes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/capsule.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/code.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/complex.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/dict.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/ellipsis.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/float.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/frame.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/frozenset.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/function.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/iterator.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/list.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mapping.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mappingproxy.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/memoryview.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/none.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/notimplemented.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/num.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/pysuper.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/sequence.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/set.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/slice.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/traceback.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/tuple.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/typeobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/anyref.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/mod.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/proxy.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/types/weakref/reference.rs",
    "workspace_with_path_dep-0.1.0/pyo3/src/version.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_anyhow.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_append_to_inittab.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_arithmetics.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_buffer.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_buffer_protocol.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_bytes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_attributes.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_basics.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_comparisons.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_conversion.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_formatting.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_class_new.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_coroutine.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_datetime.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_datetime_import.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_declarative_module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_default_impls.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_enum.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_exceptions.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_field_cfg.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_frompy_intopy_roundtrip.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_frompyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_gc.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_getter_setter.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_inheritance.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_intopyobject.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_macro_docs.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_macros.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_mapping.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_methods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_module.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_multiple_pymethods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_proto_methods.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_pyfunction.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_pyself.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_sequence.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_serde.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_static_slots.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_string.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_super.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_text_signature.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_variable_arguments.rs",
    "workspace_with_path_dep-0.1.0/pyo3/tests/test_various.rs",
    "workspace_with_path_dep-0.1.0/pyproject.toml",
}

----

test workspace_with_path_dep_sdist ... FAILED

failures:

failures:
    workspace_with_path_dep_sdist

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 60 filtered out; finished in 1.56s


--- STDERR:              maturin::run workspace_with_path_dep_sdist ---
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
🔗 Found pyo3 bindings
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
From `cargo package --list --allow-dirty --manifest-path /Users/goldbaum/Documents/pyo3/pyo3-macros-backend/Cargo.toml`:
    Blocking waiting for file lock on package cache
From `cargo package --list --allow-dirty --manifest-path /Users/goldbaum/Documents/maturin/test-crates/workspace_with_path_dep/transitive_lib/Cargo.toml`:
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
    Blocking waiting for file lock on package cache
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
From `cargo package --list --allow-dirty --manifest-path /Users/goldbaum/Documents/pyo3/pyo3-build-config/Cargo.toml`:
    Blocking waiting for file lock on package cache
From `cargo package --list --allow-dirty --manifest-path /Users/goldbaum/Documents/maturin/test-crates/workspace_with_path_dep/generic_lib/Cargo.toml`:
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
From `cargo package --list --allow-dirty --manifest-path /Users/goldbaum/Documents/maturin/test-crates/workspace_with_path_dep/python/Cargo.toml`:
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
warning: manifest has no description, license, license-file, documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
📦 Built source distribution to /Users/goldbaum/Documents/maturin/test-crates/wheels/sdist-workspace-with-path-dep/workspace_with_path_dep-0.1.0.tar.gz
```

</details>

Somehow the maturin and pyo3 sources are ending up in the sdist for these crates?