### PR TITLE
propagate abiflags to wheel name on Windows

### DIFF
--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -120,6 +120,11 @@ impl InterpreterConfig {
                 })
             }
             (Os::Windows, CPython) => {
+                let abiflags = if python_version < (3, 8) {
+                    "m".to_string()
+                } else {
+                    abiflags.to_string()
+                };
                 let ext_suffix = if python_version < (3, 8) {
                     ".pyd".to_string()
                 } else {
@@ -135,7 +140,7 @@ impl InterpreterConfig {
                     major,
                     minor,
                     interpreter_kind: CPython,
-                    abiflags: abiflags.to_string(),
+                    abiflags,
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),
                     gil_disabled,

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -135,8 +135,7 @@ impl InterpreterConfig {
                     major,
                     minor,
                     interpreter_kind: CPython,
-                    // abiflags is always empty on Windows
-                    abiflags: String::new(),
+                    abiflags: abiflags.to_string(),
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),
                     gil_disabled,
@@ -152,7 +151,6 @@ impl InterpreterConfig {
                     major,
                     minor,
                     interpreter_kind: PyPy,
-                    // abiflags is always empty on Windows
                     abiflags: String::new(),
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -26,7 +26,7 @@ metadata = {
     "executable": sys.executable or None,
     "major": sys.version_info.major,
     "minor": sys.version_info.minor,
-    "abiflags": sysconfig.get_config_var("abiflags"),
+    "abiflags": sysconfig.get_config_var("ABIFLAGS"),
     "interpreter": platform.python_implementation().lower(),
     "ext_suffix": ext_suffix,
     "soabi": sysconfig.get_config_var("SOABI") or None,

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -26,7 +26,7 @@ metadata = {
     "executable": sys.executable or None,
     "major": sys.version_info.major,
     "minor": sys.version_info.minor,
-    "abiflags": sysconfig.get_config_var("ABIFLAGS"),
+    "abiflags": sysconfig.get_config_var("abiflags"),
     "interpreter": platform.python_implementation().lower(),
     "ext_suffix": ext_suffix,
     "soabi": sysconfig.get_config_var("SOABI") or None,

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -1,7 +1,7 @@
 pub use self::config::InterpreterConfig;
 use crate::auditwheel::PlatformTag;
 use crate::{BridgeModel, BuildContext, Target};
-use anyhow::{bail, format_err, Context, Result};
+use anyhow::{bail, ensure, format_err, Context, Result};
 use pep440_rs::{Version, VersionSpecifiers};
 use regex::Regex;
 use serde::Deserialize;
@@ -432,9 +432,9 @@ fn fun_with_abiflags(
             if message.minor <= 7 {
                 Ok("m".to_string())
             } else if message.gil_disabled {
-                assert!(
+                ensure!(
                     message.minor >= 13,
-                    "gil_disabled is only available in python 3.13+"
+                    "gil_disabled is only available in python 3.13+ ಠ_ಠ"
                 );
                 Ok("t".to_string())
             } else {

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -425,23 +425,10 @@ fn fun_with_abiflags(
     if message.interpreter == "pypy" || message.interpreter == "graalvm" {
         // pypy and graalpy do not specify abi flags
         Ok("".to_string())
-    } else if message.system == "windows" {
-        if matches!(message.abiflags.as_deref(), Some("") | None) {
-            Ok("".to_string())
-        } else {
-            bail!("A python 3 interpreter on Windows does not define abiflags in its sysconfig ಠ_ಠ")
-        }
-    } else if let Some(ref abiflags) = message.abiflags {
-        if message.minor >= 8 {
-            // for 3.8, "builds with and without pymalloc are ABI compatible" and the flag dropped
-            Ok(abiflags.to_string())
-        } else if (abiflags != "m") && (abiflags != "dm") {
-            bail!("A python 3 interpreter on Linux or macOS must have 'm' or 'dm' as abiflags ಠ_ಠ")
-        } else {
-            Ok(abiflags.to_string())
-        }
+    } else if let Some(abiflags) = &message.abiflags {
+        Ok(abiflags.to_string())
     } else {
-        bail!("A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig ಠ_ಠ")
+        bail!("A python 3 interpreter is expected to define abiflags in its sysconfig ಠ_ಠ")
     }
 }
 

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -499,23 +499,13 @@ impl PythonInterpreter {
         } else {
             match self.interpreter_kind {
                 InterpreterKind::CPython => {
-                    if target.is_unix() {
-                        format!(
-                            "cp{major}{minor}-cp{major}{minor}{abiflags}-{platform}",
-                            major = self.major,
-                            minor = self.minor,
-                            abiflags = self.abiflags,
-                            platform = platform
-                        )
-                    } else {
-                        // On windows the abiflags are missing, but this seems to work
-                        format!(
-                            "cp{major}{minor}-none-{platform}",
-                            major = self.major,
-                            minor = self.minor,
-                            platform = platform
-                        )
-                    }
+                    format!(
+                        "cp{major}{minor}-cp{major}{minor}{abiflags}-{platform}",
+                        major = self.major,
+                        minor = self.minor,
+                        abiflags = self.abiflags,
+                        platform = platform
+                    )
                 }
                 InterpreterKind::PyPy => {
                     // pypy uses its version as part of the ABI, e.g.


### PR DESCRIPTION
xref https://github.com/pydantic/jiter/pull/172#issuecomment-2501612556

At the moment the windows builds are hard coded to use the `none` abi tag (unless they are abi3). I think this is probably technically incorrect, though in practice has worked fine historically because there was only one build on Windows... until 3.13t has come along with free-threading as a second option :)

It's important that we do emit proper abi tags (e.g. `cp313`, `cp313t`) because otherwise the two 3.13 wheels end up with the same name and can't be uploaded to PyPI. I think I also saw some install failures on `jiter` CI where a Python 3.13 build ended up installing the other build's wheel (I think `pip` detected an incorrect lib name and rejected it).

I suspect I might need to fix some tests...