### PR TITLE
search_lib_dir: Only recurse into `build*` if it is a directory.

### DIFF
--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -155,7 +155,7 @@ fn search_lib_dir(path: impl AsRef<Path>, target: &Target) -> Result<Vec<PathBuf
             Ok(f) if starts_with(f, "_sysconfigdata") && ends_with(f, "py") => vec![f.path()],
             Ok(f) if starts_with(f, "build") && f.path().is_dir() => {
                 search_lib_dir(f.path(), target)?
-            },
+            }
             Ok(f) if starts_with(f, "lib.") => {
                 let name = f.file_name();
                 // check if right target os


### PR DESCRIPTION
This avoids issues with Python 3.14 and cross-compiling where there is a `build-details.json` file now.