### PR TITLE
Update the TP docs to use `pypi` as the GH Env name

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -313,6 +313,6 @@ To enable it, modify the `release` action in the generated GitHub workflow file:
 
 - remove `MATURIN_PYPI_TOKEN` from the `env` section to make maturin use trusted publishing
 - add `id-token: write` to the action's `permissions` (see [Configuring OpenID Connect in PyPI](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi) from GitHub's documentation).
-- if `Environment name: release` was set in PyPI, add `environment: release`
+- if `Environment name: pypi` was set in PyPI, add `environment: pypi`
 
 Make sure to follow the steps listed in [PyPI's documentation](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to set up your GitHub repository as a trusted publisher in the PyPI project settings before attempting to run the workflow.


### PR DESCRIPTION
The deployment target name `release` is confusing (and a lot of people don't realize that GitHub Environment doesn't refer to a process but rather to the deployment platform). I already fixed this in the Warehouse placeholders, its docs and most other places in the ecosystem.

Refs:
* https://github.com/pypi/warehouse/pull/17036
* https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
* https://github.com/actions/starter-workflows/pull/2345/files#diff-d0d0af2177759eaa8fa1abff177e78f3f0a157756500999200b0d7888c19133aR52