### PR TITLE
Remove hard coded `pip show` in `fix_direct_url`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ packages = ["maturin"]
 bindings = "bin"
 
 [tool.black]
-target_version = ['py37']
+target-version = ['py37']
 extend-exclude = '''
 # Ignore cargo-generate templates
 ^/src/templates


### PR DESCRIPTION
Before uv 0.4.25, `uv pip show` did not support the `--files` argument which is required by `fix_direct_url`. Now that the flag is supported, falling back to pip is not necessary.

Error handling is also improved. Previously if pip was not present in the environment (which is the case for `uv venv`) no error was reported to the user but `fix_direct_url` will have failed so the package is not installed in editable mode.

fixes https://github.com/PyO3/maturin/issues/2346