### PR TITLE
Always emit deprecation warning for 'upload' and 'publish'

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -65,18 +65,17 @@ impl PublishOpt {
 
     /// Set to non interactive mode if we're running on CI
     pub fn non_interactive_on_ci(&mut self) {
+        let msg = "⚠️  Warning: The maturin upload and publish commands are deprecated and will be removed in the future. For more information see: https://github.com/PyO3/maturin/issues/2334";
+        eprintln!("{msg}");
+        if env::var("GITHUB_ACTIONS")
+            .map(|v| v == "true")
+            .unwrap_or_default()
+        {
+            // Also emit a warning annotation on the GH action
+            println!("::warning::{msg}");
+        }
+
         if !self.non_interactive && env::var("CI").map(|v| v == "true").unwrap_or_default() {
-            let msg = "⚠️  Warning: The maturin upload and publish commands are deprecated and will be removed in the future. For more information see: https://github.com/PyO3/maturin/issues/2334";
-            eprintln!("{msg}");
-
-            if env::var("GITHUB_ACTIONS")
-                .map(|v| v == "true")
-                .unwrap_or_default()
-            {
-                // Also emit a warning annotation on the GH action
-                println!("::warning::{msg}");
-            }
-
             eprintln!("🎛️ Running in non-interactive mode on CI");
             self.non_interactive = true;
         }


### PR DESCRIPTION
I tested this in a CI environment when developing so I didn't notice that the deprecation warning for using 'upload' and 'publish' was not always emitted.

This PR shifts the warning out of the CI `if` block so that it is always emitted.