### PR TITLE
Add `--compression-level` option to `build` command

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -131,6 +131,8 @@ pub struct BuildContext {
     pub editable: bool,
     /// Cargo build options
     pub cargo_options: CargoOptions,
+    /// Zip compression level
+    pub compression_level: u16,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).
@@ -631,6 +633,7 @@ impl BuildContext {
             &self.metadata24,
             &[tag.clone()],
             self.excludes(Format::Wheel)?,
+            self.compression_level,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -708,6 +711,7 @@ impl BuildContext {
             &self.metadata24,
             &[tag.clone()],
             self.excludes(Format::Wheel)?,
+            self.compression_level,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -830,6 +834,7 @@ impl BuildContext {
             &self.metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
+            self.compression_level,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -901,6 +906,7 @@ impl BuildContext {
             &self.metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
+            self.compression_level,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -999,6 +1005,7 @@ impl BuildContext {
             &metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
+            self.compression_level,
         )?;
 
         if self.project_layout.python_module.is_some() && self.target.is_wasi() {

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -190,6 +190,10 @@ pub struct BuildOptions {
     /// Cargo build options
     #[command(flatten)]
     pub cargo: CargoOptions,
+
+    /// Zip compresson level to use
+    #[arg(long, value_parser = clap::value_parser!(u16).range(0..=264), hide = true, default_value="6")]
+    pub compression_level: u16,
 }
 
 impl Deref for BuildOptions {
@@ -772,6 +776,7 @@ impl BuildContextBuilder {
             universal2,
             editable,
             cargo_options,
+            compression_level: build_options.compression_level,
         })
     }
 }

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -404,6 +404,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
             target: target_triple,
             ..cargo_options
         },
+        compression_level: 6,
     };
 
     let build_context = build_options


### PR DESCRIPTION
Add a `--compression-level` hidden option that can be used to adjust deflate compression level used for written wheels. When not provided, the default level of 6 is used (as before). When provided, accepts 0 to store the file uncompressed, and 0-264 otherwise as `zip` crate accepts.

Fixes #2566