### PR TITLE
Set entry type when adding to the tar file

### DIFF
--- a/src/module_writer.rs
+++ b/src/module_writer.rs
@@ -388,6 +388,7 @@ impl ModuleWriter for SDistWriter {
         }
 
         let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
         header.set_size(bytes.len() as u64);
         header.set_mode(permissions);
         header.set_mtime(self.mtime);


### PR DESCRIPTION
We need to explicitly set this because the header initializes with all null bytes. When this is not set, the python `tarfile` module can fail to process the file properly due to treating an entry of type `AREGTYPE` that also ends in a trailing slash as a directory instead of a regular file under some very specific circumstances.
See https://github.com/python/cpython/issues/141707 for more details

Fixes #2855 