### PR TITLE
Stop adding link-native-libraries flag by default in Emscripten platform in latest Rust

### DIFF
--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -23,6 +23,7 @@ mod pypi_tags;
 pub use pypi_tags::{is_arch_supported_by_pypi, validate_wheel_filename_for_pypi};
 
 pub(crate) const RUST_1_64_0: semver::Version = semver::Version::new(1, 64, 0);
+pub(crate) const RUST_1_93_0: semver::Version = semver::Version::new(1, 93, 0);
 
 /// All supported operating system
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]


### PR DESCRIPTION
The problem with rust trying to link libc was fixed in https://github.com/rust-lang/libc/pull/4002, and this flag is not needed anymore for recent rust versions.

Always adding this flag is preventing from using the stable Rust toolchain as `-Z` flag can only be used with the nightly toolchains. From Rust 1.93.0, it is possible to use stable toolchain to build to Emscripten target, so this PR removes this flag for Rust >= 1.93.0

cc: @hoodmane 