### PR TITLE
Fix broken `maturin develop` with latest uv

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.8.4]
+
+* Fix broken `maturin develop` with latest uv in [#2584](https://github.com/PyO3/maturin/pull/2584)
+
 ## [1.8.3]
 
 * Fix relocating shared library for namespace modules in [#2513](https://github.com/PyO3/maturin/pull/2513)

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -39,6 +39,18 @@ impl InstallBackend {
 
     fn version(&self, python_path: &Path) -> Result<semver::Version> {
         let mut cmd = self.make_command(python_path);
+
+        // Newer versions of uv no longer support `uv pip --version`, and instead
+        // require that we use `uv --version`. This is a workaround to get the
+        // version of the install backend for both old and new versions of uv.
+        cmd = match self {
+            InstallBackend::Pip { .. } => cmd,
+            InstallBackend::Uv { path, args } => {
+                let mut cmd = Command::new(path);
+                cmd.args(args);
+                cmd
+            }
+        };
         let output = cmd
             .arg("--version")
             .output()
@@ -50,7 +62,7 @@ impl InstallBackend {
         let stdout = str::from_utf8(&output.stdout)?;
         let re = match self {
             InstallBackend::Pip { .. } => Regex::new(r"pip ([\w\.]+).*"),
-            InstallBackend::Uv { .. } => Regex::new(r"uv-pip ([\w\.]+).*"),
+            InstallBackend::Uv { .. } => Regex::new(r"uv ([\w\.]+).*"),
         };
         if let Some(captures) = re.expect("regex should be valid").captures(stdout) {
             Ok(semver::Version::parse(&captures[1])


### PR DESCRIPTION
This patch fixes `maturin develop` not working with the latest versions of uv due to breaking changes in uv. Previously the `--version` argument could be supplied to any subcommand, but since v0.7 that argument can only be supplied as `uv --version`.

Specifically, the fix changes the `uv pip` command to `uv` when we get the uv version as part of the check if `show --files` is supported.

Without this patch `configure_as_editable` fails due to `check_supports_show_files` failing, which again fails because `InstallBackend::version` fails with uv 0.7.x or newer.

See https://github.com/astral-sh/uv/pull/13108 for more details.

I've not added any new tests since I believe the current test suite covers this change. The change is backwards compatible with older versions of uv. But if a new test is required, please advice exactly what/how you want tested, and I'll add it.