### PR TITLE
Make PEP 517 profile tests more resilient to cargo profiles

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -222,13 +222,3 @@ pub fn create_conda_env(name: &str, major: usize, minor: usize) -> Result<(PathB
 pub fn test_python_path() -> Option<String> {
     env::var("MATURIN_TEST_PYTHON").ok()
 }
-
-/// Find index of subslice in a larger slice
-pub fn find_subslice<T: PartialEq>(haystack: &[T], needle: &[T]) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(0);
-    }
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,5 +1,6 @@
 //! To speed up the tests, they are tests all collected in a single module
 
+use common::pep517::{target_has_profile, test_pep517};
 use common::{
     TestInstallBackend, develop, errors, handle_result, integration, other,
     test_python_implementation,
@@ -13,8 +14,6 @@ use std::path::Path;
 use std::time::Duration;
 use time::macros::datetime;
 use which::which;
-
-use crate::common::{find_subslice, pep517};
 
 mod common;
 
@@ -1004,32 +1003,28 @@ fn sdist_source_date_epoch() {
 
 #[test]
 fn pep517_default_profile() {
-    let output = handle_result(pep517::test_pep517(
+    let unique_name = "pep517-pyo3-pure";
+    handle_result(test_pep517(
         "test-crates/pyo3-pure",
-        "pep517-pyo3-pure",
+        unique_name,
         false,
         false,
     ));
 
-    assert!(
-        find_subslice(&output.stderr, b"`release` profile [optimized]").is_some(),
-        "Output was: {}",
-        std::str::from_utf8(&output.stderr).unwrap()
-    );
+    assert!(target_has_profile(unique_name, "release"));
+    assert!(!target_has_profile(unique_name, "debug"));
 }
 
 #[test]
 fn pep517_editable_profile() {
-    let output = handle_result(pep517::test_pep517(
+    let unique_name = "pep517-pyo3-pure-editable";
+    handle_result(test_pep517(
         "test-crates/pyo3-pure",
-        "pep517-pyo3-pure-editable",
+        unique_name,
         false,
         true,
     ));
 
-    assert!(
-        find_subslice(&output.stderr, b"`dev` profile [unoptimized + debuginfo]").is_some(),
-        "Output was: {}",
-        std::str::from_utf8(&output.stderr).unwrap()
-    );
+    assert!(!target_has_profile(unique_name, "release"));
+    assert!(target_has_profile(unique_name, "debug"));
 }


### PR DESCRIPTION
A trick for faster rust compilation from the official book is to avoid generating debug information by default (https://doc.rust-lang.org/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information).

To apply this for globally, or to use this for projects that already have a `.cargo/config.toml`, we can add the following to `~/.cargo/config.toml`:
```toml
[profile.dev]
debug = "line-tables-only"

[profile.dev.package."*"]
debug = false

[profile.debugging]
inherits = "dev"
debug = true
```

or simply:

```toml
[profile.dev]
debug = false
```

This effect is larger for more complex projects with more dependencies, but also noticeable for maturin. On my machine, a fresh debug build goes from 14.6s to 9s, `hyperfine --prepare "touch src/archive_source.rs" "cargo build"` goes from 960ms to 870ms.

This breaks the PEP 517 profile test because the log message looks different:

```
Finished `dev` profile [unoptimized] target(s) in 8.84s
```

To make the test more resilient to all sorts of global profile changes, we instead check in the target directory which profiles were built.