### PR TITLE
Sort RECORD file in wheel archives to make them deterministic.

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -153,7 +153,11 @@ impl PathWriter {
             record_file.display()
         ))?;
 
-        for (filename, hash, len) in self.record {
+        // Sort records for deterministic output
+        let mut sorted_records = self.record.clone();
+        sorted_records.sort_by(|(path_a, _, _), (path_b, _, _)| path_a.cmp(path_b));
+
+        for (filename, hash, len) in sorted_records {
             buffer
                 .write_all(format!("{filename},sha256={hash},{len}\n").as_bytes())
                 .context(format!(
@@ -389,7 +393,12 @@ impl WheelWriter {
         let record_filename = self.record_file.to_str().unwrap().replace('\\', "/");
         debug!("Adding {}", record_filename);
         self.zip.start_file(&record_filename, options)?;
-        for (filename, hash, len) in self.record {
+
+        // Sort records for deterministic output
+        let mut sorted_records = self.record.clone();
+        sorted_records.sort_by(|(path_a, _, _), (path_b, _, _)| path_a.cmp(path_b));
+
+        for (filename, hash, len) in sorted_records {
             self.zip
                 .write_all(format!("{filename},sha256={hash},{len}\n").as_bytes())?;
         }


### PR DESCRIPTION
While working on reproducible builds in nixpkgs ([#397290](https://github.com/NixOS/nixpkgs/pull/397290), [#384709](https://github.com/NixOS/nixpkgs/issues/384709)), I noticed that the RECORD files generated in wheels had inconsistent ordering between builds.

It looked like this was due to both the WheelWriter and PathWriter implementations writing entries in the order they were processed, without any explicit sorting. This PR adds a simple sort step before writing to ensure deterministic output.

I'm not familiar with Rust yet, so if there's anything I’ve missed or done in a non-idiomatic way, I’d really appreciate any feedback or suggestions. Thanks!