### PR TITLE
Upgrade memmap2 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
`maturin` fails on build on AIX due to the following:
```
error[E0308]: mismatched types
    --> /home/amyk/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/memmap2-0.9.9/src/unix.rs:429:30
     |
 429 |             if libc::madvise(self.ptr.offset(offset), len, advice) != 0 {
     |                ------------- ^^^^^^^^^^^^^^^^^^^^^^^ expected `*mut u8`, found `*mut c_void`
     |                |
     |                arguments to this function are incorrect
     |
     = note: expected raw pointer `*mut u8`
                found raw pointer `*mut c_void`
note: function defined here
    --> /home/amyk/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libc-0.2.180/src/unix/aix/mod.rs:3010:12
     |
3010 |     pub fn madvise(addr: caddr_t, len: size_t, advice: c_int) -> c_int;
     |            ^^^^^^^

```
This issue is resolved thanks to https://github.com/RazrFalcon/memmap2-rs/commit/d2054a2c9225b8b89968a0f49d10aaed9ff76367, which is available in v0.9.10.