### PR TITLE
update `conda` versions in test

### DIFF
--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -234,7 +234,7 @@ pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String
     // Create environments to build against, prepended with "A" to ensure that integration
     // tests are executed with these environments
     let mut interpreters = Vec::new();
-    for minor in 7..=10 {
+    for minor in 9..=12 {
         let (_, venv_python) = create_conda_env(&format!("A-maturin-env-3{minor}"), 3, minor)?;
         interpreters.push(venv_python);
     }


### PR DESCRIPTION
`conda` now supports 3.9 through 3.12

Possibly helps with the test failures seen in #2750 