### PR TITLE
Switch from `wasm32-wasi` to `wasm32-wasip1`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ build_and_test: &BUILD_AND_TEST
   only_if: $CIRRUS_BRANCH =~ 'gh-readonly-queue/.*' || $CIRRUS_PR != ""
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-    - rustup target add wasm32-wasi
+    - rustup target add wasm32-wasip1
     - python3 -m pip install --upgrade cffi virtualenv
   build_script:
     - cargo build

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -8,5 +8,5 @@ pipx ensurepath
 pipx install uniffi-bindgen
 pipx install cargo-deny
 
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rustup
         with:
-          targets: wasm32-wasi # Used by the test suite
+          targets: wasm32-wasip1 # Used by the test suite
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Install additional Rust target

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -518,11 +518,12 @@ fn integration_wasm_hello_world() {
         None,
         "integration-wasm-hello-world",
         false,
-        Some("wasm32-wasi"),
+        Some("wasm32-wasip1"),
     ));
 
     let python_implementation = test_python_implementation().unwrap();
-    let venv_name = format!("integration-wasm-hello-world-py3-wasm32-wasi-{python_implementation}");
+    let venv_name =
+        format!("integration-wasm-hello-world-py3-wasm32-wasip1-{python_implementation}");
 
     // Make sure we're actually running wasm
     assert!(Path::new("test-crates")


### PR DESCRIPTION
`wasm32-wasi` was renamed to `wasm32-wasip1`:
https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1.html#wasm32-wasip1