### PR TITLE
Use a single location for MSRV

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,15 +1,21 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "nox",
+# ]
+# ///
 import os
 import json
 import sys
 from pathlib import Path
+import tomllib
 
 import nox
-
 
 PYODIDE_VERSION = os.getenv("PYODIDE_VERSION", "0.29.0")
 GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS")
 GITHUB_ENV = os.getenv("GITHUB_ENV")
-MSRV = "1.83.0"
+MSRV = tomllib.loads(Path("Cargo.toml").read_text())["package"]["rust-version"]
 
 
 def append_to_github_env(name: str, value: str):


### PR DESCRIPTION
The MSRV values got out of sync.

This bumps the minimum required Python version for running the noxfile to Python 3.11. See also https://nox.thea.codes/en/stable/tutorial.html#running-without-the-nox-command-or-adding-dependencies