### PR TITLE
fix: enable static linking for loongarch64/riscv64 musl targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.loongarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.riscv64gc-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
- Fix: #3007 

This ensures the generated binaries are fully statically linked.