### PR TITLE
Docs: Update rust-as-submodule instructions

### DIFF
--- a/guide/src/project_layout.md
+++ b/guide/src/project_layout.md
@@ -136,6 +136,22 @@ This can be done by adding `module-name = <package name>.<rust pymodule name>` t
 module-name = "my_project._my_project"
 ```
 
+Update the module name in `lib.rs` to match the expected module name:
+
+```diff
+#[pymodule]
+- fn my_project(...)
++ fn _my_project(...)
+```
+
+If you are using the `pyo3` bindings, you can alternatively add `#[pyo3(name = ...)]` to the `#[pymodule]` declaration:
+
+```diff
+#[pymodule]
++ #[pyo3(name = "_my_project")]
+fn my_project(...)
+```
+
 You can then import your Rust module inside your Python source as follows:
 
 ```python


### PR DESCRIPTION
# Summary
The instructions in [Import Rust as a submodule of your project](https://www.maturin.rs/project_layout.html#import-rust-as-a-submodule-of-your-project) are incomplete.

This PR adds instructions on how to update the Rust module name.

Fixes #2455

## Current status
When updating the `tool.maturin.module-name` in `pyproject.toml` like this:

```toml
[tool.maturin]
module-name = "my_project._my_project"
```

`maturin build` emit the following warning:

> ⚠️  Warning: Couldn't find the symbol `PyInit__my_project` in the native library. Python will fail to import this module. If you're using pyo3, check that `#[pymodule]` uses `_my_project` as module name

## What is added
This PR adds documentation on how to update the module name in `lib.rs`:

Either:

```diff
#[pymodule]
- fn my_project(...)
+ fn _my_project(...)
```

Or (if using `pyo3` bindings):

```diff
#[pymodule]
+ #[pyo3(name = "_my_project")]
fn my_project(...)
```

## Alternatives
I used the `diff` markup to highlight what needs to be changed. Some people might prefer the `rust` markup to display the desired state:

```rust
#[pymodule]
fn _my_project(...)
```

and

```rust
#[pymodule]
#[pyo3(name = "_my_project")]
fn my_project(...)
```

(Thanks for this awesome project!)