### PR TITLE
fix auditwheel .so relocation for namespace modules

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -419,6 +419,14 @@ impl BuildContext {
         let artifact_dir = match self.bridge() {
             // cffi bindings that contains '.' in the module name will be split into directories
             BridgeModel::Cffi => self.module_name.split(".").collect::<PathBuf>(),
+            // For namespace packages the modules the modules resides resides at ${module_name}.so
+            // where periods are replaced with slashes so for example my.namespace.module would reside
+            // at my/namespace/module.so
+            _ if self.module_name.contains(".") => {
+                let mut path = self.module_name.split(".").collect::<PathBuf>();
+                path.pop();
+                path
+            }
             // For other bindings artifact .so file usually resides at ${module_name}/${module_name}.so
             _ => PathBuf::from(&self.module_name),
         };


### PR DESCRIPTION
For a project of mine I have a setup as a namespace package like this:

``` toml
[tool.maturin]
python-source = "python/src"
module-name = "my.example.namespace.module"
```

The module has a shared library dependency and currently the shared object generated by audit wheel fails to load as the rpath gets set incorrectly. The wheel has the following contents

```
/my.libs/my_dep.so
/my/example/namespace/module.so
```
 The `RATH`/`RUNPATH` for `/my/example/namespace/module.so` gets set to `$ORIGIN/../my.libs/my_dep.so` which means that `my_dep.so` is not found while trying to load the module. Instead the `RATH`/`RUNPATH` should be: `$ORIGIN/../../../my.libs/my_dep.so`.

I took a stab at fixing this. It looks like the logic for determining the artifact path was wrong and assumed the shared library would endup in `my.example.namespace.module/module.so` but it endsup in `my/example/namespace/module.so`.
