### PR TITLE
Add Cygwin support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ fat-macho = { version = "0.4.8", default-features = false }
 once_cell = "1.7.2"
 rustc_version = "0.4.0"
 semver = "1.0.22"
-target-lexicon = "0.13.0"
+target-lexicon = "0.13.3"
 indexmap = "2.2.3"
 pyproject-toml = { version = "0.13.5", features = ["pep639-glob"] }
 python-pkginfo = "0.6.6"

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -662,6 +662,14 @@ impl BuildContext {
             (Os::Wasi, Arch::Wasm32) => {
                 "any".to_string()
             }
+            // Cygwin
+            (Os::Cygwin, _) => {
+                format!(
+                    "{}_{}",
+                    target.target_os().to_string().to_ascii_lowercase(),
+                    target.get_platform_arch()?,
+                )
+            }
             // osname_release_machine fallback for any POSIX system
             (_, _) => {
                 let info = PlatformInfo::new()

--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -874,7 +874,11 @@ pub fn write_bindings_module(
     let ext_name = &project_layout.extension_name;
     let so_filename = if is_abi3 {
         if target.is_unix() {
-            format!("{ext_name}.abi3.so")
+            if target.is_cygwin() {
+                format!("{ext_name}.abi3.dll")
+            } else {
+                format!("{ext_name}.abi3.so")
+            }
         } else {
             match python_interpreter {
                 Some(python_interpreter) if python_interpreter.is_windows_debug() => {

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -292,6 +292,8 @@ fn fun_with_abiflags(
     if bridge != &BridgeModel::Cffi
         && target.get_python_os() != message.system
         && !target.cross_compiling()
+        && !(target.get_python_os() == "cygwin"
+            && message.system.to_lowercase().starts_with("cygwin"))
     {
         bail!(
             "platform.system() in python, {}, and the rust target, {:?}, don't match ಠ_ಠ",

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -43,6 +43,7 @@ pub enum Os {
     Wasi,
     Aix,
     Hurd,
+    Cygwin,
 }
 
 impl fmt::Display for Os {
@@ -63,6 +64,7 @@ impl fmt::Display for Os {
             Os::Wasi => write!(f, "Wasi"),
             Os::Aix => write!(f, "AIX"),
             Os::Hurd => write!(f, "Hurd"),
+            Os::Cygwin => write!(f, "Cygwin"),
         }
     }
 }
@@ -209,6 +211,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
         Os::Emscripten | Os::Wasi => vec![Arch::Wasm32],
         Os::Aix => vec![Arch::Powerpc64],
         Os::Hurd => vec![Arch::X86, Arch::X86_64],
+        Os::Cygwin => vec![Arch::X86, Arch::X86_64],
     }
 }
 
@@ -283,6 +286,7 @@ impl Target {
             OperatingSystem::Wasi | OperatingSystem::WasiP1 | OperatingSystem::WasiP2 => Os::Wasi,
             OperatingSystem::Aix => Os::Aix,
             OperatingSystem::Hurd => Os::Hurd,
+            OperatingSystem::Cygwin => Os::Cygwin,
             unsupported => bail!("The operating system {:?} is not supported", unsupported),
         };
 
@@ -463,6 +467,7 @@ impl Target {
             Os::Wasi => "wasi",
             Os::Aix => "aix",
             Os::Hurd => "gnu",
+            Os::Cygwin => "cygwin",
         }
     }
 
@@ -558,7 +563,8 @@ impl Target {
             | Os::Emscripten
             | Os::Wasi
             | Os::Aix
-            | Os::Hurd => true,
+            | Os::Hurd
+            | Os::Cygwin => true,
         }
     }
 
@@ -608,6 +614,12 @@ impl Target {
     #[inline]
     pub fn is_msvc(&self) -> bool {
         self.env == Environment::Msvc
+    }
+
+    /// Returns true if the current platform is cygwin
+    #[inline]
+    pub fn is_cygwin(&self) -> bool {
+        self.os == Os::Cygwin
     }
 
     /// Returns true if the current platform is illumos


### PR DESCRIPTION
Add Cygwin to all OS logic and bump `target-lexicon` dependency to 0.13.3 for Cygwin support.

In `fun_with_abiflags()` add a special case for cygwin, since `platform.system()` returns something like `"CYGWIN_NT-10.0-26200"` there, and not just `"Cygwin"` alone like with other systems.

In `get_platform_tag()` default to something like `"cygwin-x86_64"`, which doesn't match `sysconfig.get_platform()` in upstream Cygwin currently, but is proposed here to make pip happy:
https://cygwin.com/pipermail/cygwin-apps/2025-October/044659.html

In `write_bindings_module()` use `".abi3.dll"` for abi3 builds, as `importlib.machinery.EXTENSION_SUFFIXES` looks like
`['.cpython-39-x86_64-cygwin.dll', '.abi3.dll', '.dll']` on Cygwin.

With this, one gets a working maturin when building with `--no-default-features --features cli-completion,scaffolding`. The other features pull in abandoned crates that don't work on Cygwin, like https://github.com/PyO3/maturin/issues/1858

Fixes #2818

Co-authored-by: @Kreijstal