### PR TITLE
respect CLI profile over pyproject.toml

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -113,8 +113,6 @@ pub struct BuildContext {
     /// The directory to store the built wheels in. Defaults to a new "wheels"
     /// directory in the project's target directory
     pub out: PathBuf,
-    /// Build artifacts in release mode, with optimizations
-    pub release: bool,
     /// Strip the library for minimum file size
     pub strip: bool,
     /// Checking the linked libraries for manylinux/musllinux compliance

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -549,7 +549,6 @@ impl BuildOptions {
 #[derive(Debug)]
 pub struct BuildContextBuilder {
     build_options: BuildOptions,
-    release: bool,
     strip: bool,
     editable: bool,
     sdist_only: bool,
@@ -559,16 +558,10 @@ impl BuildContextBuilder {
     fn new(build_options: BuildOptions) -> Self {
         Self {
             build_options,
-            release: false,
             strip: false,
             editable: false,
             sdist_only: false,
         }
-    }
-
-    pub fn release(mut self, release: bool) -> Self {
-        self.release = release;
-        self
     }
 
     pub fn strip(mut self, strip: bool) -> Self {
@@ -589,7 +582,6 @@ impl BuildContextBuilder {
     pub fn build(self) -> Result<BuildContext> {
         let Self {
             build_options,
-            release,
             strip,
             editable,
             sdist_only,
@@ -819,7 +811,6 @@ impl BuildContextBuilder {
             manifest_path: cargo_toml_path,
             target_dir,
             out: wheel_dir,
-            release,
             strip,
             auditwheel,
             #[cfg(feature = "zig")]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -170,11 +170,6 @@ fn cargo_build_command(
         .into_rustc_options(user_specified_target);
     cargo_rustc.message_format = vec!["json-render-diagnostics".to_string()];
 
-    // --release and --profile are conflicting options
-    if context.release && cargo_rustc.profile.is_none() {
-        cargo_rustc.release = true;
-    }
-
     // Add `--crate-type cdylib` if available
     if compile_target
         .target

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -390,11 +390,16 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         extras,
         skip_install,
         pip_path,
-        cargo_options,
+        mut cargo_options,
         uv,
         compression,
     } = develop_options;
     compression.validate();
+
+    // set profile to release if specified; `--release` and `--profile` are mutually exclusive
+    if release {
+        cargo_options.profile = Some("release".to_string());
+    }
 
     let mut target_triple = cargo_options.target.clone();
     let target = Target::from_target_triple(cargo_options.target.as_ref())?;
@@ -429,7 +434,6 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 
     let build_context = build_options
         .into_build_context()
-        .release(release)
         .strip(strip)
         .editable(true)
         .build()?;

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -24,7 +24,6 @@ pub fn pyo3_no_extension_module() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build()?
@@ -62,7 +61,6 @@ pub fn locked_doesnt_build_without_cargo_lock() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();
@@ -100,7 +98,6 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build()?
@@ -169,7 +166,6 @@ pub fn pypi_compatibility_unsupported_target() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();
@@ -210,7 +206,6 @@ pub fn pypi_compatibility_mixed_tags() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -132,7 +132,6 @@ pub fn test_integration(
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let build_context = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build()?;
@@ -260,7 +259,6 @@ pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String
 
     let build_context = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build()?;

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -70,7 +70,6 @@ pub fn test_musl() -> Result<bool> {
 
     let build_context = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build()?;
@@ -114,7 +113,6 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
 
     let build_context = options
         .into_build_context()
-        .release(false)
         .strip(false)
         .editable(false)
         .build()?;
@@ -149,7 +147,6 @@ pub fn test_source_distribution(
 
     let mut build_context = build_options
         .into_build_context()
-        .release(false)
         .strip(false)
         .editable(false)
         .sdist_only(true)
@@ -225,7 +222,6 @@ fn build_wheel_files(package: impl AsRef<Path>, unique_name: &str) -> Result<Zip
 
     let build_context = build_options
         .into_build_context()
-        .release(false)
         .strip(false)
         .editable(false)
         .build()?;
@@ -286,7 +282,6 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
     ])?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();
@@ -303,7 +298,6 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
     ])?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();
@@ -324,7 +318,6 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
         ])?;
         let result = options
             .into_build_context()
-            .release(false)
             .strip(cfg!(feature = "faster-tests"))
             .editable(false)
             .build();
@@ -341,7 +334,6 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
         ])?;
         let result = options
             .into_build_context()
-            .release(false)
             .strip(cfg!(feature = "faster-tests"))
             .editable(false)
             .build();
@@ -367,7 +359,6 @@ pub fn abi3_without_version() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .release(false)
         .strip(cfg!(feature = "faster-tests"))
         .editable(false)
         .build();


### PR DESCRIPTION
Fixes #2787 

This tweaks the order of application of the `--release` flag so that it's merged into the `--profile` flag at the right time to respect precedence of
- cli options
- pyproject.toml configuration
- default values

I verified it works well locally. I would love some guidance how to test this.