### PR TITLE
Allow specifying compression method and level, in both `build` and `develop` modes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,8 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1247,6 +1249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1362,16 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
 
 [[package]]
 name = "lzma-sys"
@@ -3434,10 +3455,12 @@ dependencies = [
  "displaydoc",
  "flate2",
  "indexmap",
+ "lzma-rs",
  "memchr",
  "thiserror 2.0.3",
  "time",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -3452,4 +3475,32 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ zip = { version = "2.3.0", default-features = false, features = [
     "bzip2",
     "deflate",
     "time",
+    "zstd",
+    "lzma"
 ] }
 thiserror = "2.0.3"
 fs-err = "3.0.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.8.x]
+
+- Allow specifying compression method and level, in both `build` and `develop` modes, in [#2625](https://github.com/PyO3/maturin/pull/2625).
+
 ## [1.8.6]
 
 * Print a message when overriding platform tag from `_PYTHON_HOST_PLATFORM` in [#2594](https://github.com/PyO3/maturin/pull/2594)

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -85,9 +85,11 @@ Options:
       --compatibility [<compatibility>...]
           Control the platform tag on linux.
 
-          Options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example `musllinux_1_2`) and `linux` for the native linux tag.
+          Options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example `musllinux_1_2`) and `linux` for the native
+          linux tag.
 
-          Note that `manylinux1` and `manylinux2010` is unsupported by the rust compiler. Wheels with the native `linux` tag will be rejected by pypi, unless they are separately validated by `auditwheel`.
+          Note that `manylinux1` and `manylinux2010` is unsupported by the rust compiler. Wheels with the native `linux` tag will be rejected by pypi, unless they
+          are separately validated by `auditwheel`.
 
           The default is the lowest compatible `manylinux` tag, or plain `linux` if nothing matched
 
@@ -142,6 +144,16 @@ Options:
 
       --future-incompat-report
           Outputs a future incompatibility report at the end of the build (unstable)
+
+      --compression-method <COMPRESSION_METHOD>
+          Zip compresson method to use
+
+          [default: deflated]
+
+          Possible values:
+          - deflated: Deflate compression
+          - stored:   No compression
+          - zstd:     Zstandard compression
 
   -h, --help
           Print help (see a summary with '-h')

--- a/guide/src/local_development.md
+++ b/guide/src/local_development.md
@@ -60,6 +60,16 @@ Options:
       --uv
           Use `uv` to install packages instead of `pip`
 
+      --compression-method <COMPRESSION_METHOD>
+          Zip compresson method to use
+
+          [default: deflated]
+
+          Possible values:
+          - deflated: Deflate compression
+          - stored:   No compression
+          - zstd:     Zstandard compression
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -3,6 +3,7 @@ use crate::auditwheel::{PlatformTag, Policy};
 use crate::bridge::Abi3Version;
 use crate::build_options::CargoOptions;
 use crate::compile::{warn_missing_py_init, CompileTarget};
+use crate::compression::CompressionOptions;
 use crate::module_writer::{
     add_data, write_bin, write_bindings_module, write_cffi_module, write_python_part,
     write_uniffi_module, write_wasm_launcher, WheelWriter,
@@ -132,8 +133,8 @@ pub struct BuildContext {
     pub editable: bool,
     /// Cargo build options
     pub cargo_options: CargoOptions,
-    /// Zip compression level
-    pub compression_level: u16,
+    /// Compression options
+    pub compression: CompressionOptions,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).
@@ -671,7 +672,7 @@ impl BuildContext {
             &self.metadata24,
             &[tag.clone()],
             self.excludes(Format::Wheel)?,
-            self.compression_level,
+            self.compression,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -749,7 +750,7 @@ impl BuildContext {
             &self.metadata24,
             &[tag.clone()],
             self.excludes(Format::Wheel)?,
-            self.compression_level,
+            self.compression,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -872,7 +873,7 @@ impl BuildContext {
             &self.metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
-            self.compression_level,
+            self.compression,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -944,7 +945,7 @@ impl BuildContext {
             &self.metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
-            self.compression_level,
+            self.compression,
         )?;
         self.add_external_libs(&mut writer, &[&artifact], &[ext_libs])?;
 
@@ -1043,7 +1044,7 @@ impl BuildContext {
             &metadata24,
             &tags,
             self.excludes(Format::Wheel)?,
-            self.compression_level,
+            self.compression,
         )?;
 
         if self.project_layout.python_module.is_some() && self.target.is_wasi() {

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1,6 +1,7 @@
 use crate::auditwheel::{AuditWheelMode, PlatformTag};
 use crate::bridge::{Abi3Version, PyO3Crate};
 use crate::compile::{CompileTarget, LIB_CRATE_TYPES};
+use crate::compression::CompressionOptions;
 use crate::cross_compile::{find_sysconfigdata, parse_sysconfigdata};
 use crate::project_layout::ProjectResolver;
 use crate::pyproject_toml::ToolMaturin;
@@ -217,10 +218,9 @@ pub struct BuildOptions {
     #[command(flatten)]
     pub cargo: CargoOptions,
 
-    /// Zip compresson level to use
-    #[arg(long, value_parser = clap::value_parser!(u16).range(0..=264), hide = true, default_value="6"
-    )]
-    pub compression_level: u16,
+    /// Wheel compression options
+    #[command(flatten)]
+    pub compression: CompressionOptions,
 }
 
 impl Deref for BuildOptions {
@@ -587,6 +587,7 @@ impl BuildContextBuilder {
             editable,
             sdist_only,
         } = self;
+        build_options.compression.validate();
         let ProjectResolver {
             project_layout,
             cargo_toml_path,
@@ -807,7 +808,7 @@ impl BuildContextBuilder {
             universal2,
             editable,
             cargo_options,
-            compression_level: build_options.compression_level,
+            compression: build_options.compression,
         })
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,88 @@
+use clap::{CommandFactory, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
+/// Wheel ZIP compression method. May only be compatible with recent package manager versions.
+// See https://docs.rs/zip/latest/zip/write/struct.FileOptions.html#method.compression_level
+pub enum CompressionMethod {
+    #[default]
+    /// Deflate compression (levels 0-9, default 6)
+    // NOTE: The levels will change if we enable Zopfli!
+    Deflated,
+    /// No compression
+    Stored,
+    /// BZIP2 compression (levels 0-9, default 6)
+    Bzip2,
+    /// Zstandard compression (supported from Python 3.14; levels -7-22, default 3)
+    Zstd,
+}
+impl CompressionMethod {
+    /// Default level for this compression method
+    // NOTE: This should match the default from the `zip` crates.
+    pub fn default_level(self) -> i64 {
+        match self {
+            CompressionMethod::Deflated => 6,
+            CompressionMethod::Stored => 0,
+            CompressionMethod::Bzip2 => 6,
+            CompressionMethod::Zstd => 3,
+        }
+    }
+    /// Allowed levels for the method.
+    pub fn level_range(self) -> std::ops::RangeInclusive<i64> {
+        match self {
+            CompressionMethod::Deflated => 0..=9,
+            CompressionMethod::Stored => 0..=0,
+            CompressionMethod::Bzip2 => 0..=9,
+            CompressionMethod::Zstd => -7..=22,
+        }
+    }
+}
+impl From<CompressionMethod> for zip::CompressionMethod {
+    fn from(source: CompressionMethod) -> Self {
+        match source {
+            CompressionMethod::Deflated => zip::CompressionMethod::Deflated,
+            CompressionMethod::Stored => zip::CompressionMethod::Stored,
+            CompressionMethod::Bzip2 => zip::CompressionMethod::Bzip2,
+            CompressionMethod::Zstd => zip::CompressionMethod::ZSTD,
+        }
+    }
+}
+#[derive(Debug, Default, Serialize, Deserialize, clap::Parser, Clone, Copy, Eq, PartialEq)]
+/// Wheel ZIP compression options.
+pub struct CompressionOptions {
+    /// Zip compression method. Only Stored and Deflated are currently compatible with all
+    /// package managers.
+    #[arg(long, value_enum, default_value_t = CompressionMethod::default())]
+    pub compression_method: CompressionMethod,
+
+    /// Zip compression level. Defaults to method default.
+    #[arg(long, allow_negative_numbers = true)]
+    pub compression_level: Option<i64>,
+}
+impl CompressionOptions {
+    /// Validate arguments, exit on error
+    pub fn validate(&self) {
+        if let Some(level) = self.compression_level {
+            let range = self.compression_method.level_range();
+            if !range.contains(&level) {
+                let mut cmd = Self::command();
+                cmd.error(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    format!(
+                        "Invalid level {} for compression method {:?}. Use a level in range {:?}",
+                        level, self.compression_method, range
+                    ),
+                )
+                .exit();
+            }
+        }
+    }
+    /// No compression
+    pub fn none() -> Self {
+        let method = CompressionMethod::Stored;
+        Self {
+            compression_method: method,
+            compression_level: Some(method.default_level()),
+        }
+    }
+}

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -1,5 +1,6 @@
 use crate::auditwheel::AuditWheelMode;
 use crate::build_options::CargoOptions;
+use crate::compression::CompressionOptions;
 use crate::target::detect_arch_from_python;
 use crate::BuildContext;
 use crate::BuildOptions;
@@ -229,6 +230,10 @@ pub struct DevelopOptions {
     /// Use `uv` to install packages instead of `pip`
     #[arg(long)]
     pub uv: bool,
+
+    /// Wheel compression options
+    #[command(flatten)]
+    pub compression: CompressionOptions,
 }
 
 #[instrument(skip_all)]
@@ -387,7 +392,10 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         pip_path,
         cargo_options,
         uv,
+        compression,
     } = develop_options;
+    compression.validate();
+
     let mut target_triple = cargo_options.target.clone();
     let target = Target::from_target_triple(cargo_options.target.as_ref())?;
     let python = target.get_venv_python(venv_dir);
@@ -416,7 +424,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
             target: target_triple,
             ..cargo_options
         },
-        compression_level: 6,
+        compression,
     };
 
     let build_context = build_options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use crate::build_context::{BuildContext, BuiltWheelMetadata};
 pub use crate::build_options::{BuildOptions, CargoOptions, TargetTriple};
 pub use crate::cargo_toml::CargoToml;
 pub use crate::compile::{compile, BuildArtifact};
+pub use crate::compression::{CompressionMethod, CompressionOptions};
 pub use crate::develop::{develop, DevelopOptions};
 #[cfg(feature = "schemars")]
 pub use crate::generate_json_schema::{generate_json_schema, GenerateJsonSchemaOptions, Mode};
@@ -53,6 +54,7 @@ mod cargo_toml;
 /// Generate CI configuration
 pub mod ci;
 mod compile;
+mod compression;
 mod cross_compile;
 mod develop;
 mod generate_json_schema;

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -79,6 +79,21 @@ Options:
       --future-incompat-report
           Outputs a future incompatibility report at the end of the build (unstable)
 
+      --compression-method <COMPRESSION_METHOD>
+          Zip compression method. Only Stored and Deflated are currently compatible with all package
+          managers
+          
+          [default: deflated]
+
+          Possible values:
+          - deflated: Deflate compression (levels 0-9, default 6)
+          - stored:   No compression
+          - bzip2:    BZIP2 compression (levels 0-9, default 6)
+          - zstd:     Zstandard compression (supported from Python 3.14; levels -7-22, default 3)
+
+      --compression-level <COMPRESSION_LEVEL>
+          Zip compression level. Defaults to method default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -55,6 +55,21 @@ Options:
       --uv
           Use `uv` to install packages instead of `pip`
 
+      --compression-method <COMPRESSION_METHOD>
+          Zip compression method. Only Stored and Deflated are currently compatible with all package
+          managers
+          
+          [default: deflated]
+
+          Possible values:
+          - deflated: Deflate compression (levels 0-9, default 6)
+          - stored:   No compression
+          - bzip2:    BZIP2 compression (levels 0-9, default 6)
+          - zstd:     Zstandard compression (supported from Python 3.14; levels -7-22, default 3)
+
+      --compression-level <COMPRESSION_LEVEL>
+          Zip compression level. Defaults to method default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -125,6 +125,21 @@ Options:
       --future-incompat-report
           Outputs a future incompatibility report at the end of the build (unstable)
 
+      --compression-method <COMPRESSION_METHOD>
+          Zip compression method. Only Stored and Deflated are currently compatible with all package
+          managers
+          
+          [default: deflated]
+
+          Possible values:
+          - deflated: Deflate compression (levels 0-9, default 6)
+          - stored:   No compression
+          - bzip2:    BZIP2 compression (levels 0-9, default 6)
+          - zstd:     Zstandard compression (supported from Python 3.14; levels -7-22, default 3)
+
+      --compression-level <COMPRESSION_LEVEL>
+          Zip compression level. Defaults to method default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -71,6 +71,7 @@ pub fn test_develop(
             ..Default::default()
         },
         uv,
+        compression: Default::default(),
     };
     develop(develop_options, &venv_dir)?;
 


### PR DESCRIPTION
This is a follow-up to https://github.com/PyO3/maturin/issues/2566 that adds the ability to
- Specify other compression methods
- Control compression in the `develop` mode, not only `build`. Solves #2622

```
--compression-method <COMPRESSION_METHOD>
    Zip compresson method. Only Stored and Deflated are currently compatible with all package managers

    [default: deflated]

    Possible values:
    - deflated: Deflate compression
    - stored:   No compression
    - bzip2:    BZIP2 compression
    - zstd:     Zstandard compression (supported from Python 3.14)

--compression-level <COMPRESSION_LEVEL>
    Zip compresson level

    [default: 6]
```

Note that additional compression methods were added in `uv` 0.7.3 in https://github.com/astral-sh/uv/pull/13285 but adding local `whl` is broken until https://github.com/astral-sh/uv/pull/13781 is merged.

I tested the change locally by setting
```
        compression: maturin::CompressionOptions {
            compression_method: maturin::CompressionMethod::Bzip2,
            compression_level: 6,
        },
```
in the tests, which is supported by `pip`. I can do a follow-up PR to update the tests after `uv` is updated, possibly with a version check.