### PR TITLE
fix: support `maturin develop` on Windows ARM with x86 Python

### DIFF
--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -31,6 +31,11 @@ pub fn is_cross_compiling(target: &Target) -> Result<bool> {
         // Not cross-compiling to compile for 32-bit Python from windows 64-bit
         return Ok(false);
     }
+    if target_triple.starts_with("x86_64-pc-windows") && host.starts_with("aarch64-pc-windows") {
+        // Not cross-compiling to compile for x86-64 Python from Windows arm64,
+        // Windows arm64 can run x86-64 binaries natively
+        return Ok(false);
+    }
     if target_triple.ends_with("windows-gnu") && host.ends_with("windows-msvc") {
         // Not cross-compiling to compile for Windows GNU from Windows MSVC host
         return Ok(false);

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -785,6 +785,13 @@ pub(crate) fn detect_arch_from_python(python: &PathBuf, target: &Target) -> Opti
                 } else if platform.contains("arm64") && target.target_arch() != Arch::Aarch64 {
                     return Some(TargetTriple::Regular("aarch64-apple-darwin".to_string()));
                 }
+            } else if platform.contains("win") {
+                // On Windows ARM with x86_64 Python (win-amd64), detect the arch mismatch
+                if platform.contains("amd64") && target.target_arch() != Arch::X86_64 {
+                    return Some(TargetTriple::Regular("x86_64-pc-windows-msvc".to_string()));
+                } else if platform.contains("arm64") && target.target_arch() != Arch::Aarch64 {
+                    return Some(TargetTriple::Regular("aarch64-pc-windows-msvc".to_string()));
+                }
             }
         }
         _ => eprintln!("⚠️  Warning: Failed to determine python platform"),


### PR DESCRIPTION
Windows ARM can natively run x86_64 binaries, so building for `x86_64-pc-windows-msvc` from `aarch64-pc-windows` should not be treated as cross-compilation.

Also extend `detect_arch_from_python` to auto-detect architecture mismatches on Windows (e.g. x86_64 Python on ARM host), so `maturin develop` works without needing `--target`.

Fixes #2778