### PR TITLE
Use trusted publishing for crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,8 @@ jobs:
     name: Release crates.io
     runs-on: ubuntu-latest
     needs: [build, build-musl]
+    permissions:
+      id-token: write
     environment:
       name: crates.io
       url: ${{ steps.set_url.outputs.env_url }}
@@ -288,9 +290,9 @@ jobs:
       - name: cargo publish (dry run)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: cargo publish --dry-run
-      - name: cargo login
+      - name: Authenticate with crates.io
         if: startsWith(github.ref, 'refs/tags/')
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+        uses: rust-lang/crates-io-auth-action@v1
       - name: cargo publish
         if: startsWith(github.ref, 'refs/tags/')
         run: cargo publish


### PR DESCRIPTION
I'm trying to remove my crates.io tokens.