### PR TITLE
fix link to pyo3 documentation

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1137,7 +1137,7 @@ pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<Br
                 eprintln!(
                     "⚠️  Warning: You're building a library without activating {lib}'s \
                      `extension-module` feature. \
-                     See https://pyo3.rs/v{version}/building_and_distribution.html#linking"
+                     See https://pyo3.rs/v{version}/building-and-distribution.html#the-extension-module-feature"
                 );
             }
 


### PR DESCRIPTION
Has been broken since pyo3 0.14.2

old link: https://pyo3.rs/v0.14.1/building_and_distribution.html#linking
new link: https://pyo3.rs/v0.23.3/building-and-distribution.html#the-extension-module-feature