### PR TITLE
Fix .libs directory name for namespace packages

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -372,16 +372,14 @@ impl BuildContext {
 
         patchelf::verify_patchelf()?;
 
-        // Put external libs to ${module_name}.libs directory
+        // Put external libs to ${distribution_name}.libs directory
         // See https://github.com/pypa/auditwheel/issues/89
-        let mut libs_dir = self
-            .project_layout
-            .python_module
-            .as_ref()
-            .and_then(|py| py.file_name().map(|s| s.to_os_string()))
-            .unwrap_or_else(|| self.module_name.clone().into());
-        libs_dir.push(".libs");
-        let libs_dir = PathBuf::from(libs_dir);
+        // Use the distribution name (matching auditwheel's behavior) to avoid
+        // conflicts with other packages in the same namespace.
+        let libs_dir = PathBuf::from(format!(
+            "{}.libs",
+            self.metadata24.get_distribution_escaped()
+        ));
 
         let temp_dir = writer.temp_dir()?;
         let mut soname_map = BTreeMap::new();


### PR DESCRIPTION
Use the distribution name (from package metadata) instead of the python module's top-level directory name for the external shared libraries directory. This matches auditwheel's behavior and avoids conflicts when multiple native namespace packages share the same top-level namespace.

Previously, for a namespace package with module-name like 'namespace.package._native', the .libs directory was incorrectly named 'namespace.libs' (from `python_module.file_name()`). Now it correctly uses the distribution name, e.g. 'namespace_package_reproduction.libs'.

Fixes #2746