### PR TITLE
fix: exclude duplicate python source files from sdist for workspace members

### DIFF
--- a/src/source_distribution.rs
+++ b/src/source_distribution.rs
@@ -483,9 +483,6 @@ enum CrateRole<'a> {
 /// and rewriting path entries in Cargo.toml
 ///
 /// Runs `cargo package --list --allow-dirty` to obtain a list of files to package.
-///
-/// `skip_prefixes` is a list of path prefixes (relative to the manifest directory) whose files
-/// should be skipped because they are added separately (e.g. python source directories).
 fn add_crate_to_source_distribution(
     writer: &mut VirtualWriter<SDistWriter>,
     manifest_path: impl AsRef<Path>,


### PR DESCRIPTION
When a project is in a subdirectory of a Cargo workspace, `cargo package --list` returns python source files that are also added by the explicit python source loop. This results in duplicate files in the sdist: once under the crate subdirectory prefix (e.g. `my-crate/python/...`) and once at the top level (e.g. `python/...`).

Skip files from `cargo package --list` that fall under python source directories when the crate is a workspace member in a subdirectory, since those files will be added separately by the python source loop.

Fixes #2383