### PR TITLE
Replace rustls-pemfile with rustls-pki-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "rustc_version",
  "rustflags",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "rustversion",
  "same-file",
  "schemars",
@@ -2194,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "std",
     "tls12",
 ], optional = true }
-rustls-pemfile = { version = "2.1.0", optional = true }
+rustls-pki-types = { version = "1.13.1", optional = true }
 keyring = { version = "2.3.2", default-features = false, features = [
     "linux-no-secret-service",
 ], optional = true }
@@ -180,13 +180,13 @@ rustls = [
     "dep:rustls",
     "ureq?/tls",
     "cargo-xwin?/rustls-tls",
-    "dep:rustls-pemfile",
+    "dep:rustls-pki-types",
 ]
 native-tls = [
     "dep:native-tls",
     "ureq?/native-tls",
     "cargo-xwin?/native-tls",
-    "dep:rustls-pemfile",
+    "dep:rustls-pki-types",
 ]
 
 # cross compile using zig or xwin

--- a/deny.toml
+++ b/deny.toml
@@ -81,8 +81,6 @@ ignore = [
     "RUSTSEC-2024-0436",
     # num_prefix unmaintained
     "RUSTSEC-2025-0119",
-    # rustls-pemfile unmaintained
-    "RUSTSEC-2025-0134",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },


### PR DESCRIPTION
The recommended replacement for `rustls-pemfile` seems to be using `rustls-pki-types`, so I did that here