### PR TITLE
Add `git cliff` config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,33 @@
+[changelog]
+header = """
+# Changelog
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for commit in commits %}
+    - {% if commit.remote.pr_title %}\
+          {{ commit.remote.pr_title | upper_first }}\
+      {% else %}\
+          {{ commit.message | split(pat="\n") | first | upper_first }}\
+      {% endif %}\
+      {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/pyo3/maturin/pull/{{ commit.remote.pr_number }})){%- endif %}\
+{% endfor %}\n
+"""
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+commit_parsers = [
+    { field = "github.pr_labels", pattern = "internal", skip = true },
+    { message = ".*pre-commit autoupdate.*", skip = true },
+    { message = ".*", group = "Other" },
+]
+
+[remote.github]
+owner = "pyo3"
+repo = "maturin"

--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -100,3 +100,23 @@ There are some optional hacks that can speed up the tests (over 80s to 17s on my
 1. By running `cargo build --release --manifest-path test-crates/cargo-mock/Cargo.toml` you can activate a cargo cache avoiding to rebuild the pyo3 test crates with every python version.
 2. Delete `target/test-cache` to clear the cache (e.g. after changing a test crate) or remove `test-crates/cargo-mock/target/release/cargo` to deactivate it.
 3. By running the tests with the `faster-tests` feature, binaries are stripped and wheels are only stored and not compressed.
+
+## Releasing
+
+_These instructions are a work in progress_
+
+Update the changelog:
+
+```
+git cliff -u --prepend Changelog.md
+```
+
+Update the version in `Cargo.toml` and run:
+
+```
+cargo check
+```
+
+Create a PR a release PR.
+
+After the release PR merged, update main, create a git tag and push the tag.


### PR DESCRIPTION
When I started maturin, I chose the https://keepachangelog.com style for the project changelog, and would edit the changelog manually. I now want to change this to automated changelog generation and a slightly improved style.

This PR adds a [git cliff](https://git-cliff.org/) config that can generate the changelog based on commits and PR labels. The style is simplified, The version header doesn't have a link anymore, and the PR link is in parentheses behind the description.

It also adds a release guide to the contributing guidelines, with the goal of simplifying the release workflow.

Blocked on https://github.com/orhun/git-cliff/issues/1189