### PR TITLE
rename `mod test` -> `mod tests` for consistency

### DIFF
--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -563,7 +563,7 @@ pub fn relpath(to: &Path, from: &Path) -> PathBuf {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::auditwheel::audit::relpath;
     use crate::Target;
     use pretty_assertions::assert_eq;

--- a/src/auditwheel/policy.rs
+++ b/src/auditwheel/policy.rs
@@ -120,7 +120,7 @@ impl Policy {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{Arch, Policy, MANYLINUX_POLICIES, MUSLLINUX_POLICIES};
     use crate::PlatformTag;
     use pretty_assertions::assert_eq;

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1354,7 +1354,7 @@ fn emcc_version() -> Result<String> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::macosx_deployment_target;
     use pretty_assertions::assert_eq;
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1626,7 +1626,7 @@ impl CargoOptions {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use cargo_metadata::MetadataCommand;
     use pretty_assertions::assert_eq;
     use std::path::Path;

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -107,7 +107,7 @@ pub struct RemainingCoreMetadata {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use indoc::indoc;
 

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -504,7 +504,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::path::PathBuf;
 
     use super::parse_direct_url_path;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -717,7 +717,7 @@ fn fold_header(text: &str) -> String {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use cargo_metadata::MetadataCommand;
     use expect_test::{expect, Expect};

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -459,7 +459,7 @@ suppress_build_script_link_lines=false"#,
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use expect_test::expect;
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
A very small tidy up; `mod tests` is the convention I usually see across the ecosystem, `maturin` had a mix of `mod test` and `mod tests`.