### PR TITLE
`--profile` conflicts with `--release` (and/or `--debug`)

### DIFF
--- a/src/develop.rs
+++ b/src/develop.rs
@@ -198,7 +198,7 @@ pub struct DevelopOptions {
     )]
     pub bindings: Option<String>,
     /// Pass --release to cargo
-    #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS,)]
+    #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS, conflicts_with = "profile")]
     pub release: bool,
     /// Strip the library for minimum file size
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ enum Command {
     /// Build the crate into python packages
     Build {
         /// Build artifacts in release mode, with optimizations
-        #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+        #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS, conflicts_with = "profile")]
         release: bool,
         /// Strip the library for minimum file size
         #[arg(long)]
@@ -78,7 +78,7 @@ enum Command {
     /// Build and publish the crate as python packages to pypi
     Publish {
         /// Do not pass --release to cargo
-        #[arg(long)]
+        #[arg(long, conflicts_with = "profile")]
         debug: bool,
         /// Do not strip the library for minimum file size
         #[arg(long = "no-strip")]


### PR DESCRIPTION
This makes `maturin` behave like `cargo` when passing `--release --profile dev`, e.g.

```
$ cargo build --release --profile dev
error: the argument '--release' cannot be used with '--profile <PROFILE-NAME>'
```

we now get similar from `maturin`

```
$ cargo run -- build --release --profile dev
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/maturin build --release --profile dev`
error: the argument '--release' cannot be used with '--profile <PROFILE-NAME>'
```