### PR TITLE
Template: use Pyo3 0.27 and inline module

### DIFF
--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 {% if bindings == "pyo3" -%}
-pyo3 = "0.26.0"
+pyo3 = "0.27.0"
 {% elif bindings == "uniffi" -%}
 uniffi = "0.28.0"
 

--- a/src/templates/lib.rs.j2
+++ b/src/templates/lib.rs.j2
@@ -1,17 +1,16 @@
 {%- if bindings == "pyo3" -%}
 use pyo3::prelude::*;
 
-/// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
-
 /// A Python module implemented in Rust.
 #[pymodule]
-fn {{crate_name}}(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
-    Ok(())
+mod {{crate_name}} {
+    use pyo3::prelude::*;
+
+    /// Formats the sum of two numbers as string.
+    #[pyfunction]
+    fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+        Ok((a + b).to_string())
+    }
 }
 {%- elif bindings == "uniffi" -%}
 fn add(a: u32, b: u32) -> u32 {


### PR DESCRIPTION
Follows PyO3 doc migration to push for inline modules for pymodules