### PR TITLE
Remove shebang from non-executable __init__.py file

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 maturin's implementation of the PEP 517 interface. Calls maturin through subprocess
 


### PR DESCRIPTION
This shebang line doesn’t appear to be doing anything useful. Originally patched downstream in the Fedora package by @decathorpe.