### PR TITLE
Don't install dependencies when running `maturin develop --skip-install`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ build_and_test:
 freebsd_task:
   name: Test (x86_64 FreeBSD)
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
   env:
     PATH: $HOME/.cargo/bin:$PATH
   target_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,22 +191,20 @@ checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -3431,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.6"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
+checksum = "b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a"
 dependencies = [
  "arbitrary",
  "bzip2",
@@ -3443,7 +3441,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "time",
  "zopfli",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,8 @@ feature-depth = 1
 ignore = [
     # multipart unmaintained
     "RUSTSEC-2023-0050",
+    # paste unmaintained
+    "RUSTSEC-2024-0436",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -458,7 +458,9 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         }
     };
 
-    install_dependencies(&build_context, &extras, &python, venv_dir, &install_backend)?;
+    if !skip_install {
+        install_dependencies(&build_context, &extras, &python, venv_dir, &install_backend)?;
+    }
 
     let wheels = build_context.build_wheels()?;
     if !skip_install {


### PR DESCRIPTION
Closes #2496