### PR TITLE
Fix wrong abi3 tag for conditional cargo features enabled pyo3 abi3 feature

### DIFF
--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -184,13 +184,19 @@ impl BuildContext {
                     let abi3_interps: Vec<_> = self
                         .interpreter
                         .iter()
-                        .filter(|interp| interp.has_stable_api())
+                        .filter(|interp| {
+                            interp.has_stable_api()
+                                && (interp.major as u8, interp.minor as u8) >= (*major, *minor)
+                        })
                         .cloned()
                         .collect();
                     let non_abi3_interps: Vec<_> = self
                         .interpreter
                         .iter()
-                        .filter(|interp| !interp.has_stable_api())
+                        .filter(|interp| {
+                            !interp.has_stable_api()
+                                || (interp.major as u8, interp.minor as u8) < (*major, *minor)
+                        })
                         .cloned()
                         .collect();
                     let mut built_wheels = Vec::new();

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -153,7 +153,12 @@ impl GenerateCI {
             ..
         } = ProjectResolver::resolve(self.manifest_path.clone(), cargo_options, false)?;
         let pyproject = pyproject_toml.as_ref();
-        let bridge = find_bridge(&cargo_metadata, pyproject.and_then(|x| x.bindings()))?;
+        let extra_pyo3_features = crate::build_options::pyo3_features_from_conditional(pyproject);
+        let bridge = find_bridge(
+            &cargo_metadata,
+            pyproject.and_then(|x| x.bindings()),
+            &extra_pyo3_features,
+        )?;
         let project_name = pyproject
             .and_then(|project| project.project_name())
             .unwrap_or(&project_layout.extension_name);


### PR DESCRIPTION
Detect abi3 from conditional features in pyproject.toml when not found in cargo metadata. Also filter abi3 interpreters by version >= abi3 minimum version so interpreters below the minimum get regular version-specific wheels.

Fixes https://github.com/PyO3/maturin/issues/3028