### PR TITLE
Add support for RISC-V architecture in manylinux and update compatibi…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,9 @@ jobs:
           - target: "loongarch64-unknown-linux-gnu"
             image: "manylinux_2_36-cross:loongarch64"
             compatibility: "manylinux_2_36"
+          - target: "riscv64gc-unknown-linux-gnu"
+            image: "manylinux_2_39-cross:riscv64"
+            compatibility: "manylinux_2_39"
     container:
       image: docker://ghcr.io/rust-cross/${{ matrix.platform.image }}
       env:
@@ -178,9 +181,9 @@ jobs:
       - uses: actions/checkout@v4
       # powerpc64le-unknown-linux-musl doesn't have official std library release
       - run: rustup target add --toolchain stable ${{ matrix.platform.target }}
-        if: ${{ !contains(fromJson('["powerpc64le-unknown-linux-musl", "s390x-unknown-linux-gnu", "loongarch64-unknown-linux-gnu"]'), matrix.platform.target) }}
+        if: ${{ !contains(fromJson('["powerpc64le-unknown-linux-musl", "s390x-unknown-linux-gnu", "loongarch64-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu"]'), matrix.platform.target) }}
       - uses: dtolnay/rust-toolchain@stable
-        if: contains(fromJson('["s390x-unknown-linux-gnu", "loongarch64-unknown-linux-gnu"]'), matrix.platform.target)
+        if: contains(fromJson('["s390x-unknown-linux-gnu", "loongarch64-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu"]'), matrix.platform.target)
         with:
           targets: ${{ matrix.platform.target }}
       - name: Build wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,6 +389,11 @@ jobs:
             abi: cp310-cp310
             python: python3.10
             container: ghcr.io/rust-cross/manylinux_2_36-cross:loongarch64
+          - target: riscv64gc-unknown-linux-gnu
+            abi: cp310-cp310
+            python: python3.10
+            container: ghcr.io/rust-cross/manylinux_2_39-cross:riscv64
+            extra-args: --manylinux 2_39
           # PyPy
           - target: aarch64-unknown-linux-gnu
             abi: pp310-pypy310_pp73
@@ -408,57 +413,19 @@ jobs:
         run: |
           set -ex
           # Use bundled sysconfig
-          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
+          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml ${{ matrix.platform.extra-args }}
 
           # Use PYO3_CROSS_LIB_DIR
           export PYO3_CROSS_LIB_DIR=/opt/python/${{ matrix.platform.abi }}
-          bin/maturin build -i python3.9 --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
+          bin/maturin build -i python3.9 --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml ${{ matrix.platform.extra-args }}
           unset PYO3_CROSS_LIB_DIR
 
           # Test abi3
-          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-pure/Cargo.toml
+          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-pure/Cargo.toml ${{ matrix.platform.extra-args }}
 
           # --find-interpreter
-          bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
-  test-riscv64-compile:
-    name: Test Cross Compile
-    needs: build-maturin
-    runs-on: ubuntu-latest
-    container: ${{ matrix.platform.container }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - target: riscv64gc-unknown-linux-gnu
-            abi: cp310-cp310
-            python: python3.10
-            container: ghcr.io/rust-cross/manylinux_2_39-cross:riscv64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: maturin-build
-          path: bin
-      - run: chmod +x bin/maturin
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform.target }}
-      - name: Build wheels
-        run: |
-          set -ex
-          # Use bundled sysconfig
-          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
-
-          # Use PYO3_CROSS_LIB_DIR
-          export PYO3_CROSS_LIB_DIR=/opt/python/${{ matrix.platform.abi }}
-          bin/maturin build -i python3.9 --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
-          unset PYO3_CROSS_LIB_DIR
-
-          # Test abi3
-          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-pure/Cargo.toml --manylinux 2_39
-
-          # --find-interpreter
-          bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
+          bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml ${{ matrix.platform.extra-args }}
+          
   test-bootstrap:
     name: Test Bootstrap
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -425,7 +425,7 @@ jobs:
 
           # --find-interpreter
           bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml ${{ matrix.platform.extra-args }}
-          
+
   test-bootstrap:
     name: Test Bootstrap
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,7 +420,45 @@ jobs:
 
           # --find-interpreter
           bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml
+  test-riscv64-compile:
+    name: Test Cross Compile
+    needs: build-maturin
+    runs-on: ubuntu-latest
+    container: ${{ matrix.platform.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: riscv64gc-unknown-linux-gnu
+            abi: cp310-cp310
+            python: python3.10
+            container: ghcr.io/rust-cross/manylinux_2_39-cross:riscv64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: maturin-build
+          path: bin
+      - run: chmod +x bin/maturin
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
+      - name: Build wheels
+        run: |
+          set -ex
+          # Use bundled sysconfig
+          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
 
+          # Use PYO3_CROSS_LIB_DIR
+          export PYO3_CROSS_LIB_DIR=/opt/python/${{ matrix.platform.abi }}
+          bin/maturin build -i python3.9 --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
+          unset PYO3_CROSS_LIB_DIR
+
+          # Test abi3
+          bin/maturin build -i ${{ matrix.platform.python }} --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-pure/Cargo.toml --manylinux 2_39
+
+          # --find-interpreter
+          bin/maturin build --find-interpreter --release --out dist --target ${{ matrix.platform.target }} -m test-crates/pyo3-mixed/Cargo.toml --manylinux 2_39
   test-bootstrap:
     name: Test Bootstrap
     runs-on: ${{ matrix.os }}

--- a/src/target/legacy_py.rs
+++ b/src/target/legacy_py.rs
@@ -57,7 +57,7 @@ pub(super) static IOS_ARCHES: &[&str] = &["arm64", "x86_64"];
 pub(super) static ANDROID_ARCHES: &[&str] = &["armeabi_v7a", "arm64_v8a", "x86", "x86_64"];
 
 pub(super) static MANYLINUX_ARCHES: &[&str] = &[
-    "x86_64", "i686", "aarch64", "armv7l", "ppc64le", "s390x", "ppc64",
+    "x86_64", "i686", "aarch64", "armv7l", "ppc64le", "s390x", "ppc64", "riscv64",
 ];
 
 pub(super) static MUSLLINUX_ARCHES: &[&str] =

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -483,7 +483,7 @@ impl Target {
             }
             Arch::Riscv64 => PlatformTag::Manylinux {
                 major: 2,
-                minor: 31,
+                minor: 39, // 2_39 is the minimum version supported uploaded to PyPI
             },
             Arch::LoongArch64 => PlatformTag::Manylinux {
                 major: 2,

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -483,7 +483,7 @@ impl Target {
             }
             Arch::Riscv64 => PlatformTag::Manylinux {
                 major: 2,
-                minor: 39, // 2_39 is the minimum version supported uploaded to PyPI
+                minor: 31,
             },
             Arch::LoongArch64 => PlatformTag::Manylinux {
                 major: 2,

--- a/src/target/pypi_tags.rs
+++ b/src/target/pypi_tags.rs
@@ -97,17 +97,6 @@ fn is_platform_tag_allowed_by_pypi(platform_tag: &str) -> bool {
     if let Some(captures) = LINUX_PLATFORM_RE.captures(platform_tag) {
         let libc = captures.name("libc").unwrap().as_str();
         let arch = captures.name("arch").unwrap().as_str();
-        // please see https://github.com/pypi/warehouse/pull/18390
-        if arch == "riscv64" && libc == "many" {
-            let parts: Vec<&str> = platform_tag.split('_').collect();
-            let major: u8 = parts[1].parse().expect("parse major failed");
-            let minor: u8 = parts[2].parse().expect("parse minor failed");
-            // pypi now support manylinux_2_39_riscv64
-            if major == 2 && minor >= 39 {
-                return true;
-            }
-            return false;
-        }
 
         return match libc {
             "musl" => MUSLLINUX_ARCHES.contains(&arch),

--- a/src/target/pypi_tags.rs
+++ b/src/target/pypi_tags.rs
@@ -171,7 +171,7 @@ mod tests {
             // manylinux platforms
             ("manylinux2014_x86_64", true),
             ("manylinux_2_17_aarch64", true),
-            ("manylinux_2_17_riscv64", false),
+            ("manylinux_2_17_riscv64", true),
             ("manylinux_2_39_riscv64", true),
             // musllinux platforms
             ("musllinux_1_1_x86_64", true),

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -158,7 +158,7 @@ pub fn pypi_compatibility_unsupported_target() -> Result<()> {
         "--compatibility",
         "pypi",
         "--target",
-        "riscv64gc-unknown-linux-gnu", // Unsupported by PyPI
+        "riscv32gc-unknown-linux-gnu", // Unsupported by PyPI
         "--target-dir",
         "test-crates/targets/pypi_compatibility_unsupported_target",
         "--out",
@@ -178,7 +178,7 @@ pub fn pypi_compatibility_unsupported_target() -> Result<()> {
         let err_string = err.to_string();
         assert!(
             err_string.contains(
-                "Target riscv64gc-unknown-linux-gnu architecture is not supported by PyPI"
+                "Target riscv32gc-unknown-linux-gnu architecture is not supported by PyPI"
             ),
             "{err_string}",
         );


### PR DESCRIPTION
Recently, pypi has just provided support for riscv wheel uploads. For details, please see https://github.com/pypi/warehouse/pull/18390

Here you can see that test.pypi.org has deployed support, https://github.com/pypi/warehouse/deployments/test.pypi.org

I think maturin-action can also provide support for this, mainly by setting manylinux_2_39 as the default and supported version of riscv64, so that riscv64 packages that can be uploaded to pypi can be packaged

Here are the results of my github action run, 

CI result:
[release](https://github.com/ffgan/maturin/actions/runs/16551719275)
[test](https://github.com/ffgan/maturin/actions/runs/16551720338)



The results show that riscv64 runs well


**Other Info**

Co-authored-by: @kotvaer
Co-authored-by: nijincheng@iscas.ac.cn；