### PR TITLE
Fix Target::get_python_arch comment (#2712)

### DIFF
--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -378,7 +378,7 @@ impl Target {
         Ok(release)
     }
 
-    /// Returns the name python uses in `sys.platform` for this architecture.
+    /// Returns the name python uses in `platform.machine()` for this architecture.
     pub fn get_python_arch(&self) -> &str {
         match self.arch {
             Arch::Aarch64 => "aarch64",


### PR DESCRIPTION
Fix comment for the source of get_python_arch() analog in Python.

This fixes #2712