### PR TITLE
Allow `--release` to override `profile` in `[tool.maturin]`

### DIFF
--- a/src/develop.rs
+++ b/src/develop.rs
@@ -8,7 +8,6 @@ use crate::PythonInterpreter;
 use crate::Target;
 use anyhow::ensure;
 use anyhow::{anyhow, bail, Context, Result};
-use cargo_options::heading;
 use fs_err as fs;
 use regex::Regex;
 use std::path::Path;
@@ -184,9 +183,6 @@ pub struct DevelopOptions {
         value_parser = ["pyo3", "pyo3-ffi", "cffi", "uniffi", "bin"]
     )]
     pub bindings: Option<String>,
-    /// Pass --release to cargo
-    #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS,)]
-    pub release: bool,
     /// Strip the library for minimum file size
     #[arg(long)]
     pub strip: bool,
@@ -368,7 +364,6 @@ fn parse_direct_url_path(pip_show_output: &str) -> Result<Option<PathBuf>> {
 pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
     let DevelopOptions {
         bindings,
-        release,
         strip,
         extras,
         skip_install,
@@ -408,7 +403,6 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 
     let build_context = build_options
         .into_build_context()
-        .release(release)
         .strip(strip)
         .editable(true)
         .build()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 //! Run with --help for usage information
 
 use anyhow::{bail, Context, Result};
-use cargo_options::heading;
 #[cfg(feature = "zig")]
 use cargo_zigbuild::Zig;
 #[cfg(feature = "cli-completion")]
@@ -61,9 +60,6 @@ enum Command {
     #[command(name = "build", alias = "b")]
     /// Build the crate into python packages
     Build {
-        /// Build artifacts in release mode, with optimizations
-        #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
-        release: bool,
         /// Strip the library for minimum file size
         #[arg(long)]
         strip: bool,
@@ -377,13 +373,11 @@ fn run() -> Result<()> {
     match opt.command {
         Command::Build {
             build,
-            release,
             strip,
             sdist,
         } => {
             let build_context = build
                 .into_build_context()
-                .release(release)
                 .strip(strip)
                 .editable(false)
                 .build()?;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -28,7 +28,7 @@ pub struct PublishOpt {
     /// The repository (package index) to upload the package to. Should be a section in the config file.
     ///
     /// Can also be set via MATURIN_REPOSITORY environment variable.
-    #[arg(short = 'r', long, env = "MATURIN_REPOSITORY", default_value = "pypi")]
+    #[arg(long, env = "MATURIN_REPOSITORY", default_value = "pypi")]
     repository: String,
     /// The URL of the registry where the wheels are uploaded to. This overrides --repository.
     ///

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -83,11 +83,11 @@ Options:
           Print help (see a summary with '-h')
 
 Compilation Options:
-  -r, --release
-          Build artifacts in release mode, with optimizations
-
   -j, --jobs <N>
           Number of parallel jobs, defaults to # of CPUs
+
+  -r, --release
+          Pass --release to cargo
 
       --profile <PROFILE-NAME>
           Build artifacts with the specified Cargo profile

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -59,11 +59,11 @@ Options:
           Print help (see a summary with '-h')
 
 Compilation Options:
-  -r, --release
-          Pass --release to cargo
-
   -j, --jobs <N>
           Number of parallel jobs, defaults to # of CPUs
+
+  -r, --release
+          Pass --release to cargo
 
       --profile <PROFILE-NAME>
           Build artifacts with the specified Cargo profile

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -16,7 +16,7 @@ Options:
       --no-sdist
           Don't build a source distribution
 
-  -r, --repository <REPOSITORY>
+      --repository <REPOSITORY>
           The repository (package index) to upload the package to. Should be a section in the config
           file.
           
@@ -131,6 +131,9 @@ Options:
 Compilation Options:
   -j, --jobs <N>
           Number of parallel jobs, defaults to # of CPUs
+
+  -r, --release
+          Pass --release to cargo
 
       --profile <PROFILE-NAME>
           Build artifacts with the specified Cargo profile

--- a/tests/cmd/upload.stdout
+++ b/tests/cmd/upload.stdout
@@ -9,7 +9,7 @@ Arguments:
           The python packages to upload
 
 Options:
-  -r, --repository <REPOSITORY>
+      --repository <REPOSITORY>
           The repository (package index) to upload the package to. Should be a section in the config
           file.
           

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -59,7 +59,6 @@ pub fn test_develop(
     let manifest_file = package.join("Cargo.toml");
     let develop_options = DevelopOptions {
         bindings,
-        release: false,
         strip: false,
         extras: Vec::new(),
         skip_install: false,


### PR DESCRIPTION
Unfortunately there is conflicts with `-r/--release` and `-r/--repository` in `maturin publish` command, so this is a breaking change.

Fixes https://github.com/PyO3/maturin/discussions/2567