### PR TITLE
fix: resolve wheel include patterns relative to project root

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -1050,9 +1050,12 @@ pub fn source_distribution(
         }
     }
 
+    let escaped_pyproject_dir = PathBuf::from(glob::Pattern::escape(
+        pyproject_dir.to_string_lossy().as_ref(),
+    ));
     let mut include = |pattern| -> Result<()> {
         eprintln!("📦 Including files matching \"{pattern}\"");
-        for source in glob::glob(&pyproject_dir.join(pattern).to_string_lossy())
+        for source in glob::glob(&escaped_pyproject_dir.join(pattern).to_string_lossy())
             .with_context(|| format!("Invalid glob pattern: {pattern}"))?
             .filter_map(Result::ok)
         {

--- a/test-crates/pyo3-mixed-py-subdir/assets/extra_data.txt
+++ b/test-crates/pyo3-mixed-py-subdir/assets/extra_data.txt
@@ -1,0 +1,1 @@
+test data

--- a/test-crates/pyo3-mixed-py-subdir/pyproject.toml
+++ b/test-crates/pyo3-mixed-py-subdir/pyproject.toml
@@ -17,3 +17,4 @@ get_42 = "pyo3_mixed_py_subdir:get_42"
 [tool.maturin]
 module-name = "pyo3_mixed_py_subdir._pyo3_mixed"
 python-source = "python"
+include = ["assets/extra_data.txt"]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -951,6 +951,27 @@ fn pyo3_mixed_include_exclude_wheel_files() {
     ))
 }
 
+// Regression test for https://github.com/PyO3/maturin/issues/2691
+// Verifies that `include` patterns work correctly with `python-source` (src-layout),
+// where include paths should be resolved relative to the project root, not the python dir.
+#[test]
+fn pyo3_mixed_py_subdir_include_wheel_files() {
+    handle_result(other::check_wheel_files(
+        "test-crates/pyo3-mixed-py-subdir",
+        vec![
+            "pyo3_mixed_py_subdir-2.1.3.dist-info/METADATA",
+            "pyo3_mixed_py_subdir-2.1.3.dist-info/RECORD",
+            "pyo3_mixed_py_subdir-2.1.3.dist-info/WHEEL",
+            "pyo3_mixed_py_subdir-2.1.3.dist-info/entry_points.txt",
+            "pyo3_mixed_py_subdir/__init__.py",
+            "pyo3_mixed_py_subdir/python_module/__init__.py",
+            "pyo3_mixed_py_subdir/python_module/double.py",
+            "assets/extra_data.txt",
+        ],
+        "wheel-files-pyo3-mixed-py-subdir-include",
+    ))
+}
+
 // Tests that paths in the wheel `RECORD` use `/` instead of `\\`. Even
 // (especially, exclusively) on Windows.
 #[test]


### PR DESCRIPTION
Include patterns in `[tool.maturin]` were resolved relative to `python_dir` instead of the project root (pyproject.toml directory). This caused include patterns to silently match nothing when `python-source` was set (src-layout), since paths like `target/release/binary` would incorrectly resolve to `python/target/release/binary`.

Now consistent with:
- Poetry's behavior (patterns relative to pyproject.toml)
- sdist include handling (already used `pyproject_toml_path.parent()`)
- exclude handling (already used `pyproject_toml_path.parent()`)

Fixes: https://github.com/PyO3/maturin/issues/2691