### PR TITLE
Calculate file options for WheelWriter once and cache the result

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -86,7 +86,7 @@ impl CompressionOptions {
         }
     }
 
-    pub(crate) fn get_file_options(&self) -> zip::write::FileOptions<'_, ()> {
+    pub(crate) fn get_file_options(&self) -> zip::write::FileOptions<'static, ()> {
         let method = if cfg!(feature = "faster-tests") {
             // Unlike users which can use the develop subcommand, the tests have to go through
             // packing a zip which pip than has to unpack. This makes this 2-3 times faster


### PR DESCRIPTION
We can store the file options directly after calculating the compression options and mtime once since they will never change.