### PR TITLE
fix: only ignore maturin-generated native libraries on all platforms

### DIFF
--- a/src/module_writer/mod.rs
+++ b/src/module_writer/mod.rs
@@ -171,11 +171,17 @@ pub fn write_python_part(
         let relative = absolute.strip_prefix(python_dir).unwrap();
         if !absolute.is_dir() {
             // Ignore native libraries from develop, if any
-            if let Some(extension) = relative.extension()
-                && extension.to_string_lossy() == "so"
-            {
-                debug!("Ignoring native library {}", relative.display());
-                continue;
+            if let Some(file_name) = relative.file_name() {
+                let file_name = file_name.to_string_lossy();
+                if file_name.starts_with(&project_layout.extension_name)
+                    && (file_name.ends_with(".so")
+                        || file_name.ends_with(".pyd")
+                        || file_name.ends_with(".dll")
+                        || file_name.ends_with(".dylib"))
+                {
+                    debug!("Ignoring native library {}", relative.display());
+                    continue;
+                }
             }
             #[cfg(unix)]
             let mode = absolute.metadata()?.permissions().mode();


### PR DESCRIPTION
Previously, only `.so` files were ignored during wheel building, causing issues on Windows where `.pyd`/`.dll` artifacts from develop mode would trigger "File overwrote an existing tracked file" errors.

Now checks that the filename starts with the `extension_name` and ends with a native library extension (`.so`, `.pyd`, `.dll`, `.dylib`), so only maturin-generated files are skipped.

Fixes #3022