### PR TITLE
CI: always run `conclusion` step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -545,6 +545,7 @@ jobs:
       - test-downstream
       - check
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - name: Result
         run: |


### PR DESCRIPTION
Fixes buggy auto-merge behavior when it's skipped.