### PR TITLE
feat(pep517): Default editable installs to debug builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1485,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "fs4",
+ "fs_extra",
  "glob",
  "goblin",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ schemars = { version = "0.8.16", optional = true }
 pretty_assertions = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
+fs_extra = "1.3.0"
 expect-test = "1.4.1"
 fs4 = { version = "0.12.0", features = ["fs-err3"] }
 indoc = "2.0.3"

--- a/guide/src/local_development.md
+++ b/guide/src/local_development.md
@@ -151,3 +151,8 @@ maturin develop
 
 Then Python source code changes will take effect immediately because the interpreter looks
 for the modules directly in the project source tree.
+
+By default, editable installs use the `dev` (debug) profile for faster development cycles.
+If you explicitly need a `release` build in editable mode, you can set the profile in
+`pyproject.toml` (`[tool.maturin] profile = "release"`), which overrides this default
+behavior.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -3,6 +3,12 @@
 This guide can help you upgrade code through breaking changes from one maturin version to the next.
 For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
+## From 1.9.5 to 1.9.6
+
+### Editable installs default to debug builds
+
+Editable installs (`pip install -e .`) now default to the `dev` (debug) profile instead of `release` to speed up development workflows. The `maturin develop` command is unaffected. To restore the old behavior, you can explicitly set `profile = "release"` in the `[tool.maturin]` section of your `pyproject.toml`.
+
 ## From 0.14.* to 0.15
 
 ### Build with `--no-default-features` by default when bootstrapping from sdist

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,7 +296,7 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
         } => {
             let build_context = build_options
                 .into_build_context()
-                .release(true)
+                .release(!editable)
                 .strip(strip)
                 .editable(editable)
                 .build()?;

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -974,3 +974,23 @@ fn pyo3_source_date_epoch() {
         "pyo3_source_date_epoch",
     ))
 }
+
+#[test]
+fn pep517_editable_install_is_debug() {
+    handle_result(other::test_pep517_editable_install_is_debug());
+}
+
+#[test]
+fn pep517_install_is_release() {
+    handle_result(other::test_pep517_install_is_release());
+}
+
+#[test]
+fn pep517_editable_release_override() {
+    handle_result(other::test_pep517_editable_release_override());
+}
+
+#[test]
+fn pep517_regular_dev_override() {
+    handle_result(other::test_pep517_regular_dev_override());
+}


### PR DESCRIPTION
This commit changes the default build profile for PEP 517 editable installs (`pip install -e .`) from `release` to `dev` (debug). This change is intended to speed up the development cycle for users who frequently use editable installs for testing and iteration.

The previous behavior of building in release mode can be restored by explicitly setting the profile in `pyproject.toml`:
```
[tool.maturin]
profile = "release"
```

Regular `pip install .` will continue to use the `release` profile as before.

This change also includes:
- The addition of integration tests to verify the build profiles for different installation scenarios (editable, regular, and with profile overrides).
- Fixes within the test suite to correctly handle temporary project setup and `pyproject.toml` modifications during testing.
- Updates to the documentation to reflect this new default behavior.

---

# Analysis and Solution for Issue \#2590: Editable builds should build in dev profile by default

This document summarizes the analysis, implementation plan, testing, and documentation to resolve issue #2590 in `maturin`.

## 1\. Problem Analysis

### Issue Description

The main problem is that editable installations, performed through the PEP 517 backend (e.g., with `pip install -e .`), compile the Rust code in `release` mode by default. This is inconsistent with the purpose of editable installs, which are intended for development and should be fast. The `maturin develop` command, in contrast, correctly uses the `dev` (debug) profile.

### Expected Behavior

Editable installations should use the `dev` (debug) build profile by default to speed up development cycles. Normal (non-editable) wheel builds should continue to use the `release` profile.

### Root Cause

The cause, identified in the issue and confirmed in the source code, is located in the `src/main.rs` file, within the handler for the `pep517 build-wheel` command. The build is unconditionally configured with `.release(true)`.

-----

## 2\. Proposed Solution (Code)

The solution is to make the build profile dependent on whether the installation is editable.

  - **File to Modify**: `src/main.rs`

  - **Function**: `pep517`

  - **Specific Change**:
    Modify the construction of the `build_context` for the `Pep517Command::BuildWheel` subcommand.

    **Current Code:**

    ```rust
    let build_context = build_options
        .into_build_context()
        .release(true)
        .strip(strip)
        .editable(editable)
        .build()?;
    ```

    **Proposed Code:**

    ```rust
    let build_context = build_options
        .into_build_context()
        .release(!editable) // The release profile is the inverse of editable
        .strip(strip)
        .editable(editable)
        .build()?;
    ```

This modification ensures that `release` is `false` when `editable` is `true`, and vice versa.

-----

## 3\. Test Plan

The current test suite does not specifically cover the scenario of a PEP 517 editable installation. Existing tests focus on `maturin develop` or the construction of distribution wheels.

Therefore, a new integration test will be created with the following steps:

1.  **Create a virtual environment (`venv`)** for the test.
2.  **Run `pip install -e .`** on an example crate (`test-crates/pyo3-pure`).
3.  **Capture the standard error output (`stderr`)** from the installation process, as `cargo` writes its compilation status there.
4.  **Verify the output**:
      - Ensure the output contains `dev [unoptimized + debuginfo]`.
      - Ensure the output does **not** contain `release [optimized]`.
5.  **Verify functionality**: Use the `check_installed` utility to confirm that the package is functional after installation.

This test will be added in `tests/common/other.rs` and invoked from `tests/run.rs`.

-----

## 4\. Documentation Plan

To properly document the change, modifications will be made to two files:

### a. `guide/src/local_development.md`

This is the primary location. A note will be added in the **"PEP 660 Editable Installs"** section to inform users of the new default behavior.

**Proposed content:**

> By default, editable installs use the `dev` (debug) profile for faster development cycles. If you explicitly need a `release` build in editable mode, you can set the profile in `pyproject.toml` (`[tool.maturin] profile = "release"`), which overrides this default behavior.

### b. `guide/src/migration.md`

An entry will be added to record the change in behavior for users updating `maturin`.

**Proposed content:**

> **Editable installs default to debug builds**
>
> Editable installs (`pip install -e .`) now default to the `dev` (debug) profile instead of `release` to speed up development workflows. The `maturin develop` command is unaffected. To restore the old behavior, you can explicitly set `profile = "release"` in the `[tool.maturin]` section of your `pyproject.toml`.

-----

## 5\. Manual Verification of the Change

These steps verify that the fix works by forcing `pip` to use a local version of `maturin` instead of one from PyPI.

**Step 1: Compile `maturin` into a `wheel`**

From the root directory of the `maturin` project, run the following command to compile `maturin` and package it into a `wheel`.

```bash
# Clean up previous builds (optional)
rm -rf dist

# Use cargo to run the local maturin and build a wheel of itself
cargo run -- build --out dist
```

**Step 2: Create and prepare the virtual environment**

A clean test environment is created, and `pip` is updated.

```bash
# Create the virtual environment
python3 -m venv .venv_test

# Activate the environment
source .venv_test/bin/activate

# Upgrade pip
pip install --upgrade pip
```

*(On Windows, activation is `.\.venv_test\Scripts\activate`)*

**Step 3: Install the local `maturin` `wheel`**

Install the `maturin` you just compiled into the test environment.

```bash
pip install dist/*.whl
```

**Step 4: Perform the editable installation**

Now, install the test package in editable mode. The `--no-build-isolation` flag is crucial for `pip` to use the `maturin` we installed in the previous step.

```bash
pip install -v -e test-crates/pyo3-pure --no-deps --no-build-isolation
```

**Step 5: Verify the Output**

The output of the last command should include the line confirming a debug build:

```
Finished dev [unoptimized + debuginfo] target(s) in ...s
```

**Step 6: Clean Up (Optional)**

```bash
deactivate
rm -rf .venv_test
```

---

## 6. Debugging Cascading Errors During Testing

During the implementation of the integration tests, a series of cascading errors arose that were not directly related to the main change but had to be resolved to validate the solution.

The confusion about why seemingly unrelated errors (like failures with the Python interpreter) were appearing is clarified by understanding the sequence in which they were discovered and fixed:

1.  **Initial Error (`pyproject.toml` not found):** The test was failing because the test project's files were not being copied to the correct temporary directory. This was solved by using the `content_only = true` option when copying.
2.  **Second Error (Duplicate TOML):** Once the above was fixed, the test started failing due to a format error in `pyproject.toml` (`TOMLDecodeError`). This occurred because the test script was adding a duplicate `[tool.maturin]` section. It was corrected to modify the existing section instead of adding a new one.
3.  **Third Error (`python3.12` Interpreter):** With the test configuration errors resolved, a failure emerged in the `pypi_compatibility_mixed_tags` test. This test was failing because it was trying to get metadata from the `python3.12` interpreter before performing an argument validation that would have terminated the execution earlier. The real problem was an incorrect order of operations within `maturin`, which was exposed thanks to the previous fixes.
4.  **Fourth Error (Compilation Failure - borrow checker):** Correcting the order of operations introduced a Rust compiler error (`borrow of partially moved value`). This was solved by cloning the necessary data instead of moving it, thus satisfying the borrow checker.

In summary, the initial changes to implement the main functionality did not introduce these errors but rather fixed other problems that were hiding them. The debugging process was like "peeling the layers of an onion," where solving one problem revealed the next.
