### PR TITLE
Fix a few typos in the guide

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,7 +37,7 @@
 ## [1.9.0]
 
 * Add full PEP 639 support for `project.license` and `project.license-files` in [#2647](https://github.com/PyO3/maturin/pull/2647).
-* Add `--compatiblity pypi` to only build wheels with platform tags that can also be uploaded to PyPI. This blocks e.g. building for riscv64, which is supported by manylinux, but not by PyPI.
+* Add `--compatibility pypi` to only build wheels with platform tags that can also be uploaded to PyPI. This blocks e.g. building for riscv64, which is supported by manylinux, but not by PyPI.
 
 ## [1.8.7]
 

--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -67,7 +67,7 @@ Ready to contribute? Here's how to setup maturin for local development.
    ```
 8. Submit a pull request through the [GitHub website](https://github.com/PyO3/maturin/pulls).
 
-We provide a pre-configured [dev container](https://containers.dev/) that could be used in [Github Codespaces](https://github.com/features/codespaces), [VSCode](https://code.visualstudio.com/), [JetBrains](https://www.jetbrains.com/remote-development/gateway/), [JuptyerLab](https://jupyterlab.readthedocs.io/en/stable/).
+We provide a pre-configured [dev container](https://containers.dev/) that could be used in [Github Codespaces](https://github.com/features/codespaces), [VSCode](https://code.visualstudio.com/), [JetBrains](https://www.jetbrains.com/remote-development/gateway/), [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/).
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/pyo3/maturin?quickstart=1&machine=standardLinux32gb)
 

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -102,7 +102,7 @@ Options:
           Outputs a future incompatibility report at the end of the build (unstable)
 
       --compression-method <COMPRESSION_METHOD>
-          Zip compresson method to use
+          Zip compression method to use
 
           [default: deflated]
 

--- a/guide/src/local_development.md
+++ b/guide/src/local_development.md
@@ -61,7 +61,7 @@ Options:
           Use `uv` to install packages instead of `pip`
 
       --compression-method <COMPRESSION_METHOD>
-          Zip compresson method to use
+          Zip compression method to use
 
           [default: deflated]
 


### PR DESCRIPTION
They were found thanks to the [typos](https://github.com/crate-ci/typos) tool.