### PR TITLE
Fix constant rebuilds

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -443,7 +443,7 @@ fn cargo_build_command(
             fs::create_dir_all(&maturin_target_dir)?;
             // We don't want to rewrite the file every time as that will make cargo
             // trigger a rebuild of the project every time
-            let existing_pyo3_config = fs::read_to_string(&config_file).unwrap_or_default()
+            let existing_pyo3_config = fs::read_to_string(&config_file).unwrap_or_default();
             if pyo3_config != existing_pyo3_config {
                 fs::write(&config_file, pyo3_config).with_context(|| {
                     format!(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -443,14 +443,8 @@ fn cargo_build_command(
             fs::create_dir_all(&maturin_target_dir)?;
             // We don't want to rewrite the file every time as that will make cargo
             // trigger a rebuild of the project every time
-            let rewrite = if config_file.exists() {
-                std::fs::read_to_string(&config_file)
-                    .map(|previous| previous != pyo3_config)
-                    .unwrap_or(false)
-            } else {
-                true
-            };
-            if rewrite {
+            let existing_pyo3_config = fs::read_to_string(&config_file).unwrap_or_default()
+            if pyo3_config != existing_pyo3_config {
                 fs::write(&config_file, pyo3_config).with_context(|| {
                     format!(
                         "Failed to create pyo3 config file at '{}'",

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -441,12 +441,23 @@ fn cargo_build_command(
                 target_triple, interpreter.major, interpreter.minor
             ));
             fs::create_dir_all(&maturin_target_dir)?;
-            fs::write(&config_file, pyo3_config).with_context(|| {
-                format!(
-                    "Failed to create pyo3 config file at '{}'",
-                    config_file.display()
-                )
-            })?;
+            // We don't want to rewrite the file every time as that will make cargo
+            // trigger a rebuild of the project every time
+            let rewrite = if config_file.exists() {
+                std::fs::read_to_string(&config_file)
+                    .map(|previous| previous != pyo3_config)
+                    .unwrap_or(false)
+            } else {
+                true
+            };
+            if rewrite {
+                fs::write(&config_file, pyo3_config).with_context(|| {
+                    format!(
+                        "Failed to create pyo3 config file at '{}'",
+                        config_file.display()
+                    )
+                })?;
+            }
             let abs_config_file = config_file.normalize()?.into_path_buf();
             build_command.env("PYO3_CONFIG_FILE", abs_config_file);
         }


### PR DESCRIPTION
On some of my computers, maturin build always rebuilds pyo3 and friends, and looking at the cargo fingerprinting, this is caused by the py03-config file being written regardless of changes. This only writes the file if it has changed since last rebuild, which seems to prevent the problem.