### PR TITLE
fix: `maturin build --sdist` wheel name/layout for excluded workspace crates

### DIFF
--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -610,6 +610,7 @@ pub struct BuildContextBuilder {
     strip: Option<bool>,
     editable: bool,
     sdist_only: bool,
+    pyproject_toml_path: Option<PathBuf>,
 }
 
 impl BuildContextBuilder {
@@ -619,6 +620,7 @@ impl BuildContextBuilder {
             strip: None,
             editable: false,
             sdist_only: false,
+            pyproject_toml_path: None,
         }
     }
 
@@ -637,12 +639,18 @@ impl BuildContextBuilder {
         self
     }
 
+    pub fn pyproject_toml_path(mut self, path: Option<PathBuf>) -> Self {
+        self.pyproject_toml_path = path;
+        self
+    }
+
     pub fn build(self) -> Result<BuildContext> {
         let Self {
             build_options,
             strip,
             editable,
             sdist_only,
+            pyproject_toml_path: explicit_pyproject_path,
         } = self;
         build_options.compression.validate();
         let ProjectResolver {
@@ -660,6 +668,7 @@ impl BuildContextBuilder {
             build_options.manifest_path.clone(),
             build_options.cargo.clone(),
             editable,
+            explicit_pyproject_path,
         )?;
         let pyproject = pyproject_toml.as_ref();
 

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -151,7 +151,7 @@ impl GenerateCI {
             pyproject_toml,
             project_layout,
             ..
-        } = ProjectResolver::resolve(self.manifest_path.clone(), cargo_options, false)?;
+        } = ProjectResolver::resolve(self.manifest_path.clone(), cargo_options, false, None)?;
         let pyproject = pyproject_toml.as_ref();
         let extra_pyo3_features = crate::build_options::pyo3_features_from_conditional(pyproject);
         let bridge = find_bridge(

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -562,7 +562,7 @@ pub fn test_build_wheels_from_sdist(package: impl AsRef<Path>, unique_name: &str
         .context("Failed to build source distribution")?;
 
     // Step 2: Unpack sdist and build wheels from it
-    let (_tmp, cargo_toml) = unpack_sdist(&sdist_path)?;
+    let (_tmp, cargo_toml, pyproject_toml) = unpack_sdist(&sdist_path)?;
     let wheel_options = BuildOptions {
         out: Some(wheel_dir),
         cargo: CargoOptions {
@@ -579,6 +579,7 @@ pub fn test_build_wheels_from_sdist(package: impl AsRef<Path>, unique_name: &str
         .into_build_context()
         .strip(Some(cfg!(feature = "faster-tests")))
         .editable(false)
+        .pyproject_toml_path(Some(pyproject_toml))
         .build()?;
     let wheels = wheel_context.build_wheels()?;
     assert!(


### PR DESCRIPTION
When a crate is excluded from its Cargo workspace and has path dependencies outside its directory, the sdist places pyproject.toml at the sdist root while the Cargo.toml lives in a subdirectory.  After unpacking, `resolve_manifest_paths` walks up from the Cargo.toml but stops at the cargo workspace boundary (which for an excluded crate is the crate's own directory), never reaching the pyproject.toml.  This caused module-name, project name, and python-source to be lost, producing wheels with the wrong name and missing python files.

Fix by threading the known pyproject.toml path from `unpack_sdist` through `BuildContextBuilder` into `ProjectResolver::resolve`, so the discovery walk is skipped when the path is already known.

Also canonicalize the unpacked sdist directory to resolve symlinks (e.g. /var -> /private/var on macOS), which otherwise causes `project_root` and `python_dir` to disagree after `normalize()`, silently excluding python source files from wheels.

Closes #3030