### PR TITLE
Release 1.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>", "messense <messense@icloud.com>"]
 name = "maturin"
-version = "1.11.2"
+version = "1.11.3"
 description = "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages"
 exclude = [
     "test-crates/**/*",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.11.3
+
+* Fix manylinux2014 compliance check ([#2922](https://github.com/pyo3/maturin/pull/2922))
+
 ## 1.11.2
 
 * Fix failed release


### PR DESCRIPTION
The regression broke ty's release process, releasing the fix from main (https://github.com/astral-sh/ty/actions/runs/20797756758/job/59736672093)