### PR TITLE
support interpreter names like '3.13t

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1279,8 +1279,17 @@ fn find_interpreter_in_sysconfig(
             .map(|c| c.is_ascii_digit())
             .unwrap_or(false)
         {
-            // Eg: -i 3.9 without interpreter kind, assume it's CPython
-            (InterpreterKind::CPython, &*python, "")
+            // Eg: -i 3.9 or 3.13t without interpreter kind, assume it's CPython
+            let (ver, abiflags) = if let Some(ver) = python
+                .strip_prefix('-')
+                .unwrap_or(&python)
+                .strip_suffix('t')
+            {
+                (ver, "t")
+            } else {
+                (&*python, "")
+            };
+            (InterpreterKind::CPython, ver, abiflags)
         } else {
             // if interpreter not known
             if std::path::Path::new(&python).is_file() {


### PR DESCRIPTION
Without this, I get:

```
± maturin build --release --out dist --interpreter 3.13t
📦 Including license file "/Users/goldbaum/Documents/rpds-py/LICENSE"
🔗 Found pyo3 bindings
⚠️  Warning: Failed to determine python platform
[src/build_options.rs:1254:22] interp.display().to_string() = "3.13t"
💥 maturin failed
  Caused by: Invalid python interpreter minor version '13t', expect a digit
  Caused by: invalid digit found in string
```