### PR TITLE
Template: update rust edition to 2024

### DIFF
--- a/src/templates/Cargo.toml.j2
+++ b/src/templates/Cargo.toml.j2
@@ -1,7 +1,7 @@
 [package]
 name = "{{ name }}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 {%- if bindings != "bin" %}


### PR DESCRIPTION
Fixes https://github.com/PyO3/maturin/issues/2518
The template should be updated to the latest rust edition to give new users the best experience.
Note: This project itself can't update to rust 2024 edition until the MSRV is raised to 1.85
See also: previous PR bumping 2018 => 2021 https://github.com/PyO3/maturin/pull/874