### PR TITLE
Use uv instead of sudo pip and pin release bootstrapping version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,9 @@ jobs:
           # Make psm compile, see https://github.com/rust-lang/stacker/issues/79
           CFLAGS_s390x_unknown_linux_gnu: "-march=z10"
         run: |
-          uvx maturin build --release -b bin -o dist \
+          # TODO: Avoid pinning an explicit version here. This specific version avoid a regression in a later version
+          # See https://github.com/pyo3/maturin/pull/2922
+          uvx maturin==1.10.1 build --release -b bin -o dist \
             --target ${{ matrix.platform.target }} \
             --compatibility ${{ matrix.platform.compatibility }} \
             --features password-storage


### PR DESCRIPTION
Remove "sudo pip" style commands, they are a bad practice and we shouldn't have them in our CI.

This change relies on uv covering the same platforms as maturin in CI.

Also pin maturin==1.10.1 for cross builds for now, see https://github.com/PyO3/maturin/actions/runs/20812085659/job/59778558155 and https://github.com/PyO3/maturin/pull/2922