### PR TITLE
Add linux sw_64 architecture support

### DIFF
--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -97,7 +97,7 @@ pub enum Arch {
     Sparc64,
     Sparcv9,
     LoongArch64,
-    Sw_64,
+    Sw64,
 }
 
 impl fmt::Display for Arch {
@@ -123,7 +123,7 @@ impl fmt::Display for Arch {
             Arch::Sparc64 => write!(f, "sparc64"),
             Arch::Sparcv9 => write!(f, "sparcv9"),
             Arch::LoongArch64 => write!(f, "loongarch64"),
-            Arch::Sw_64 => write!(f, "sw_64"),
+            Arch::Sw64 => write!(f, "sw_64"),
         }
     }
 }
@@ -149,7 +149,7 @@ impl Arch {
             Arch::Wasm32 => "wasm32",
             Arch::S390X => "s390x",
             Arch::LoongArch64 => "loongarch64",
-            Arch::Sw_64 => "sw_64",
+            Arch::Sw64 => "sw_64",
         }
     }
 }
@@ -176,7 +176,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
             Arch::Mips,
             Arch::Sparc64,
             Arch::LoongArch64,
-            Arch::Sw_64,
+            Arch::Sw64,
         ],
         Os::Windows => vec![Arch::X86, Arch::X86_64, Arch::Aarch64],
         Os::Macos => vec![Arch::Aarch64, Arch::X86_64],
@@ -324,7 +324,7 @@ impl Target {
             Architecture::Sparc64 => Arch::Sparc64,
             Architecture::Sparcv9 => Arch::Sparcv9,
             Architecture::LoongArch64 => Arch::LoongArch64,
-            Architecture::Sw_64 => Arch::Sw_64,
+            Architecture::Sw64 => Arch::Sw64,
             unsupported => bail!("The architecture {} is not supported", unsupported),
         };
 
@@ -409,7 +409,7 @@ impl Target {
             Arch::Sparc64 => "sparc64",
             Arch::Sparcv9 => "sparcv9",
             Arch::LoongArch64 => "loongarch64",
-            Arch::Sw_64 => "sw_64",
+            Arch::Sw64 => "sw_64",
         }
     }
 
@@ -528,7 +528,7 @@ impl Target {
             | Arch::Sparc64
             | Arch::Sparcv9
             | Arch::LoongArch64
-            | Arch::Sw_64 => 64,
+            | Arch::Sw64 => 64,
             Arch::Armv5teL
             | Arch::Armv6L
             | Arch::Armv7L


### PR DESCRIPTION
In this commit, support for a new architecture sw_64 is added to maturin. sw_64 is a new RISC ISA, which is a bit like RISC-V. Though it is a rather new ISA, it has been added to openEuler and openAnolis port since 2020. So supporting this new architecture is meaningful. 
It's PR is to solve compilation failure on sw_64 architecture.

Binutils has identified EM_SW64 is 268, I hope maturin can accept this patch. Thanks.

https://gabi.xinuos.com/elf/a-emachine.html

https://en.wikipedia.org/wiki/Sunway_(processor)