### PR TITLE
Release to crates.io only after the builds passed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,29 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  release-crates-io:
-    name: Release crates.io
-    runs-on: ubuntu-latest
-    environment:
-      name: crates.io
-      url: ${{ steps.set_url.outputs.env_url }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: cargo publish (dry run)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: cargo publish --dry-run
-      - name: cargo login
-        if: startsWith(github.ref, 'refs/tags/')
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: cargo publish
-        if: startsWith(github.ref, 'refs/tags/')
-        run: cargo publish
-      - name: Set environment url
-        id: set_url
-        run: |
-          VERSION=$(echo $GITHUB_REF | sed -e "s#refs/tags/v##g")
-          echo "env_url=https://crates.io/crates/maturin/$VERSION" >> $GITHUB_OUTPUT
-
   build:
     name: Build ${{ matrix.target }}
     strategy:
@@ -298,3 +275,27 @@ jobs:
             *.deb
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           generate_release_notes: true
+
+  release-crates-io:
+    name: Release crates.io
+    runs-on: ubuntu-latest
+    needs: [build, build-musl]
+    environment:
+      name: crates.io
+      url: ${{ steps.set_url.outputs.env_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: cargo publish (dry run)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: cargo publish --dry-run
+      - name: cargo login
+        if: startsWith(github.ref, 'refs/tags/')
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: cargo publish
+        if: startsWith(github.ref, 'refs/tags/')
+        run: cargo publish
+      - name: Set environment url
+        id: set_url
+        run: |
+          VERSION=$(echo $GITHUB_REF | sed -e "s#refs/tags/v##g")
+          echo "env_url=https://crates.io/crates/maturin/$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Reduce the risk of partial releases a bit.