### PR TITLE
Correct tagging for x86_64 iOS simulator wheels.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix tagging for iOS x86_64 simulator wheels.
+
 ## [1.10.1]
 
 * Fix wrong dependency on Homebrew liblzma on macOS by static linking liblama

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -627,7 +627,7 @@ impl BuildContext {
                 } else {
                     "x86_64"
                 };
-                let abi = if self.target.target_triple().ends_with("-sim") {
+                let abi = if target.target_arch() == Arch::X86_64 || self.target.target_triple().ends_with("-sim") {
                     "iphonesimulator"
                 } else {
                     "iphoneos"


### PR DESCRIPTION
#2827 introduced PEP 730-compilant tags for iOS wheels. 

The PR description for that ticket correctly described the tags that *should* exist; but due to the inconsistent naming of the Rust `x86_64-apple-ios` *simulator* target, the implementation in #2827 would produce wheels tagged `x86_64_iphoneos`.

This PR corrects that oversight. 