### PR TITLE
fix: correctly select minimum abi3 version

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -954,7 +954,7 @@ fn has_abi3(deps: &HashMap<&str, &Node>) -> Result<Option<(u8, u8)>> {
                 .collect::<Result<Vec<(u8, u8)>>>()
                 .context(format!("Bogus {lib} cargo features"))?
                 .into_iter()
-                .min();
+                .max();
             if abi3_selected && min_abi3_version.is_none() {
                 bail!(
                         "You have selected the `abi3` feature but not a minimum version (e.g. the `abi3-py36` feature). \


### PR DESCRIPTION
The pyo3 docs states that if multiple abi3 versions are specified then the highest version should be used. But this is not the current behaviour of maturin.

https://pyo3.rs/v0.14.5/building_and_distribution#minimum-python-version-for-abi3
> Note: If you set more that one of these api version feature flags the highest version always wins. For example, with both abi3-py36 and abi3-py38 set, PyO3 would build a wheel which supports Python 3.8 and up.