### PR TITLE
Fix sdist duplicate README error when readme is in both Cargo.toml and pyproject.toml

### DIFF
--- a/src/module_writer/virtual_writer.rs
+++ b/src/module_writer/virtual_writer.rs
@@ -74,6 +74,11 @@ impl<W: ModuleWriterInternal> VirtualWriter<W> {
         self.excludes.matched(path.as_ref(), false).is_whitelist()
     }
 
+    /// Returns `true` if the given target path has already been added to the archive
+    pub(crate) fn contains_target(&self, target: impl AsRef<Path>) -> bool {
+        self.tracker.contains_key(target.as_ref())
+    }
+
     /// Checks exclusions and previously tracked sources to determine if the
     /// current source should be allowed.
     /// Returns Ok(Some(..)) if the new source should be included, Ok(None) if


### PR DESCRIPTION
When both Cargo.toml and pyproject.toml specify a readme that resolves to the same target path in the sdist but from different source files, maturin errored with 'was already added'. This can happen when Cargo.toml points to a parent directory README while pyproject.toml points to a local one.

Skip adding files that are already tracked in the sdist archive, both when processing `cargo package --list` output and when adding pyproject.toml readme/license files.

Fixes #2358