### PR TITLE
feat: support conditional cargo features based on Python version

### DIFF
--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -18,6 +18,13 @@ profile = "release"
 editable-profile = "release"
 # List of features to activate
 features = ["foo", "bar"]
+# Features can also be conditional on the target Python version
+# using PEP 440 version specifiers:
+# features = [
+#   "always-on-feature",
+#   { feature = "pyo3/abi3-py311", python-version = ">=3.11" },
+#   { feature = "pyo3/abi3-py38", python-version = "<3.11" },
+# ]
 # Activate all available features
 all-features = false
 # Do not activate the `default` feature

--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -75,13 +75,13 @@
       }
     },
     "features": {
-      "description": "Space or comma separated list of features to activate",
+      "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and `python-version` keys.",
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/FeatureSpec"
       }
     },
     "frozen": {
@@ -306,6 +306,33 @@
       },
       "required": [
         "name"
+      ]
+    },
+    "FeatureSpec": {
+      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n]\n```",
+      "anyOf": [
+        {
+          "description": "A plain feature name, always enabled",
+          "type": "string"
+        },
+        {
+          "description": "A feature enabled only when the target Python version matches",
+          "type": "object",
+          "properties": {
+            "feature": {
+              "description": "The cargo feature to enable",
+              "type": "string"
+            },
+            "python-version": {
+              "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
+              "type": "string"
+            }
+          },
+          "required": [
+            "feature",
+            "python-version"
+          ]
+        }
       ]
     },
     "Format": {

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -29,6 +29,7 @@ use fs_err as fs;
 use ignore::overrides::{Override, OverrideBuilder};
 use lddtree::Library;
 use normpath::PathExt;
+use pep440_rs::VersionSpecifiers;
 use platform_info::*;
 use regex::Regex;
 use sha2::{Digest, Sha256};
@@ -149,6 +150,8 @@ pub struct BuildContext {
     pub sbom: Option<SbomConfig>,
     /// Include the import library (.dll.lib) in the wheel on Windows
     pub include_import_lib: bool,
+    /// Cargo features conditionally enabled based on the target Python version
+    pub conditional_features: Vec<(String, VersionSpecifiers)>,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).


### PR DESCRIPTION
Extend `[tool.maturin] features` to accept both plain feature strings and conditional objects with `feature` and `python-version` keys:

```toml
features = [
  "always-on-feature",
  { feature = "pyo3/abi3-py311", python-version = ">=3.11" },
  { feature = "pyo3/abi3-py38", python-version = "<3.11" },
]
```

Conditional features use PEP 440 version specifiers and are resolved at build time against the target Python interpreter version.

Closes #2472