### PR TITLE
Bump develop_pyo3_ffi_pure test timeout to 120s

### DIFF
--- a/tests/run.rs
+++ b/tests/run.rs
@@ -228,7 +228,7 @@ fn develop_hello_world(#[case] backend: TestInstallBackend, #[case] name: &str) 
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(60))]
+#[timeout(Duration::from_secs(120))]
 #[case(TestInstallBackend::Pip, "pip")]
 #[case(TestInstallBackend::Uv, "uv")]
 #[test]


### PR DESCRIPTION
On RISC-V machines (in my case Milk-V Pioneer, one of the most performant one available), 60s is not enough in this test.