### PR TITLE
Support `maturin.build-args` config setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,9 +1624,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -1656,9 +1656,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -34,7 +34,10 @@ def get_config() -> Dict[str, str]:
 
 
 def get_maturin_pep517_args(config_settings: Optional[Mapping[str, Any]] = None) -> List[str]:
-    build_args = config_settings.get("build-args") if config_settings else None
+    build_args = None
+    if config_settings:
+        # TODO: Deprecate and remove build-args in favor of maturin.build-args in maturin 2.0
+        build_args = config_settings.get("maturin.build-args", config_settings.get("build-args"))
     if build_args is None:
         env_args = os.getenv("MATURIN_PEP517_ARGS", "")
         args = shlex.split(env_args)


### PR DESCRIPTION
config settings is a flat dict, better add namespace to it.