### PR TITLE
chore: Update cbindgen to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ glob = "0.3.0"
 cargo-config2 = "0.1.24"
 cargo_metadata = "0.19.0"
 cargo-options = "0.7.2"
-cbindgen = { version = "0.27.0", default-features = false }
+cbindgen = { version = "0.28.0", default-features = false }
 flate2 = "1.0.18"
 goblin = "0.9.0"
 platform-info = "2.0.2"


### PR DESCRIPTION
The version `cbindgen 0.28.0` supports parsing unsafe attributes. As such it restorers maturins ability to build cffi bindings for crates which are created with Rust edition 2024.