### PR TITLE
chore: clean up various logic for rust versions under MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,6 @@ dependencies = [
  "rustflags",
  "rustls",
  "rustls-pemfile",
- "rustversion",
  "same-file",
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,6 @@ indoc = "2.0.3"
 insta = "1.34.0"
 pretty_assertions = "1.3.0"
 rstest = "0.22.0"
-rustversion = "1.0.9"
 time = { version = "0.3.34", features = ["macros"] }
 trycmd = "0.15.0"
 which = "7.0.0"

--- a/guide/src/sphinx.md
+++ b/guide/src/sphinx.md
@@ -38,7 +38,7 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.9"
-    rust: "1.55"
+    rust: "1.86"
 
 python:
   install:

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1358,29 +1358,25 @@ mod tests {
 
     #[test]
     fn test_macosx_deployment_target() {
-        let rustc_ver = rustc_version::version().unwrap();
-        let rustc_ver = (rustc_ver.major, rustc_ver.minor);
-        let x86_64_minor = if rustc_ver >= (1, 74) { 12 } else { 7 };
-        let universal2_minor = if rustc_ver >= (1, 74) { 12 } else { 9 };
         assert_eq!(
             macosx_deployment_target(None, false).unwrap(),
-            ((10, x86_64_minor), (11, 0))
+            ((10, 12), (11, 0))
         );
         assert_eq!(
             macosx_deployment_target(None, true).unwrap(),
-            ((10, universal2_minor), (11, 0))
+            ((10, 12), (11, 0))
         );
         assert_eq!(
             macosx_deployment_target(Some("10.6"), false).unwrap(),
-            ((10, x86_64_minor), (11, 0))
+            ((10, 12), (11, 0))
         );
         assert_eq!(
             macosx_deployment_target(Some("10.6"), true).unwrap(),
-            ((10, universal2_minor), (11, 0))
+            ((10, 12), (11, 0))
         );
         assert_eq!(
             macosx_deployment_target(Some("10.9"), false).unwrap(),
-            ((10, universal2_minor), (11, 0))
+            ((10, 12), (11, 0))
         );
         assert_eq!(
             macosx_deployment_target(Some("11.0.0"), false).unwrap(),

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,3 @@
-use crate::target::RUST_1_64_0;
 #[cfg(feature = "zig")]
 use crate::PlatformTag;
 use crate::{BridgeModel, BuildContext, PythonInterpreter, Target};
@@ -177,12 +176,8 @@ fn cargo_build_command(
         .iter()
         .any(|crate_type| LIB_CRATE_TYPES.contains(crate_type))
     {
-        // `--crate-type` is stable since Rust 1.64.0
-        // See https://github.com/rust-lang/cargo/pull/10838
-        if target.rustc_version.semver >= RUST_1_64_0 {
-            debug!("Setting crate_type to cdylib for Rust >= 1.64.0");
-            cargo_rustc.crate_type = vec!["cdylib".to_string()];
-        }
+        debug!("Setting crate_type to cdylib");
+        cargo_rustc.crate_type = vec!["cdylib".to_string()];
     }
 
     let target_triple = target.target_triple();

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -22,8 +22,6 @@ mod pypi_tags;
 
 pub use pypi_tags::{is_arch_supported_by_pypi, validate_wheel_filename_for_pypi};
 
-pub(crate) const RUST_1_64_0: semver::Version = semver::Version::new(1, 64, 0);
-
 /// All supported operating system
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -469,18 +467,13 @@ impl Target {
     /// Returns the oldest possible Manylinux tag for this architecture
     pub fn get_minimum_manylinux_tag(&self) -> PlatformTag {
         match self.arch {
-            Arch::Aarch64 | Arch::Armv7L | Arch::Powerpc64 | Arch::Powerpc64Le | Arch::S390X => {
-                PlatformTag::manylinux2014()
-            }
-            Arch::X86 | Arch::X86_64 => {
-                // rustc 1.64.0 bumps glibc requirement to 2.17
-                // see https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
-                if self.rustc_version.semver >= RUST_1_64_0 {
-                    PlatformTag::manylinux2014()
-                } else {
-                    PlatformTag::manylinux2010()
-                }
-            }
+            Arch::Aarch64
+            | Arch::Armv7L
+            | Arch::Powerpc64
+            | Arch::Powerpc64Le
+            | Arch::S390X
+            | Arch::X86
+            | Arch::X86_64 => PlatformTag::manylinux2014(),
             Arch::Riscv64 => PlatformTag::Manylinux {
                 major: 2,
                 minor: 31,

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -160,13 +160,9 @@ pub fn test_integration(
             && !build_context.target.is_musl_libc()
             && build_context.target.get_minimum_manylinux_tag() != PlatformTag::Linux
         {
-            let rustc_ver = rustc_version::version()?;
             let python_arch = build_context.target.get_python_arch();
-            let file_suffix = if rustc_ver >= semver::Version::new(1, 64, 0) {
-                format!("manylinux_2_17_{python_arch}.manylinux2014_{python_arch}.whl")
-            } else {
-                format!("manylinux_2_12_{python_arch}.manylinux2010_{python_arch}.whl")
-            };
+            let file_suffix =
+                format!("manylinux_2_17_{python_arch}.manylinux2014_{python_arch}.whl");
             assert!(filename.to_string_lossy().ends_with(&file_suffix))
         }
         let mut venv_name = if supported_version == "py3" {

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -913,7 +913,6 @@ fn workspace_with_path_dep_git_sdist_generator() {
     ))
 }
 
-#[rustversion::since(1.64)]
 #[test]
 fn workspace_inheritance_sdist() {
     handle_result(other::test_source_distribution(


### PR DESCRIPTION
MSRV was bumped to 1.83 in https://github.com/PyO3/maturin/pull/2790
While reading through the codebase working on other changes I encountered a few hard-to-grep logic checks for rust versions below the MSRV of this project. Thus it can be cleaned up.