### PR TITLE
Fix PEP 639 implementation, use `License-Expression` over `License`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [1.9.2]
+
+* Fix PEP 639 implementation, use `License-Expression` over `License`.
+
 ## [1.9.1]
 
 * Fix absolute license file path from `Cargo.toml` in [#2667](https://github.com/PyO3/maturin/pull/2667)

--- a/test-crates/pyo3-mixed/pyproject.toml
+++ b/test-crates/pyo3-mixed/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = ["boltons"]
+license = "MIT"
 dynamic = ["version"]
 
 [project.scripts]


### PR DESCRIPTION
We were using the old field for PEP 639 `project.license = "..."` metadata. Caught by https://github.com/scientific-python/cookie/pull/623#issuecomment-3090157407