### PR TITLE
Fix calculation of platform tag for FreeBSD

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -624,7 +624,14 @@ impl BuildContext {
                 }
             }
             // FreeBSD
-            (Os::FreeBsd, _)
+            | (Os::FreeBsd, _) => {
+                format!(
+                    "{}_{}_{}",
+                    target.target_os().to_string().to_ascii_lowercase(),
+                    target.get_platform_release()?.to_ascii_lowercase(),
+                    target.target_arch().machine(),
+                )
+            }
             // NetBSD
             | (Os::NetBsd, _)
             // OpenBSD


### PR DESCRIPTION
maturin used to use the default platform tag calculation which causes trouble with several tools. When PEP 517 is used, both tools lowercase the tag to retrieve a wheel from an index making the one produced by maturin unusable. In comparison, setuptools performs lower() prior returning the tag.

This fixes #2710

Before fix:
```
📖 Found type stub file at rpds.pyi
📦 Built wheel for CPython 3.10 to /usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_STABLE_amd64.whl
/usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_STABLE_amd64.whl
Successfully built rpds_py-0.27.0-cp310-cp310-freebsd_13_5_STABLE_amd64.whl
```
after fix:
```
📖 Found type stub file at rpds.pyi
📦 Built wheel for CPython 3.10 to /usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_stable_amd64.whl
/usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_stable_amd64.whl
```
even with modified `uname -r`:
```
📖 Found type stub file at rpds.pyi
📦 Built wheel for CPython 3.10 to /usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_stable_amd64.whl
/usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_stable_amd64.whl

$ UNAME_r=13.5-RELEASE maturin pep517 build-wheel --compatibility off
🔗 Found pyo3 bindings
🐍 Found CPython 3.10 at /usr/local/bin/python3
📡 Using build options features from pyproject.toml
   Compiling target-lexicon v0.13.2
   Compiling python3-dll-a v0.2.14
   Compiling once_cell v1.21.3
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling libc v0.2.172
   Compiling autocfg v1.4.0
   Compiling heck v0.5.0
   Compiling triomphe v0.1.14
   Compiling unindent v0.2.4
   Compiling indoc v2.0.6
   Compiling archery v1.2.1
   Compiling memoffset v0.9.1
   Compiling rpds v1.1.1
   Compiling quote v1.0.40
   Compiling pyo3-build-config v0.25.1
   Compiling syn v2.0.101
   Compiling pyo3-macros-backend v0.25.1
   Compiling pyo3-ffi v0.25.1
   Compiling pyo3 v0.25.1
   Compiling pyo3-macros v0.25.1
   Compiling rpds-py v0.27.0 (/usr/home/cafe-custom-uis/rpds)
    Finished `release` profile [optimized] target(s) in 30.15s
📖 Found type stub file at rpds.pyi
📦 Built wheel for CPython 3.10 to /usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_release_amd64.whl
/usr/home/cafe-custom-uis/rpds/target/wheels/rpds_py-0.27.0-cp310-cp310-freebsd_13_5_release_amd64.whl
```
Idea taken from setuptools:
* https://github.com/pypa/setuptools/blob/9cc2f5c05c333cd4cecd2c0d9e7c5e208f2a3148/setuptools/_vendor/wheel/_bdist_wheel.py#L348-L350
* https://github.com/pypa/setuptools/blob/9cc2f5c05c333cd4cecd2c0d9e7c5e208f2a3148/setuptools/command/bdist_wheel.py#L331-L333


@emaste