### PR TITLE
Bump metadata version to 2.4 to fix license bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.7.6-beta.1"
+version = "1.7.6"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>", "messense <messense@icloud.com>"]
 name = "maturin"
-version = "1.7.6-beta.1"
+version = "1.7.6"
 description = "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages"
 exclude = [
     "test-crates/**/*",

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -679,7 +679,7 @@ mod test {
         );
 
         let expected = expect![[r#"
-            Metadata-Version: 2.3
+            Metadata-Version: 2.4
             Name: info-project
             Version: 0.1.0
             Summary: A test project

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -70,7 +70,7 @@ impl Metadata23 {
     /// Initializes with name, version and otherwise the defaults
     pub fn new(name: String, version: Version) -> Self {
         Self {
-            metadata_version: "2.3".to_string(),
+            metadata_version: "2.4".to_string(),
             name,
             version,
             platform: vec![],


### PR DESCRIPTION
When a project sets `license = { file = "LICENSE" }`, we're currently emitting a `License-File` entry, but Metadata-Version 2.3, which is invalid and now gets rejected by PyPI, breaking publish for projects using `license = { file = "LICENSE" }`. This change bumps the metadata version.

Alternatively, we could only bump the version if license files are used and use the old `License` field for `license = { file = "LICENSE" }` again, but i'm not aware of any index currently rejecting metadata version 2.4.