### PR TITLE
Export all Cargo URL metadata items to Python

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -480,6 +480,12 @@ impl Metadata24 {
         };
         let name = package.name.clone();
         let mut project_url = IndexMap::new();
+        if let Some(homepage) = package.homepage.as_ref() {
+            project_url.insert("Homepage".to_string(), homepage.clone());
+        }
+        if let Some(documentation) = package.documentation.as_ref() {
+            project_url.insert("Documentation".to_string(), documentation.clone());
+        }
         if let Some(repository) = package.repository.as_ref() {
             project_url.insert("Source Code".to_string(), repository.clone());
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -814,6 +814,7 @@ A test project
             Author: konstin <konstin@mailbox.org>
             Author-email: konstin <konstin@mailbox.org>
             Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM
+            Project-URL: Homepage, https://example.org
 
             # Some test package
 


### PR DESCRIPTION
Currently, only the repository URL is exported to projects that set `dynamic = ["urls", …]`, whereas the [Cargo format knows three URLs](https://doc.rust-lang.org/cargo/reference/manifest.html?highlight=url) – repository, documentation and homepage.

With this change, they are exported under their respective [well-known Python labels](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels).

Tested on https://github.com/chrysn/cbor-diag-py/pull/17, where using it produces this delta (that project has no home page):

```patch
 Description-Content-Type: text/x-rst; charset=UTF-8
+Project-URL: Documentation, https://cbor-diag.readthedocs.io
 Project-URL: Source Code, https://github.com/chrysn/cbor-diag-py
```