### PR TITLE
feat: add python-implementation condition to conditional features

### DIFF
--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -75,7 +75,7 @@
       }
     },
     "features": {
-      "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and `python-version` keys.",
+      "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and optional `python-version` and `python-implementation` keys.",
       "type": [
         "array",
         "null"
@@ -309,14 +309,14 @@
       ]
     },
     "FeatureSpec": {
-      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n]\n```",
+      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions\nand/or implementations.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\", python-implementation = \"cpython\" },\n  { feature = \"pypy-compat\", python-implementation = \"pypy\" },\n]\n```",
       "anyOf": [
         {
           "description": "A plain feature name, always enabled",
           "type": "string"
         },
         {
-          "description": "A feature enabled only when the target Python version matches",
+          "description": "A feature enabled only when the conditions match",
           "type": "object",
           "properties": {
             "feature": {
@@ -326,11 +326,14 @@
             "python-version": {
               "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
               "type": "string"
+            },
+            "python-implementation": {
+              "description": "Python implementation name, e.g. \"cpython\", \"pypy\", \"graalpy\"",
+              "type": "string"
             }
           },
           "required": [
-            "feature",
-            "python-version"
+            "feature"
           ]
         }
       ]

--- a/src/build_context.rs
+++ b/src/build_context.rs
@@ -14,6 +14,7 @@ use crate::compression::CompressionOptions;
 use crate::module_writer::ModuleWriter;
 use crate::module_writer::{WheelWriter, add_data, write_pth};
 use crate::project_layout::ProjectLayout;
+use crate::pyproject_toml::ConditionalFeature;
 use crate::sbom::{SbomData, generate_sbom_data, write_sboms};
 use crate::source_distribution::source_distribution;
 use crate::target::validate_wheel_filename_for_pypi;
@@ -29,7 +30,6 @@ use fs_err as fs;
 use ignore::overrides::{Override, OverrideBuilder};
 use lddtree::Library;
 use normpath::PathExt;
-use pep440_rs::VersionSpecifiers;
 use platform_info::*;
 use regex::Regex;
 use sha2::{Digest, Sha256};
@@ -156,8 +156,8 @@ pub struct BuildContext {
     pub include_import_lib: bool,
     /// Include debug info files (.pdb, .dSYM, .dwp) in the wheel
     pub include_debuginfo: bool,
-    /// Cargo features conditionally enabled based on the target Python version
-    pub conditional_features: Vec<(String, VersionSpecifiers)>,
+    /// Cargo features conditionally enabled based on the target Python version/implementation
+    pub conditional_features: Vec<ConditionalFeature>,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1147,15 +1147,17 @@ pub fn pyo3_features_from_conditional(
     };
     let crate_names: &[&'static str] = &["pyo3", "pyo3-ffi"];
     for spec in features {
-        if let FeatureSpec::Conditional { feature, .. } = spec {
-            for &crate_name in crate_names {
-                let prefix = format!("{crate_name}/");
-                if let Some(feat_name) = feature.strip_prefix(&prefix) {
-                    extra
-                        .entry(crate_name)
-                        .or_default()
-                        .push(feat_name.to_string());
-                }
+        let feature = match spec {
+            FeatureSpec::Plain(_) => continue,
+            FeatureSpec::Conditional { feature, .. } => feature,
+        };
+        for &crate_name in crate_names {
+            let prefix = format!("{crate_name}/");
+            if let Some(feat_name) = feature.strip_prefix(&prefix) {
+                extra
+                    .entry(crate_name)
+                    .or_default()
+                    .push(feat_name.to_string());
             }
         }
     }


### PR DESCRIPTION
Allow conditional cargo features to also filter on the Python implementation (cpython, pypy, graalpy) in addition to python-version.

Both fields are now optional — at least one must be present for a conditional entry, otherwise treated as a plain entry. Matching is case-insensitive.

Example:

```toml
  features = [
    { feature = "pyo3/abi3-py311", python-version = ">=3.11", python-implementation = "cpython" },
    { feature = "pypy-compat", python-implementation = "pypy" },
  ]
```

Closes #3037