### PR TITLE
Ensure parent directory exists before writing a file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix generated WHEEL Tag metadata to be spec compliant.
+* Ensure parent directory is created before attempting to write a file in ModuleWriter
 
 ## [1.9.6]
 


### PR DESCRIPTION
I ran into a bug when I moved my `LICENSE` file from the root of the repository to `LICENSES/MIT.txt` and updated the `license-file` directive in my `pyproject.toml` to match. `uv build --sdist .` and `uv build --wheel .` both had no issues, but running `uv lock -U` reported an error.

I tracked the issue down to the fact that both `WheelWriter` and `SdistWriter` don't care about adding directories and just stub out their implementation of `add_directory()`, but `PathWriter` does, and it needs the parent directory to exist before the file is written.

In this PR I ensured that all non-test code that calls `add_bytes_with_permissions()` calls `add_directory()` first. I considered giving `add_bytes_with_permissions()` a default impl that calls `add_directory()` and adding a layer of indirection to the trait but decided against it.

Alternately, given that 2 of the 3 main implementations of `ModuleWriter` don't care about directories, maybe `add_directory()` shouldn't be part of the trait and should be an internal implementation detail for the `PathWriter` implementation of `add_bytes_with_permissions()`? (See https://github.com/PyO3/maturin/pull/2824 for a take at this)