### PR TITLE
Note Homebrew installation conflicts with rustup

### DIFF
--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -31,7 +31,7 @@ On macOS [maturin is in Homebrew](https://formulae.brew.sh/formula/maturin#defau
 brew install maturin
 ```
 
-*Note*: installing maturin with Homebrew will also install Rust with homebrew (as Rust is a dependency). If you previously installed Rust using [`rustup`](https://www.rust-lang.org/tools/install), then having Rust also installed with Homebrew can cause conflicts. Therefore, if you have installed Rust with `rustup` it's better to install maturin with another method.
+**Note**: Installing maturin with Homebrew will also install Rust as a dependency, even if you already have Rust installed via [rustup](https://www.rust-lang.org/tools/install). This results in two separate Rust installations, which can cause conflicts. If you've already installed Rust with `rustup`, consider using an alternative installation method than Homebrew for maturin.
 
 ### conda
 

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -31,7 +31,7 @@ On macOS [maturin is in Homebrew](https://formulae.brew.sh/formula/maturin#defau
 brew install maturin
 ```
 
-**Note**: Installing maturin with Homebrew will also install Rust as a dependency, even if you already have Rust installed via [rustup](https://www.rust-lang.org/tools/install). This results in two separate Rust installations, which can cause conflicts. If you've already installed Rust with `rustup`, consider using an alternative installation method than Homebrew for maturin.
+**Note**: Installing maturin with Homebrew will also install Rust as a dependency, even if you already have Rust installed via [rustup](https://www.rust-lang.org/tools/install). This results in two separate Rust installations, which can cause conflicts. If you've already installed Rust with `rustup`, consider installing maturin with a method other than Homebrew (such as from source with cargo).
 
 ### conda
 

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -31,6 +31,8 @@ On macOS [maturin is in Homebrew](https://formulae.brew.sh/formula/maturin#defau
 brew install maturin
 ```
 
+*Note*: installing maturin with Homebrew will also install Rust with homebrew (as Rust is a dependency). If you previously installed Rust using [`rustup`](https://www.rust-lang.org/tools/install), then having Rust also installed with Homebrew can cause conflicts. Therefore, if you have installed Rust with `rustup` it's better to install maturin with another method.
+
 ### conda
 
 Installing from the `conda-forge` channel can be achieved by adding `conda-forge` to your conda channels with:


### PR DESCRIPTION
I added a quick note to the Homebrew section of the install guides to mention it could cause conflicts with rustup. For background I ran into this causing conflicts with cross compiling with cross.rs:

1. Installed Rust with rustup
2. Setup cross.rs (with cargo) and added toolchains for x86 linux (was able to cross compile)
3. Decided to try maturin and installed with homebrew
    - This installed another version of rustc alongside the version that rustup installed
4. cross would then fail to compile because it would look for the toolchains with the homebrew rust even though rustup was installed

```sh
$ which rustup
/Users/$HOME/.cargo/bin/rustup

$ rustc --version
rustc 1.86.0 (05f9846f8 2025-03-31) (Homebrew)

$ which rustc
/opt/homebrew/bin/rustc 
```