### PR TITLE
feat: include debug info files (.pdb, .dSYM, .dwp) in wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.egg
 *.egg-info/
+*.dwp
+*.dSYM
 *.o
+*.pdb
 *.py[cdo]
 *.so
 .pytest_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
  "unicode-xid",
  "ureq",
  "url",
+ "walkdir",
  "which",
  "wild",
  "xz2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ xz2 = { version = "0.1", optional = true }
 # log
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+walkdir = "2.5.0"
 
 # project scaffolding, maturin new/init/generate-ci
 dialoguer = { version = "0.12.0", default-features = false, optional = true }

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -42,6 +42,11 @@ Options:
       --strip
           Strip the library for minimum file size
 
+      --include-debuginfo
+          Include debug info files (.pdb on Windows, .dSYM on macOS, .dwp on Linux) in the wheel.
+          When enabled, maturin automatically configures split-debuginfo=packed so that separate
+          debug info files are produced. Cannot be used with --strip.
+
       --sdist
           Build a source distribution
 

--- a/guide/src/local_development.md
+++ b/guide/src/local_development.md
@@ -4,6 +4,8 @@
 
 For local development, the `maturin develop` command can be used to quickly
 build a package in debug mode by default and install it to virtualenv.
+Debug info files (.pdb, .dSYM, .dwp) are automatically included alongside the
+built artifact unless `--strip` is used.
 
 ```
 Usage: maturin develop [OPTIONS] [ARGS]...

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -150,6 +150,8 @@ pub struct BuildContext {
     pub sbom: Option<SbomConfig>,
     /// Include the import library (.dll.lib) in the wheel on Windows
     pub include_import_lib: bool,
+    /// Include debug info files (.pdb, .dSYM, .dwp) in the wheel
+    pub include_debuginfo: bool,
     /// Cargo features conditionally enabled based on the target Python version
     pub conditional_features: Vec<(String, VersionSpecifiers)>,
 }

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -220,6 +220,12 @@ pub struct BuildOptions {
     #[arg(long)]
     pub zig: bool,
 
+    /// Include debug info files (.pdb on Windows, .dSYM on macOS, .dwp on Linux)
+    /// in the wheel. When enabled, maturin automatically configures
+    /// split-debuginfo=packed so that separate debug info files are produced.
+    #[arg(long)]
+    pub include_debuginfo: bool,
+
     /// Cargo build options
     #[command(flatten)]
     pub cargo: CargoOptions,
@@ -762,6 +768,10 @@ impl BuildContextBuilder {
         }
 
         let strip = strip.unwrap_or_else(|| pyproject.map(|x| x.strip()).unwrap_or_default());
+        if strip && build_options.include_debuginfo {
+            bail!("--include-debuginfo cannot be used with --strip");
+        }
+        let include_debuginfo = build_options.include_debuginfo;
         let skip_auditwheel = pyproject.map(|x| x.skip_auditwheel()).unwrap_or_default()
             || build_options.skip_auditwheel;
         let auditwheel = build_options
@@ -940,6 +950,7 @@ impl BuildContextBuilder {
             pypi_validation,
             sbom,
             include_import_lib,
+            include_debuginfo,
             conditional_features,
         })
     }

--- a/src/develop.rs
+++ b/src/develop.rs
@@ -474,6 +474,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
             target: target_triple,
             ..cargo_options
         },
+        include_debuginfo: !strip,
         sbom_include: Vec::new(),
         compression,
     };

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -68,6 +68,11 @@ Options:
           
           Make sure you installed zig with `pip install maturin[zig]`
 
+      --include-debuginfo
+          Include debug info files (.pdb on Windows, .dSYM on macOS, .dwp on Linux) in the wheel.
+          When enabled, maturin automatically configures split-debuginfo=packed so that separate
+          debug info files are produced
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -107,6 +107,11 @@ Options:
           
           Make sure you installed zig with `pip install maturin[zig]`
 
+      --include-debuginfo
+          Include debug info files (.pdb on Windows, .dSYM on macOS, .dwp on Linux) in the wheel.
+          When enabled, maturin automatically configures split-debuginfo=packed so that separate
+          debug info files are produced
+
   -q, --quiet
           Do not print cargo log messages
 

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -327,7 +327,8 @@ pub fn check_wheel_files(
 ) -> Result<()> {
     let wheel = build_wheel_files(package, unique_name)?;
     let drop_platform_specific_files = |file: &&str| -> bool {
-        !matches!(Path::new(file).extension(), Some(ext) if ext == "pyc" || ext == "pyd" || ext == "so")
+        !matches!(Path::new(file).extension(), Some(ext) if ext == "pyc" || ext == "pyd" || ext == "so" || ext == "pdb" || ext == "dwp")
+            && !file.contains(".dSYM/")
     };
     assert_eq!(
         wheel


### PR DESCRIPTION
Add `--include-debuginfo` CLI flag for `maturin build` and `maturin publish` to opt-in to including debug info files (`.pdb`, `.dSYM`, `.dwp`) in wheels. For maturin develop, debug info is automatically included unless `--strip` is used.

## `split-debuginfo` handling

When `--include-debuginfo` is active (or in develop mode), maturin configures `split-debuginfo` rustflags appropriately per platform:
* macOS: sets `split-debuginfo=packed` (overrides Cargo's default unpacked)
* Linux: keeps Cargo's default off (embedded in binary)
* Windows MSVC: keeps Cargo's default packed (`.pdb`)

Validates that existing `split-debuginfo` rustflags are compatible — only rejects unpacked on Linux (scattered `.dwo` files that cargo doesn't report).

## How it works

* Debug info paths are extracted from cargo's JSON `CompilerArtifact` filenames array, the same way import libraries are already handled
* `--include-debuginfo` and `--strip` are mutually exclusive (checked at build time)
* Stale debug info from previous editable installs is cleaned up before copying
* `.dSYM` bundle filtering in `is_develop_build_artifact` correctly matches on the bundle directory name rather than leaf filenames

Closes #2213, closes #267, closes #2220