### PR TITLE
Handle archived dylibs on AIX

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -616,6 +616,12 @@ impl Target {
         self.os == Os::Hurd
     }
 
+    /// Returns true if we're building a binary for AIX
+    #[inline]
+    pub fn is_aix(&self) -> bool {
+        self.os == Os::Aix
+    }
+
     /// Returns true if the current platform's target env is Musl
     #[inline]
     pub fn is_musl_libc(&self) -> bool {


### PR DESCRIPTION
In recent Rust versions, the dylib format for AIX has changed to reflect that shared libraries on AIX are normal archived, in the Big archive format. 
See https://github.com/rust-lang/rust/pull/132362.

However, Python wheels on the platforms still use un-archived shared objects, so this change updates module_writer to unarchive the archived dylib before we copy it over to the wheel.