### PR TITLE
feat: add `include-import-lib` option to bundle Windows import libraries in wheels

### DIFF
--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -63,6 +63,10 @@ strip = true
 # Source distribution generator,
 # supports cargo (default) and git.
 sdist-generator = "cargo"
+# Include the Windows import library (.dll.lib or .dll.a) in the wheel.
+# This is useful when distributing shared libraries that other programs
+# need to link against at compile time.
+include-import-lib = false
 # Use base Python executable instead of venv Python executable in PEP 517 build.
 #
 # This can help avoid unnecessary rebuilds, as the Python executable does not change

--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -101,6 +101,11 @@
         "$ref": "#/$defs/GlobPattern"
       }
     },
+    "include-import-lib": {
+      "description": "Include the import library (.dll.lib) in the wheel on Windows",
+      "type": "boolean",
+      "default": false
+    },
     "locked": {
       "description": "Require Cargo.lock is up to date",
       "type": [

--- a/src/binding_generator/mod.rs
+++ b/src/binding_generator/mod.rs
@@ -193,6 +193,16 @@ where
                         }
                     }
                 }
+
+                // 4a. Install import library on Windows
+                if let Some(import_lib) = &artifact.import_lib_path
+                    && context.include_import_lib
+                {
+                    let target = base_path.join(import_lib.file_name().unwrap());
+                    fs::create_dir_all(target.parent().unwrap())?;
+                    debug!("Installing import library {}", target.display());
+                    fs::copy(import_lib, &target)?;
+                }
             }
             _ => {
                 // 2b. Install the artifact
@@ -212,6 +222,15 @@ where
                         // Use add_entry_force to bypass exclusion checks for generated binding files
                         writer.add_entry_force(target, source)?;
                     }
+                }
+
+                // 4b. Install import library on Windows
+                if let Some(import_lib) = &artifact.import_lib_path
+                    && context.include_import_lib
+                {
+                    let dest = module.join(import_lib.file_name().unwrap());
+                    debug!("Adding import library to archive {}", dest.display());
+                    writer.add_file_force(dest, import_lib, false)?;
                 }
             }
         }

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -147,6 +147,8 @@ pub struct BuildContext {
     pub pypi_validation: bool,
     /// SBOM configuration
     pub sbom: Option<SbomConfig>,
+    /// Include the import library (.dll.lib) in the wheel on Windows
+    pub include_import_lib: bool,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -887,6 +887,9 @@ impl BuildContextBuilder {
         }
 
         let crate_name = cargo_toml.package.name;
+        let include_import_lib = pyproject
+            .map(|p| p.include_import_lib())
+            .unwrap_or_default();
         Ok(BuildContext {
             target,
             compile_targets,
@@ -912,6 +915,7 @@ impl BuildContextBuilder {
             compression: build_options.compression,
             pypi_validation,
             sbom,
+            include_import_lib,
         })
     }
 }

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -306,6 +306,9 @@ pub struct ToolMaturin {
     pub use_base_python: bool,
     /// SBOM configuration
     pub sbom: Option<SbomConfig>,
+    /// Include the import library (.dll.lib) in the wheel on Windows
+    #[serde(default)]
+    pub include_import_lib: bool,
 }
 
 /// A pyproject.toml as specified in PEP 517
@@ -438,6 +441,13 @@ impl PyProjectToml {
     /// Returns the value of `[tool.maturin.manifest-path]` in pyproject.toml
     pub fn manifest_path(&self) -> Option<&Path> {
         self.maturin()?.manifest_path.as_deref()
+    }
+
+    /// Returns the value of `[tool.maturin.include-import-lib]` in pyproject.toml
+    pub fn include_import_lib(&self) -> bool {
+        self.maturin()
+            .map(|maturin| maturin.include_import_lib)
+            .unwrap_or_default()
     }
 
     /// Warn about `build-system.requires` mismatching expectations.

--- a/test-crates/cffi-pure/pyproject.toml
+++ b/test-crates/cffi-pure/pyproject.toml
@@ -9,3 +9,4 @@ dynamic = ["version"]
 
 [tool.maturin]
 bindings = "cffi"
+include-import-lib = true


### PR DESCRIPTION
Add a new `include-import-lib` option (defaults to false) in `[tool.maturin]` that includes the Windows import library (`.dll.lib` for MSVC, `.dll.a` for MinGW) in the built wheel. This enables users who distribute shared libraries via wheels to allow other programs to link against them at compile time.

The import library path is extracted directly from cargo's JSON build output (the extra filenames reported alongside the primary artifact), so no extra file copying to staging directories is needed.

Supported for all binding types that produce cdylibs/dlls: cffi, uniffi, and pyo3.

Closes #2289