### PR TITLE
Remove add_directory() from ModuleWriter trait

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix generated WHEEL Tag metadata to be spec compliant.
+* Remove `add_directory()` from ModuleWriter and make it an implementation detail for the specific impl
 
 ## [1.9.6]
 

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -422,7 +422,6 @@ impl BuildContext {
             .unwrap_or_else(|| self.module_name.clone().into());
         libs_dir.push(".libs");
         let libs_dir = PathBuf::from(libs_dir);
-        writer.add_directory(&libs_dir)?;
 
         let temp_dir = tempfile::tempdir()?;
         let mut soname_map = BTreeMap::new();

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -267,8 +267,6 @@ fn add_crate_to_source_distribution(
         })
         .collect();
 
-    writer.add_directory(prefix)?;
-
     let cargo_toml_path = prefix.join(manifest_path.file_name().unwrap());
 
     let readme_name = readme
@@ -425,8 +423,6 @@ fn add_git_tracked_files_to_sdist(
     }
 
     let prefix = prefix.as_ref();
-    writer.add_directory(prefix)?;
-
     let file_paths = str::from_utf8(&output.stdout)
         .context("git printed invalid utf-8 ಠ_ಠ")?
         .split('\0')
@@ -647,9 +643,7 @@ fn add_cargo_package_files_to_sdist(
                 continue;
             }
             let target = root_dir.join(source.strip_prefix(pyproject_dir).unwrap());
-            if source.is_dir() {
-                writer.add_directory(target)?;
-            } else {
+            if !source.is_dir() {
                 writer.add_file(target, &source)?;
             }
         }
@@ -826,9 +820,7 @@ pub fn source_distribution(
             .filter_map(Result::ok)
         {
             let target = root_dir.join(source.strip_prefix(pyproject_dir).unwrap());
-            if source.is_dir() {
-                writer.add_directory(target)?;
-            } else {
+            if !source.is_dir() {
                 writer.add_file(target, source)?;
             }
         }

--- a/tests/common/metadata.rs
+++ b/tests/common/metadata.rs
@@ -11,11 +11,6 @@ struct MockWriter {
 }
 
 impl ModuleWriter for MockWriter {
-    fn add_directory(&mut self, path: impl AsRef<Path>) -> Result<()> {
-        self.files.push(path.as_ref().to_string_lossy().to_string());
-        Ok(())
-    }
-
     fn add_bytes_with_permissions(
         &mut self,
         target: impl AsRef<Path>,
@@ -58,10 +53,8 @@ fn metadata_hello_world_pep639() {
     .unwrap();
 
     assert_snapshot!(writer.files.join("\n").replace("\\", "/"), @r"
-    hello_world-0.1.0.dist-info
     hello_world-0.1.0.dist-info/METADATA
     hello_world-0.1.0.dist-info/WHEEL
-    hello_world-0.1.0.dist-info/licenses
     hello_world-0.1.0.dist-info/licenses/LICENSE
     hello_world-0.1.0.dist-info/licenses/licenses/AUTHORS.txt
     ");


### PR DESCRIPTION
In https://github.com/PyO3/maturin/pull/2823 I considered the idea of removing `add_directory()` entirely from the `ModuleWriter` trait since it seemed error-prone to require the programmer to ensure it was called everywhere. I decided to make a PR for that as well to see what it would look like.