### PR TITLE
Normalize wheel distribution names to match the PyPA spec

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -1035,14 +1035,6 @@ impl BuildContext {
 
         if self.target.is_wasi() {
             eprintln!("⚠️  Warning: wasi support is experimental");
-            // escaped can contain [\w\d.], but i don't know how we'd handle dots correctly here
-            if self.metadata24.get_distribution_escaped().contains('.') {
-                bail!(
-                    "Can't build wasm wheel if there is a dot in the name ('{}')",
-                    self.metadata24.get_distribution_escaped()
-                )
-            }
-
             if !self.metadata24.entry_points.is_empty() {
                 bail!("You can't define entrypoints yourself for a binary project");
             }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -652,11 +652,17 @@ impl Metadata24 {
         Ok(out)
     }
 
-    /// Returns the distribution name according to PEP 427, Section "Escaping
-    /// and Unicode"
+    /// Returns the distribution name normalized according to the PyPA Binary
+    /// Distribution Format specification.
+    ///
+    /// This is the name that will be used in the wheel filename and for the
+    /// `.dist-info` directory name. It is also the name that will be used in
+    /// the source distribution (sdist) filename.
+    ///
+    /// See https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
     pub fn get_distribution_escaped(&self) -> String {
-        let re = Regex::new(r"[^\w\d.]+").unwrap();
-        re.replace_all(&self.name, "_").to_string()
+        let re = Regex::new(r"[-_.]+").unwrap();
+        re.replace_all(&self.name, "_").to_lowercase()
     }
 
     /// Returns the version encoded according to PEP 427, Section "Escaping


### PR DESCRIPTION
This fixes building publishable sdists and wheels for packages where the name contains a dot (aka period, aka full stop). For example, [asimov.py](https://pypi.org/project/asimov.py/) gets normalized into "asimov_py":

```console
$ ls -1 target/wheels/
asimov_py-26.0.0.dev1-cp314-cp314-macosx_11_0_arm64.whl
asimov_py-26.0.0.dev1.tar.gz
```

Note some relevant history regarding distribution name normalization:

1. The [PEP 427](https://peps.python.org/pep-0427/#escaping-and-unicode) (2012) specification contained the regular expression `[^\w\d.]+` which preserved dots.
2. Popular tools (`pip`, `setuptools`, etc.) didn't actually follow this: instead, they replaced dots with underscores.
3. The [PyPA Binary Distribution Format](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode) specification was [updated](https://github.com/pypa/packaging.python.org/commit/8a54b404b3fa3de4357a61157f5ae50c767dcb78) (in 2021) to match what tools actually did, explicitly requiring dots to be replaced with underscores.
