### PR TITLE
fix: Rename inferred cdylib name for uniffi

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -1196,10 +1196,7 @@ fn generate_uniffi_bindings(
     }
 
     // uniffi bindings hardcoded the extension filenames
-    let cdylib_name = match cdylib_name {
-        Some(name) => name,
-        None => format!("uniffi_{py_binding_name}"),
-    };
+    let cdylib_name = cdylib_name.unwrap_or(py_binding_name);
     let cdylib = match target_os {
         Os::Macos => format!("lib{cdylib_name}.dylib"),
         Os::Windows => format!("{cdylib_name}.dll"),


### PR DESCRIPTION
This fixes the following remark inside of #2294.

> Similarly, odict.py attempts to read from libpyodict.dylib, which doesn't exist unless I manually override the cdylib name to be pyodict, but that could be a separate issue.

By default, uniffi assumes the cdylib for a cate `foo` is named `libfoo.ext` where `ext` is the platform specific cdylib extension. However, maturin places the the cdylib under `libuniffi_foo.ext`, breaking the binding code.

Thus, this PR removes the maturin added prefix.