### PR TITLE
Add `tpchgen-cli` python library to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ maturin itself is manylinux compliant when compiled for the musl target.
 - [rnet](https://github.com/0x676e67/rnet) - Asynchronous Python HTTP Client with Black Magic
 - [rustpy-xlsxwriter](https://github.com/rahmadafandi/rustpy-xlsxwriter): A high-performance Python library for generating Excel files, utilizing the [rust_xlsxwriter](https://github.com/jmcnamara/rust_xlsxwriter) crate for efficient data handling.
 - [tantivy-py](https://github.com/quickwit-oss/tantivy-py) - Python bindings for Tantivy
+- [tpchgen-cli](https://github.com/clflushopt/tpchgen-rs/tree/main/tpchgen-cli) - Python CLI binding for `tpchgen`, a blazing fast TPC-H benchmark data generator built in pure Rust with zero dependencies.
 - [watchfiles](https://github.com/samuelcolvin/watchfiles) - Simple, modern and high performance file watching and code reload in python
 - [wonnx](https://github.com/webonnx/wonnx/tree/master/wonnx-py) - Wonnx is a GPU-accelerated ONNX inference run-time written 100% in Rust
 


### PR DESCRIPTION
[`tpchgen`](https://github.com/clflushopt/tpchgen-rs) is a TPC-H data generator written in rust. Here's more background on its development, https://datafusion.apache.org/blog/2025/04/10/fastest-tpch-generator/

`maturin` was used to distribute the rust binary as python script, using [its `bin` bindings feature](https://www.maturin.rs/bindings#bin), with minimal code change (See https://github.com/clflushopt/tpchgen-rs/pull/121)

The rust binary cli can now be pip installed,
```
pip install tpchgen-cli
tpchgen-cli -h
```

Took me a while to figure out that `maturin` had first-class support for something like this. My first attempt was to export the cli functions manually (See https://github.com/clflushopt/tpchgen-rs/pull/119). Because of this, I think this use case is a great example to add. 

(Following #2529 as example PR)