### PR TITLE
Add use-base-python option to pyproject.toml

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add a `use-base-python` option to `pyproject.toml` with the same behaviour as `MATURIN_PEP517_USE_BASE_PYTHON`.
+
 ## [1.9.3]
 
 * Fix adding `project.license-files` to source distributions.

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -59,6 +59,13 @@ strip = true
 # Source distribution generator,
 # supports cargo (default) and git.
 sdist-generator = "cargo"
+# Use base Python executable instead of venv Python executable in PEP 517 build.
+#
+# This can help avoid unnecessary rebuilds, as the Python executable does not change
+# every time. It should not be set when the sdist build requires packages installed
+# in venv. This can also be set with the `MATURIN_PEP517_USE_BASE_PYTHON` environment
+# variable.
+use-base-python = false
 ```
 
 The `[tool.maturin.include]` and `[tool.maturin.exclude]` configuration are

--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -202,6 +202,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "use-base-python": {
+      "description": "Use base Python executable instead of venv Python executable in PEP 517 build.",
+      "default": false,
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -50,7 +50,7 @@ def get_maturin_pep517_args(config_settings: Optional[Mapping[str, Any]] = None)
 
 def _get_sys_executable() -> str:
     executable = sys.executable
-    if os.getenv("MATURIN_PEP517_USE_BASE_PYTHON") in {"1", "true"}:
+    if os.getenv("MATURIN_PEP517_USE_BASE_PYTHON") in {"1", "true"} or get_config().get("use-base-python"):
         # Use the base interpreter path when running inside a venv to avoid recompilation
         # when switching between venvs
         base_executable = getattr(sys, "_base_executable")

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -223,6 +223,13 @@ pub struct ToolMaturin {
     pub unstable_flags: Option<Vec<String>>,
     /// Additional rustc arguments
     pub rustc_args: Option<Vec<String>>,
+    /// Use base Python executable instead of venv Python executable in PEP 517 build.
+    //
+    // This can help avoid unnecessary rebuilds, as the Python executable does not change
+    // every time. It should not be set when the sdist build requires packages installed
+    // in venv.
+    #[serde(default)]
+    pub use_base_python: bool,
 }
 
 /// A pyproject.toml as specified in PEP 517


### PR DESCRIPTION
This adds a new `use-base-python = false` option to Maturin's `pyproject.toml` section, with the same behaviour as `MATURIN_PEP517_USE_BASE_PYTHON`. Fixes #2715.

I've added this entry to the schema manually — running `cargo run --features schemars -- generate-json-schema` introduced a whole bunch of extra changes (seemingly from the changes in cee86ffb4b66b6ba87a0d729c7019812593e7988), so didn't want to make the diff too noisy.