### PR TITLE
fix the name of the .data directory in the generated wheel

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -637,7 +637,11 @@ impl BuildContext {
         .context("Failed to add the files to the wheel")?;
 
         self.add_pth(&mut writer)?;
-        add_data(&mut writer, self.project_layout.data.as_deref())?;
+        add_data(
+            &mut writer,
+            &self.metadata24,
+            self.project_layout.data.as_deref(),
+        )?;
         let wheel_path = writer.finish()?;
         Ok((wheel_path, format!("cp{major}{min_minor}")))
     }
@@ -715,7 +719,11 @@ impl BuildContext {
         .context("Failed to add the files to the wheel")?;
 
         self.add_pth(&mut writer)?;
-        add_data(&mut writer, self.project_layout.data.as_deref())?;
+        add_data(
+            &mut writer,
+            &self.metadata24,
+            self.project_layout.data.as_deref(),
+        )?;
         let wheel_path = writer.finish()?;
         Ok((
             wheel_path,
@@ -838,7 +846,11 @@ impl BuildContext {
         )?;
 
         self.add_pth(&mut writer)?;
-        add_data(&mut writer, self.project_layout.data.as_deref())?;
+        add_data(
+            &mut writer,
+            &self.metadata24,
+            self.project_layout.data.as_deref(),
+        )?;
         let wheel_path = writer.finish()?;
         Ok((wheel_path, "py3".to_string()))
     }
@@ -904,7 +916,11 @@ impl BuildContext {
         )?;
 
         self.add_pth(&mut writer)?;
-        add_data(&mut writer, self.project_layout.data.as_deref())?;
+        add_data(
+            &mut writer,
+            &self.metadata24,
+            self.project_layout.data.as_deref(),
+        )?;
         let wheel_path = writer.finish()?;
         Ok((wheel_path, "py3".to_string()))
     }
@@ -1009,7 +1025,11 @@ impl BuildContext {
         self.add_external_libs(&mut writer, &artifacts_ref, ext_libs)?;
 
         self.add_pth(&mut writer)?;
-        add_data(&mut writer, self.project_layout.data.as_deref())?;
+        add_data(
+            &mut writer,
+            &self.metadata24,
+            self.project_layout.data.as_deref(),
+        )?;
         let wheel_path = writer.finish()?;
         Ok((wheel_path, "py3".to_string()))
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -569,6 +569,15 @@ impl Metadata24 {
             &self.get_version_escaped()
         ))
     }
+
+    /// Returns the name of the .data directory as defined in the wheel specification
+    pub fn get_data_dir(&self) -> PathBuf {
+        PathBuf::from(format!(
+            "{}-{}.data",
+            &self.get_distribution_escaped(),
+            &self.get_version_escaped()
+        ))
+    }
 }
 
 /// Escape email addresses with display name if necessary

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1485,7 +1485,11 @@ pub fn write_dist_info(
 /// to save or generate the data in other places
 ///
 /// See https://peps.python.org/pep-0427/#file-contents
-pub fn add_data(writer: &mut impl ModuleWriter, data: Option<&Path>) -> Result<()> {
+pub fn add_data(
+    writer: &mut impl ModuleWriter,
+    metadata24: &Metadata24,
+    data: Option<&Path>,
+) -> Result<()> {
     let possible_data_dir_names = ["data", "scripts", "headers", "purelib", "platlib"];
     if let Some(data) = data {
         for subdir in fs::read_dir(data).context("Failed to read data dir")? {
@@ -1513,7 +1517,9 @@ pub fn add_data(writer: &mut impl ModuleWriter, data: Option<&Path>) -> Result<(
                     let mode = file.metadata()?.permissions().mode();
                     #[cfg(not(unix))]
                     let mode = 0o644;
-                    let relative = file.path().strip_prefix(data.parent().unwrap()).unwrap();
+                    let relative = metadata24
+                        .get_data_dir()
+                        .join(file.path().strip_prefix(data).unwrap());
 
                     if file.path_is_symlink() {
                         // Copy the actual file contents, not the link, so that you can create a


### PR DESCRIPTION
The basename of the ".data" directory in the wheel now matches the basename of the ".dist-info" directory, as per the wheel spec[1], like so:

     distribution-1.0.dist-info
     distribution-1.0.data

1: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#the-data-directory