### PR TITLE
Error when python-source is set but Python module is missing

### DIFF
--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -150,7 +150,9 @@ impl ProjectResolver {
                 .normalize()
                 .with_context(|| {
                     format!(
-                        "python source path `{}` does not exist or is invalid",
+                        "python-source is set to `{}` but the directory does not exist. \
+                        Either create the directory or remove the `python-source` setting \
+                        from pyproject.toml.",
                         py_src.display()
                     )
                 })?
@@ -438,9 +440,10 @@ impl ProjectLayout {
                 })
             } else {
                 if custom_python_source {
-                    eprintln!(
-                        "⚠️ Warning: You specified the python source as {}, but the python module at \
-                        {} is missing. No python module will be included.",
+                    bail!(
+                        "python-source is set to `{}`, but the python module at `{}` \
+                        does not exist. Either create the Python module or remove the \
+                        `python-source` setting from pyproject.toml.",
                         python_root.display(),
                         python_module.display()
                     );

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -673,8 +673,8 @@ fn invalid_manylinux_does_not_panic() {
 }
 
 #[test]
-fn warn_on_missing_python_source() {
-    handle_result(errors::warn_on_missing_python_source())
+fn error_on_missing_python_source() {
+    handle_result(errors::error_on_missing_python_source())
 }
 
 #[test]


### PR DESCRIPTION
Previously maturin only warned when `python-source` was configured in pyproject.toml but the expected Python module directory didn't exist. This produced broken sdists that failed later with confusing errors like "Failed to normalize python source path".

Now maturin errors out early with a clear, actionable message telling the user to either create the Python module or remove the `python-source` setting.

Fixes #2489