### PR TITLE
pyproject.toml: add license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Build and publish crates with pyo3, cffi and uniffi bindings as w
 authors = [{ name = "konstin", email = "konstin@mailbox.org" }]
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.7"
-license = { text = "MIT OR Apache-2.0" }
+license = "MIT OR Apache-2.0"
 license-files = [
     "license-mit",
     "license-apache",


### PR DESCRIPTION
Fixes: #2689

This ensures that when a maturin wheel is built, both the MIT and Apache 2.0 license files are included with the package. For example, with a v1.9.1 build:

|tgamblin@megalith ~/workspace/baylibre/rise/maturin (tgamblin/add-license-files-metadata)$ unzip -l dist/maturin-1.9.1-py3-none-manylinux_2_39_x86_64.whl | grep license
|     1051  07-23-2025 13:47   maturin-1.9.1.dist-info/licenses/license-mit
|    10847  07-23-2025 13:47   maturin-1.9.1.dist-info/licenses/license-apache