### PR TITLE
Fix compiled artifacts being excluded by source path matching

### DIFF
--- a/src/binding_generator/mod.rs
+++ b/src/binding_generator/mod.rs
@@ -175,13 +175,15 @@ where
                     artifact_target.display(),
                     source.display()
                 );
-                writer.add_file(artifact_target, source, true)?;
+                // Use add_file_force to bypass exclusion checks for the compiled artifact
+                writer.add_file_force(artifact_target, source, true)?;
 
                 // 3b. Install additional files
                 if let Some(additional_files) = additional_files {
                     for (target, source) in additional_files {
                         debug!("Generating archive entry {}", target.display());
-                        writer.add_entry(target, source)?;
+                        // Use add_entry_force to bypass exclusion checks for generated binding files
+                        writer.add_entry_force(target, source)?;
                     }
                 }
             }

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -14,7 +14,7 @@ use crate::source_distribution::source_distribution;
 use crate::target::validate_wheel_filename_for_pypi;
 use crate::target::{Arch, Os};
 use crate::{
-    BridgeModel, BuildArtifact, Metadata24, ModuleWriter, PyProjectToml, PythonInterpreter, Target,
+    BridgeModel, BuildArtifact, Metadata24, PyProjectToml, PythonInterpreter, Target,
     VirtualWriter, compile, pyproject_toml::Format,
 };
 use anyhow::{Context, Result, anyhow, bail};
@@ -458,7 +458,8 @@ impl BuildContext {
             if !replacements.is_empty() {
                 patchelf::replace_needed(path, &replacements[..])?;
             }
-            writer.add_file(libs_dir.join(new_soname), path, true)?;
+            // Use add_file_force to bypass exclusion checks for external shared libraries
+            writer.add_file_force(libs_dir.join(new_soname), path, true)?;
         }
 
         eprintln!(


### PR DESCRIPTION
The VirtualWriter introduced in d6d23cf9 checks source paths against exclude patterns, which caused compiled shared libraries to be excluded when projects have patterns like `exclude = ["target/**/*"]` to ignore the Cargo target directory.

Add `add_file_force()` method to VirtualWriter that bypasses exclusion checks, and use it for compiled artifacts and external shared libraries which should always be included in the wheel.

Fixes #2909 