### PR TITLE
Fix platform tag on Solaris/Illumos

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -562,7 +562,7 @@ impl BuildContext {
 
                 let mut os = target.target_os().to_string().to_ascii_lowercase();
                 // See https://github.com/python/cpython/blob/46c8d915715aa2bd4d697482aa051fe974d440e1/Lib/sysconfig.py#L722-L730
-                if os.starts_with("sunos") {
+                if target.target_os() == Os::Solaris || target.target_os() == Os::Illumos {
                     // Solaris / Illumos
                     if let Some((major, other)) = release.split_once('_') {
                         let major_ver: u64 = major.parse().context("illumos major version is not a number")?;


### PR DESCRIPTION
This fixes platform tag on Solaris/Illumos.

The problem is that `os` here can never be `sunos`, but rather `solaris`/`illumos`.

The following:
```diff
-                if os.starts_with("sunos") {
+                if os.starts_with("illumos") || os.starts_with("solaris") {
```
works as well, but checking the enum values seems nicer (and it's definitely faster). Using `get_python_os` would likely work as well, but I didn't go that way for the same reason.
