### PR TITLE
feat: support PEP 735 dependency groups in develop command

### DIFF
--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -248,6 +248,8 @@ pub struct PyProjectToml {
     ///
     /// We use it for `[tool.maturin]`
     pub tool: Option<Tool>,
+    /// PEP 735: Dependency groups
+    pub dependency_groups: Option<pyproject_toml::DependencyGroups>,
 }
 
 impl PyProjectToml {

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -20,6 +20,11 @@ Options:
           
           Use as `--extras=extra1,extra2`
 
+  -G, --group <GROUP>
+          Install dependency groups defined in pyproject.toml (PEP 735)
+          
+          Use as `--group=test,docs`
+
       --skip-install
           Skip installation, only build the extension module inplace
           

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -62,6 +62,7 @@ pub fn test_develop(
         release: false,
         strip: false,
         extras: Vec::new(),
+        group: Vec::new(),
         skip_install: false,
         pip_path: None,
         cargo_options: CargoOptions {


### PR DESCRIPTION
Add `-G/--group` flag to 'maturin develop' that forwards `--group` to pip/uv for installing dependency groups defined in pyproject.toml.

When no `--group` is explicitly specified, defaults to installing the 'dev' group if it exists in `[dependency-groups]`, matching uv's default behavior.

Closes #2737