### PR TITLE
downgrade manylinux version for riscv64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,8 @@ jobs:
             image: "manylinux_2_36-cross:loongarch64"
             compatibility: "manylinux_2_36"
           - target: "riscv64gc-unknown-linux-gnu"
-            image: "manylinux_2_39-cross:riscv64"
-            compatibility: "manylinux_2_39"
+            image: "manylinux_2_31-cross:riscv64"
+            compatibility: "manylinux_2_31"
     container:
       image: docker://ghcr.io/rust-cross/${{ matrix.platform.image }}
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -392,8 +392,8 @@ jobs:
           - target: riscv64gc-unknown-linux-gnu
             abi: cp310-cp310
             python: python3.10
-            container: ghcr.io/rust-cross/manylinux_2_39-cross:riscv64
-            extra-args: --manylinux 2_39
+            container: ghcr.io/rust-cross/manylinux_2_31-cross:riscv64
+            extra-args: --manylinux 2_31
           # PyPy
           - target: aarch64-unknown-linux-gnu
             abi: pp310-pypy310_pp73


### PR DESCRIPTION
I previously thought PyPI only supported manylinux_2_39 and above for RISC-V64, but this restriction isn't true. Therefore, I changed the image version to 2_31.
Lowering the manylinux version improves compatibility with maturin. After preliminary CI testing, I was able to package a wheel file for manylinux_2_31.

CI result:
[Test](https://github.com/ffgan/maturin/actions/runs/16770160046)
[Release](https://github.com/ffgan/maturin/actions/runs/16770152909)


Other Info
Co-authored by: nijincheng@iscas.ac.cn;