### PR TITLE
Make `maturin develop` fail if version info is missing in `pyproject.toml`

### DIFF
--- a/src/develop.rs
+++ b/src/develop.rs
@@ -403,6 +403,16 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         .editable(true)
         .build()?;
 
+    // Ensure that version information is present, https://github.com/PyO3/maturin/issues/2416
+    if build_context
+        .pyproject_toml
+        .as_ref()
+        .is_some_and(|p| !p.warn_invalid_version_info())
+    {
+        bail!("Cannot build source distribution without valid version information. \
+               You need to specify either `project.version` or `project.dynamic = ['version']` in pyproject.toml.");
+    }
+
     let interpreter =
         PythonInterpreter::check_executable(&python, &target, build_context.bridge())?.ok_or_else(
             || anyhow!("Expected `python` to be a python interpreter inside a virtualenv ಠ_ಠ"),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -144,13 +144,18 @@ impl Metadata24 {
             }
 
             self.name.clone_from(&project.name);
-            if let Some(version) = &project.version {
-                if dynamic.contains("version") {
-                    eprintln!("⚠️  Warning: `project.dynamic` must not specify `version` when `project.version` is present in pyproject.toml");
+
+            let version_ok = pyproject_toml.warn_invalid_version_info();
+            if !version_ok {
+                // This is a hard error for maturin>=2.0, see https://github.com/PyO3/maturin/issues/2416.
+                let current_major = env!("CARGO_PKG_VERSION_MAJOR").parse::<usize>().unwrap();
+                if current_major > 1 {
+                    bail!("Invalid version information in pyproject.toml.");
                 }
+            }
+
+            if let Some(version) = &project.version {
                 self.version = version.clone();
-            } else if !dynamic.contains("version") {
-                eprintln!("⚠️  Warning: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list");
             }
 
             if let Some(description) = &project.description {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -146,11 +146,11 @@ impl Metadata24 {
             self.name.clone_from(&project.name);
             if let Some(version) = &project.version {
                 if dynamic.contains("version") {
-                    bail!("`project.dynamic` must not specify `version` when `project.version` is present in pyproject.toml");
+                    eprintln!("⚠️  Warning: `project.dynamic` must not specify `version` when `project.version` is present in pyproject.toml");
                 }
                 self.version = version.clone();
             } else if !dynamic.contains("version") {
-                bail!("`project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list");
+                eprintln!("⚠️  Warning: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list");
             }
 
             if let Some(description) = &project.description {


### PR DESCRIPTION
This PR implements the changes discussed in https://github.com/PyO3/maturin/issues/2416#issuecomment-2565278865 on top of #2417. Got this done faster than expected this morning, but won't have any time to incorporate feedback for the next ~ two days. Feel free to pull this in and butcher it any way you like. :)

Thanks again for your fantastic work on maturin! 🍰 