### PR TITLE
Update cargo_metadata to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml 0.8.23",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo-xwin"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +302,7 @@ dependencies = [
  "anyhow",
  "cargo-config2",
  "cargo-options",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap",
  "crc",
  "dirs",
@@ -300,7 +325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+dependencies = [
+ "camino",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -731,6 +771,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1367,7 +1418,7 @@ dependencies = [
  "cargo-options",
  "cargo-xwin",
  "cargo-zigbuild",
- "cargo_metadata",
+ "cargo_metadata 0.20.0",
  "cbindgen",
  "cc",
  "clap",
@@ -1576,6 +1627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1702,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_pipe"
@@ -2283,6 +2352,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +2967,12 @@ dependencies = [
  "rand",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ anyhow = "1.0.80"
 base64 = "0.22.0"
 glob = "0.3.0"
 cargo-config2 = "0.1.24"
-cargo_metadata = "0.19.0"
+cargo_metadata = "0.20.0"
 cargo-options = "0.7.2"
 cbindgen = { version = "0.29.0", default-features = false }
 flate2 = "1.0.18"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -532,7 +532,7 @@ fn compile_target(
                 };
 
                 // Extract the location of the .so/.dll/etc. from cargo's json output
-                if crate_name == &context.crate_name {
+                if crate_name.as_ref() == context.crate_name {
                     let tuples = artifact
                         .target
                         .crate_types
@@ -677,9 +677,9 @@ fn pyo3_version(cargo_metadata: &cargo_metadata::Metadata) -> Option<(u64, u64, 
         .packages
         .iter()
         .filter_map(|pkg| {
-            let name = &pkg.name;
+            let name = pkg.name.as_ref();
             if name == "pyo3" || name == "pyo3-ffi" {
-                Some((name.as_ref(), pkg))
+                Some((name, pkg))
             } else {
                 None
             }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -536,7 +536,7 @@ impl Metadata24 {
             license: package.license.clone(),
             license_files,
             project_url,
-            ..Metadata24::new(name, version)
+            ..Metadata24::new(name.to_string(), version)
         };
         Ok(metadata)
     }

--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -343,7 +343,7 @@ pub fn find_path_deps(cargo_metadata: &Metadata) -> Result<HashMap<String, PathD
             let dependency = top
                 .dependencies
                 .iter()
-                .find(|package| {
+                .find(|&package| {
                     // Package ids are opaque and there seems to be no way to query their name.
                     let dep_name = &cargo_metadata
                         .packages
@@ -351,7 +351,7 @@ pub fn find_path_deps(cargo_metadata: &Metadata) -> Result<HashMap<String, PathD
                         .find(|package| &package.id == dep_id)
                         .unwrap()
                         .name;
-                    &package.name == dep_name
+                    package.name == dep_name.as_ref()
                 })
                 .unwrap();
             if let Some(path) = &dependency.path {


### PR DESCRIPTION
Similar to https://github.com/PyO3/maturin/pull/2817 but only bumping up to `0.20.0` due to MSRV constraints. `>=0.21` uses an MSRV of 1.86 which is one minor version higher than the MSRV in maturin.