### PR TITLE
Remove dead reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ There's a `maturin sdist` command for only building a source distribution as wor
 
 For portability reasons, native python modules on linux must only dynamically link a set of very few libraries which are installed basically everywhere, hence the name manylinux.
 The pypa offers special docker images and a tool called [auditwheel](https://github.com/pypa/auditwheel/) to ensure compliance with the [manylinux rules](https://peps.python.org/pep-0599/#the-manylinux2014-policy).
-If you want to publish widely usable wheels for linux pypi, **you need to use a manylinux docker image or [build with zig](#use-zig)**.
+If you want to publish widely usable wheels for linux pypi, **you need to use a manylinux docker image or build with zig**.
 
 The Rust compiler since version 1.64 [requires at least glibc 2.17](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html), so you need to use at least manylinux2014.
 For publishing, we recommend enforcing the same manylinux version as the image with the manylinux flag, e.g. use `--manylinux 2014` if you are building in `quay.io/pypa/manylinux2014_x86_64`.


### PR DESCRIPTION
The #use-zig section the README appears to reference is in a different markdown ([this one](https://github.com/PyO3/maturin/blob/main/guide/src/distribution.md)), so the reference doesn't work.