### PR TITLE
Add `rnet` python library to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ maturin itself is manylinux compliant when compiled for the musl target.
 - [roapi](https://github.com/roapi/roapi) - ROAPI automatically spins up read-only APIs for static datasets without requiring you to write a single line of code
 - [robyn](https://github.com/sansyrox/robyn) - A fast and extensible async python web server with a Rust runtime
 - [ruff](https://github.com/charliermarsh/ruff) - An extremely fast Python linter, written in Rust
+- [rnet](https://github.com/0x676e67/rnet) - Asynchronous Python HTTP Client with Black Magic
 - [tantivy-py](https://github.com/quickwit-oss/tantivy-py) - Python bindings for Tantivy
 - [watchfiles](https://github.com/samuelcolvin/watchfiles) - Simple, modern and high performance file watching and code reload in python
 - [wonnx](https://github.com/webonnx/wonnx/tree/master/wonnx-py) - Wonnx is a GPU-accelerated ONNX inference run-time written 100% in Rust


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change adds a new project to the list of examples of Rust projects with Python bindings.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R246): Added `rnet` to the list of Rust projects with Python bindings.