### PR TITLE
`ZipWriter` requires a compression level of `None` for the `stored` method

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1610,4 +1610,27 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn wheel_writer_no_compression() -> Result<(), Box<dyn std::error::Error>> {
+        let metadata = Metadata24::new("dummy".to_string(), Version::new([1, 0]));
+        let tmp_dir = TempDir::new()?;
+
+        let writer = WheelWriter::new(
+            "no compression",
+            tmp_dir.path(),
+            &metadata,
+            &[],
+            Override::empty(),
+            CompressionOptions {
+                compression_method: CompressionMethod::Stored,
+                ..Default::default()
+            },
+        )?;
+
+        writer.finish()?;
+        tmp_dir.close()?;
+
+        Ok(())
+    }
 }

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -255,10 +255,13 @@ impl CompressionOptions {
         let mut options =
             zip::write::SimpleFileOptions::default().compression_method(method.into());
         // `zip` also has default compression levels, which should match our own, but we pass them
-        // explicitly to ensure consistency.
-        options = options.compression_level(Some(
-            self.compression_level.unwrap_or(method.default_level()),
-        ));
+        // explicitly to ensure consistency. The exception is the `Stored` method, which must have
+        // a `compression_level` of `None`.
+        options = options.compression_level(if method == CompressionMethod::Stored {
+            None
+        } else {
+            Some(self.compression_level.unwrap_or(method.default_level()))
+        });
         options
     }
 }


### PR DESCRIPTION
I tried using the `stored` compression level in Maturin 1.8.7 with my project, but I hit this error:

```
% maturin develop -b pyo3 -m path/to/Cargo.toml --compression-method stored --profile release
🔗 Found pyo3 bindings
🐍 Found CPython 3.13 at /Users/jatoben/.pyenv/versions/3.13.3/envs/project-3.13.3/bin/python
📡 Using build options features from pyproject.toml
    Finished `release` profile [optimized] target(s) in 0.02s
💥 maturin failed
  Caused by: unsupported Zip archive: Unsupported compression level
```

The same issue also occurred when I ran `cargo test --features faster-tests`.

ZipWriter [requires the compression level to be `None`](https://docs.rs/zip/2.3.0/zip/write/struct.FileOptions.html#method.compression_level) if the method is `CompressionMethod::Stored`. I didn't want to change the existing external interface, so I added a check for this case inside `CompressionOptions::get_file_options()`.