### PR TITLE
Update `generate-ci` options in user guide

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -265,6 +265,15 @@ Options:
   -m, --manifest-path <PATH>
           Path to Cargo.toml
 
+  -v, --verbose...
+          Use verbose output.
+
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
+          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+
+          You can configure fine-grained logging using the `RUST_LOG` environment variable.
+          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
   -o, --output <PATH>
           Output path
 
@@ -273,14 +282,14 @@ Options:
       --platform <platform>...
           Platform support
 
-          [default: linux windows macos]
+          [default: linux musllinux windows macos]
 
           Possible values:
           - all:        All
-          - linux:      Linux
+          - manylinux:  Manylinux
+          - musllinux:  Musllinux
           - windows:    Windows
           - macos:      macOS
-          - macosarm64: macOS(Arm64)
           - emscripten: Emscripten
 
       --pytest
@@ -289,8 +298,11 @@ Options:
       --zig
           Use zig to do cross compilation
 
+      --skip-attestation
+          Skip artifact attestation
+
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help (see a summary with '-h')
 ```
 
 ### Using PyPI's trusted publishing


### PR DESCRIPTION
Grabbed from [`tests/cmd/generate-ci.stdout`](https://github.com/PyO3/maturin/blob/cc7ee8b5838b93c7fec3c80fc7c7addfa1477952/tests/cmd/generate-ci.stdout).
