### PR TITLE
try to find interpreter version if interpreter path was given

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [1.8.x]
 
 - Allow specifying compression method and level, in both `build` and `develop` modes, in [#2625](https://github.com/PyO3/maturin/pull/2625).
+- Try to find out the interpreter version if the version was not given via `--interpreter` instead of failing immediately [#2634](https://github.com/PyO3/maturin/pull/2634).
 
 ## [1.8.6]
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1794,6 +1794,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_find_interpreter_path_version() {
         let regex = Regex::new(r"python\d\.\d+").unwrap();
         println!("{}", find_interpreter_version("python".to_string()));

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1801,5 +1801,13 @@ mod test {
             regex.is_match_at(&find_interpreter_version("python".to_string()), 0),
             true
         );
+        println!(
+            "{}",
+            find_interpreter_version("/usr/bin/python".to_string())
+        );
+        assert_eq!(
+            regex.is_match_at(&find_interpreter_version("/usr/bin/python".to_string()), 0),
+            true
+        );
     }
 }


### PR DESCRIPTION
Fixes #2633 

With this PR maturin tries to find the version of an interpreter if it is not given from the input instead of failing immediately.