### PR TITLE
Support MATURIN_STRIP env var and --strip true/false to override pyproject.toml

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -555,7 +555,7 @@ impl BuildOptions {
 #[derive(Debug)]
 pub struct BuildContextBuilder {
     build_options: BuildOptions,
-    strip: bool,
+    strip: Option<bool>,
     editable: bool,
     sdist_only: bool,
 }
@@ -564,13 +564,13 @@ impl BuildContextBuilder {
     fn new(build_options: BuildOptions) -> Self {
         Self {
             build_options,
-            strip: false,
+            strip: None,
             editable: false,
             sdist_only: false,
         }
     }
 
-    pub fn strip(mut self, strip: bool) -> Self {
+    pub fn strip(mut self, strip: Option<bool>) -> Self {
         self.strip = strip;
         self
     }
@@ -715,7 +715,7 @@ impl BuildContextBuilder {
             }
         }
 
-        let strip = pyproject.map(|x| x.strip()).unwrap_or_default() || strip;
+        let strip = strip.unwrap_or_else(|| pyproject.map(|x| x.strip()).unwrap_or_default());
         let skip_auditwheel = pyproject.map(|x| x.skip_auditwheel()).unwrap_or_default()
             || build_options.skip_auditwheel;
         let auditwheel = build_options

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -433,7 +433,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 
     let build_context = build_options
         .into_build_context()
-        .strip(strip)
+        .strip(if strip { Some(true) } else { None })
         .editable(true)
         .build()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,17 @@ enum Command {
         /// Build artifacts in release mode, with optimizations
         #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS, conflicts_with = "profile")]
         release: bool,
-        /// Strip the library for minimum file size
-        #[arg(long)]
-        strip: bool,
+        /// Strip the library for minimum file size.
+        /// Can be set to `true` or `false`, or used as a flag (`--strip` implies `true`).
+        #[arg(
+            long,
+            env = "MATURIN_STRIP",
+            // `--strip` without a value is treated as `--strip true`
+            default_missing_value = "true",
+            num_args = 0..=1,
+            require_equals = false
+        )]
+        strip: Option<bool>,
         /// Build a source distribution
         #[arg(long)]
         sdist: bool,
@@ -185,20 +193,34 @@ enum Pep517Command {
         /// The metadata_directory argument to prepare_metadata_for_build_wheel
         #[arg(long = "metadata-directory")]
         metadata_directory: PathBuf,
-        /// Strip the library for minimum file size
-        #[arg(long)]
-        strip: bool,
+        /// Strip the library for minimum file size.
+        /// Can be set to `true` or `false`, or used as a flag (`--strip` implies `true`).
+        #[arg(
+            long,
+            env = "MATURIN_STRIP",
+            // `--strip` without a value is treated as `--strip true`
+            default_missing_value = "true",
+            num_args = 0..=1,
+            require_equals = false
+        )]
+        strip: Option<bool>,
     },
     #[command(name = "build-wheel")]
     /// Implementation of build_wheel
-    ///
-    /// --release and --strip are currently unused by the PEP 517 implementation
     BuildWheel {
         #[command(flatten)]
         build_options: BuildOptions,
-        /// Strip the library for minimum file size
-        #[arg(long)]
-        strip: bool,
+        /// Strip the library for minimum file size.
+        /// Can be set to `true` or `false`, or used as a flag (`--strip` implies `true`).
+        #[arg(
+            long,
+            env = "MATURIN_STRIP",
+            // `--strip` without a value is treated as `--strip true`
+            default_missing_value = "true",
+            num_args = 0..=1,
+            require_equals = false
+        )]
+        strip: Option<bool>,
         /// Build editable wheels
         #[arg(long)]
         editable: bool,
@@ -329,7 +351,7 @@ fn pep517(subcommand: Pep517Command) -> Result<()> {
             };
             let build_context = build_options
                 .into_build_context()
-                .strip(false)
+                .strip(Some(false))
                 .editable(false)
                 .sdist_only(true)
                 .build()?;
@@ -409,7 +431,7 @@ fn run() -> Result<()> {
 
             let mut build_context = build
                 .into_build_context()
-                .strip(!no_strip)
+                .strip(Some(!no_strip))
                 .editable(false)
                 .build()?;
 
@@ -484,7 +506,7 @@ fn run() -> Result<()> {
             };
             let build_context = build_options
                 .into_build_context()
-                .strip(false)
+                .strip(Some(false))
                 .editable(false)
                 .sdist_only(true)
                 .build()?;

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -7,8 +7,12 @@ Arguments:
           Rustc flags
 
 Options:
-      --strip
-          Strip the library for minimum file size
+      --strip [<STRIP>]
+          Strip the library for minimum file size. Can be set to `true` or `false`, or used as a
+          flag (`--strip` implies `true`)
+          
+          [env: MATURIN_STRIP=]
+          [possible values: true, false]
 
       --sdist
           Build a source distribution

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -24,7 +24,7 @@ pub fn pyo3_no_extension_module() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?
         .build_wheels();
@@ -61,7 +61,7 @@ pub fn locked_doesnt_build_without_cargo_lock() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build();
     if let Err(err) = result {
@@ -98,7 +98,7 @@ pub fn invalid_manylinux_does_not_panic() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?
         .build_wheels();
@@ -171,7 +171,7 @@ pub fn pypi_compatibility_unsupported_target() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build();
 
@@ -210,7 +210,7 @@ pub fn pypi_compatibility_linux_tag() -> Result<()> {
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?
         .build_wheels();

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -138,7 +138,7 @@ pub fn test_integration(
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let build_context = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?;
     let wheels = build_context.build_wheels()?;
@@ -265,7 +265,7 @@ pub fn test_integration_conda(package: impl AsRef<Path>, bindings: Option<String
 
     let build_context = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?;
     let wheels = build_context.build_wheels()?;

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -90,7 +90,7 @@ pub fn test_musl() -> Result<bool> {
 
     let build_context = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?;
     let built_lib =
@@ -133,7 +133,7 @@ pub fn test_workspace_cargo_lock() -> Result<()> {
 
     let build_context = options
         .into_build_context()
-        .strip(false)
+        .strip(Some(false))
         .editable(false)
         .build()?;
     let source_distribution = build_context.build_source_distribution()?;
@@ -165,7 +165,7 @@ pub fn build_source_distribution(
 
     let mut build_context = build_options
         .into_build_context()
-        .strip(false)
+        .strip(Some(false))
         .editable(false)
         .sdist_only(true)
         .build()?;
@@ -276,7 +276,7 @@ fn build_wheel_files(package: impl AsRef<Path>, unique_name: &str) -> Result<Zip
 
     let build_context = build_options
         .into_build_context()
-        .strip(false)
+        .strip(Some(false))
         .editable(false)
         .build()?;
     let wheels = build_context
@@ -349,7 +349,7 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
     ])?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build();
     assert!(result.is_ok());
@@ -365,7 +365,7 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
     ])?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build();
     assert!(result.is_ok());
@@ -385,7 +385,7 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
         ])?;
         let result = options
             .into_build_context()
-            .strip(cfg!(feature = "faster-tests"))
+            .strip(Some(cfg!(feature = "faster-tests")))
             .editable(false)
             .build();
         assert!(result.is_err());
@@ -401,7 +401,7 @@ pub fn abi3_python_interpreter_args() -> Result<()> {
         ])?;
         let result = options
             .into_build_context()
-            .strip(cfg!(feature = "faster-tests"))
+            .strip(Some(cfg!(feature = "faster-tests")))
             .editable(false)
             .build();
         assert!(result.is_err());
@@ -426,7 +426,7 @@ pub fn abi3_without_version() -> Result<()> {
     let options = BuildOptions::try_parse_from(cli)?;
     let result = options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build();
     assert!(result.is_ok());
@@ -474,7 +474,7 @@ pub fn test_unreadable_dir() -> Result<()> {
 
     let sdist_context = sdist_options
         .into_build_context()
-        .strip(false)
+        .strip(Some(false))
         .editable(false)
         .sdist_only(true)
         .build()?;
@@ -494,7 +494,7 @@ pub fn test_unreadable_dir() -> Result<()> {
 
     let wheel_context = wheel_options
         .into_build_context()
-        .strip(cfg!(feature = "faster-tests"))
+        .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
         .build()?;
     let wheel_result = wheel_context.build_wheels();


### PR DESCRIPTION
Allow disabling stripping via CLI or env var without modifying pyproject.toml. The --strip flag now accepts an optional bool value and can be controlled via the MATURIN_STRIP environment variable.

Closes #2951