### PR TITLE
Update base64 dependency from 0.21 to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,12 +118,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -380,7 +374,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "encoding_rs",
 ]
 
@@ -1458,7 +1452,7 @@ name = "maturin"
 version = "1.9.6"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64",
  "bytesize",
  "cargo-config2",
  "cargo-options",
@@ -2079,7 +2073,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc36545d1021456a751b573517cb52e8c339b2f662e6b2778ef629282678de29"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "charset",
  "chumsky",
  "memchr",
@@ -2186,7 +2180,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -2897,7 +2891,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b30e6f97efe1fa43535ee241ee76967d3ff6ff3953ebb430d8d55c5393029e7b"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "litemap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ name = "maturin"
 
 [dependencies]
 anyhow = "1.0.80"
-base64 = "0.21.0"
+base64 = "0.22.0"
 glob = "0.3.0"
 cargo-config2 = "0.1.24"
 cargo_metadata = "0.19.0"


### PR DESCRIPTION
This does not appear to require any source-code changes or introduce any test regressions.