### PR TITLE
pyproject.toml: bump setuptools for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Workaround to bootstrap maturin on non-manylinux platforms
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools>=77.0.0",
     "tomli>=1.1.0 ; python_version<'3.11'",
     "setuptools-rust>=1.11.0",
 ]


### PR DESCRIPTION
Make sure we use setuptools 77.0.0 or newer, which ensures PEP 639 support. This should've been bumped along with the changes in 7402a482, otherwise the user can run into errors like the following:

|ValueError: invalid pyproject.toml config: `project.license`.
|    configuration error: `project.license` must be valid exactly by one definition (2 matches found):
|        - keys:
|            'file': {type: string}
|          required: ['file']
|        - keys:
|            'text': {type: string}
|          required: ['text']
|    ERROR Backend subprocess exited when trying to invoke build_wheel

See also #2690.