### PR TITLE
Clean up internal fields of WheelWriter

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -786,7 +786,7 @@ impl BuildContext {
             &self.metadata24,
             self.project_layout.data.as_deref(),
         )?;
-        let wheel_path = writer.finish()?;
+        let wheel_path = writer.finish(&self.metadata24)?;
         Ok((wheel_path, format!("cp{major}{min_minor}")))
     }
 
@@ -869,7 +869,7 @@ impl BuildContext {
             &self.metadata24,
             self.project_layout.data.as_deref(),
         )?;
-        let wheel_path = writer.finish()?;
+        let wheel_path = writer.finish(&self.metadata24)?;
         Ok((
             wheel_path,
             format!("cp{}{}", python_interpreter.major, python_interpreter.minor),
@@ -998,7 +998,7 @@ impl BuildContext {
             &self.metadata24,
             self.project_layout.data.as_deref(),
         )?;
-        let wheel_path = writer.finish()?;
+        let wheel_path = writer.finish(&self.metadata24)?;
         Ok((wheel_path, "py3".to_string()))
     }
 
@@ -1074,7 +1074,7 @@ impl BuildContext {
             &self.metadata24,
             self.project_layout.data.as_deref(),
         )?;
-        let wheel_path = writer.finish()?;
+        let wheel_path = writer.finish(&self.metadata24)?;
         Ok((wheel_path, "py3".to_string()))
     }
 
@@ -1189,7 +1189,7 @@ impl BuildContext {
             &self.metadata24,
             self.project_layout.data.as_deref(),
         )?;
-        let wheel_path = writer.finish()?;
+        let wheel_path = writer.finish(&self.metadata24)?;
         Ok((wheel_path, "py3".to_string()))
     }
 


### PR DESCRIPTION
This PR makes basically 3 changes:
1. Change the `record` field in `WheelWriter` to a `BTreeMap` so that the records are already sorted by path
2. Replace `ZipWriter::start_file()` with `ZipWriter::start_file_from_path()` because the latter automatically deals with zip path normalization, including replacing back slashes with forward slashes
3. Remove the `record_path` and `wheel_path` fields from the struct because `wheel_path` can be recovered from the underlying file after the zip is closed, and `record_path` can be calculated from `Metadata24` if provided