### PR TITLE
Strip a possible -git suffix from emcc version

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1235,7 +1235,10 @@ fn emcc_version() -> Result<String> {
         .arg("-dumpversion")
         .output()
         .context("Failed to run emcc to get the version")?;
-    Ok(String::from_utf8(emcc.stdout)?.trim().into())
+    let ver = String::from_utf8(emcc.stdout)?;
+    let mut trimmed = ver.trim();
+    trimmed = trimmed.strip_suffix("-git").unwrap_or(trimmed);
+    Ok(trimmed.into())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Compare here:
https://github.com/python/cpython/blob/main/configure.ac#L810
which just uses `cut -f1 -d-` to delete everything after the `-`. But we're only after deleting `-git`.