### PR TITLE
[docs] Add full pyproject.toml example to dynamic metadata docs

### DIFF
--- a/guide/src/metadata.md
+++ b/guide/src/metadata.md
@@ -76,12 +76,20 @@ When the `[project]` section is not present, maturin will populate metadata from
 
 When the `[project]` section is present, maturin will merge metadata from `Cargo.toml` and `pyproject.toml`, `pyproject.toml` takes precedence over `Cargo.toml`.
 Per specification, maturin is not allowed to populate fields that are not present in `project.dynamic` list when the `[project]` section is present.
-For example, to use the Rust crate version as the Python package version, you need to add `version` to the `project.dynamic` list:
+For example, to use the Rust crate version as the Python package version, you need to add `version` to the `project.dynamic` list and so forth:
 
 ```toml
 [project]
 name = "my-awesome-project"
-dynamic = ["version"]
+dynamic = [
+    "version",
+    "description",
+    "readme",
+    "urls",
+    "authors",
+    "license",
+    "keywords",
+]
 ```
 
 ## Add Python dependencies


### PR DESCRIPTION
Hi 👋 

Took me a while to figure out this exhaustive list as part of https://github.com/oconnor663/blake3-py/pull/88. 
- I didn't understand why maturin [fails](https://github.com/oconnor663/blake3-py/actions/runs/18435038379/job/52527366829#step:10:66) if I try to make `name` dynamic too. 
- Also License will be missing from the wheel even if [project] is not defined at all, which is also undocumented, see https://github.com/oconnor663/blake3-py/pull/69. edit: https://github.com/PyO3/maturin/issues/2773
```pytb
💥 maturin failed
  Caused by: pyproject.toml at /Users/runner/work/blake3-py/blake3-py/pyproject.toml is invalid
Error: The process '/Users/runner/work/_temp/a0ba2459-b23c-41be-b302-c3f2eeef0ed3/maturin' failed with exit code 1
  Caused by: TOML parse error at line 1, column 1
    at ExecState._setResult (/Users/runner/work/_actions/PyO3/maturin-action/v1.49.4/dist/index.js:1823:25)
  |
    at ExecState.CheckComplete (/Users/runner/work/_actions/PyO3/maturin-action/v1.49.4/dist/index.js:1806:18)
1 | [project]
    at ChildProcess.<anonymous> (/Users/runner/work/_actions/PyO3/maturin-action/v1.49.4/dist/index.js:1700:27)
  | ^^^^^^^^^
    at ChildProcess.emit (node:events:524:28)
missing field `name`
    at maybeClose (node:internal/child_process:1104:16)

    at Socket.<anonymous> (node:internal/child_process:456:11)
Error: The process '/Users/runner/work/_temp/a0ba2459-b23c-41be-b302-c3f2eeef0ed3/maturin' failed with exit code 1
    at Socket.emit (node:events:524:28)
    at Pipe.<anonymous> (node:net:343:12)
```