### PR TITLE
Use the latest version of github actions

### DIFF
--- a/src/ci.rs
+++ b/src/ci.rs
@@ -444,7 +444,7 @@ jobs:\n",
             };
             conf.push_str(&format!(
                 "      - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: {artifact_name}
           path: dist
@@ -613,7 +613,7 @@ jobs:\n",
             ));
             conf.push_str(
                 "      - name: Upload sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-sdist
           path: dist
@@ -649,7 +649,7 @@ jobs:\n",
         }
         conf.push_str(
             r#"    steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
 "#,
         );
         if !self.skip_attestation {
@@ -771,7 +771,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: auto
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-linux-${{ matrix.platform.target }}
                       path: dist
@@ -802,7 +802,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: musllinux_1_2
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-musllinux-${{ matrix.platform.target }}
                       path: dist
@@ -834,7 +834,7 @@ mod tests {
                       args: --release --out dist --find-interpreter
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-windows-${{ matrix.platform.target }}
                       path: dist
@@ -860,7 +860,7 @@ mod tests {
                       args: --release --out dist --find-interpreter
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-macos-${{ matrix.platform.target }}
                       path: dist
@@ -875,7 +875,7 @@ mod tests {
                       command: sdist
                       args: --out dist
                   - name: Upload sdist
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-sdist
                       path: dist
@@ -893,7 +893,7 @@ mod tests {
                   # Used to generate artifact attestation
                   attestations: write
                 steps:
-                  - uses: actions/download-artifact@v6
+                  - uses: actions/download-artifact@v7
                   - name: Generate artifact attestation
                     uses: actions/attest-build-provenance@v3
                     with:
@@ -981,7 +981,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: auto
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-linux-${{ matrix.platform.target }}
                       path: dist
@@ -1019,7 +1019,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: musllinux_1_2
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-musllinux-${{ matrix.platform.target }}
                       path: dist
@@ -1061,7 +1061,7 @@ mod tests {
                       args: --release --out dist -i python3.14t
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-windows-${{ matrix.platform.target }}
                       path: dist
@@ -1093,7 +1093,7 @@ mod tests {
                       args: --release --out dist -i python3.14t
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-macos-${{ matrix.platform.target }}
                       path: dist
@@ -1111,7 +1111,7 @@ mod tests {
                   # Used to generate artifact attestation
                   attestations: write
                 steps:
-                  - uses: actions/download-artifact@v6
+                  - uses: actions/download-artifact@v7
                   - name: Generate artifact attestation
                     uses: actions/attest-build-provenance@v3
                     with:
@@ -1202,7 +1202,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: auto
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-linux-${{ matrix.platform.target }}
                       path: dist
@@ -1240,7 +1240,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: musllinux_1_2
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-musllinux-${{ matrix.platform.target }}
                       path: dist
@@ -1282,7 +1282,7 @@ mod tests {
                       args: --release --out dist -i python3.14t
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-windows-${{ matrix.platform.target }}
                       path: dist
@@ -1314,7 +1314,7 @@ mod tests {
                       args: --release --out dist -i python3.14t
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-macos-${{ matrix.platform.target }}
                       path: dist
@@ -1330,7 +1330,7 @@ mod tests {
                   # Used to upload release artifacts
                   contents: write
                 steps:
-                  - uses: actions/download-artifact@v6
+                  - uses: actions/download-artifact@v7
                   - name: Install uv
                     if: ${{ startsWith(github.ref, 'refs/tags/') }}
                     uses: astral-sh/setup-uv@v7
@@ -1412,7 +1412,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: auto
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-linux-${{ matrix.platform.target }}
                       path: dist
@@ -1468,7 +1468,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: musllinux_1_2
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-musllinux-${{ matrix.platform.target }}
                       path: dist
@@ -1528,7 +1528,7 @@ mod tests {
                       args: --release --out dist --find-interpreter
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-windows-${{ matrix.platform.target }}
                       path: dist
@@ -1563,7 +1563,7 @@ mod tests {
                       args: --release --out dist --find-interpreter
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-macos-${{ matrix.platform.target }}
                       path: dist
@@ -1586,7 +1586,7 @@ mod tests {
                       command: sdist
                       args: --out dist
                   - name: Upload sdist
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-sdist
                       path: dist
@@ -1604,7 +1604,7 @@ mod tests {
                   # Used to generate artifact attestation
                   attestations: write
                 steps:
-                  - uses: actions/download-artifact@v6
+                  - uses: actions/download-artifact@v7
                   - name: Generate artifact attestation
                     uses: actions/attest-build-provenance@v3
                     with:
@@ -1673,7 +1673,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: auto
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-linux-${{ matrix.platform.target }}
                       path: dist
@@ -1701,7 +1701,7 @@ mod tests {
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                       manylinux: musllinux_1_2
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-musllinux-${{ matrix.platform.target }}
                       path: dist
@@ -1729,7 +1729,7 @@ mod tests {
                       args: --release --out dist
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-windows-${{ matrix.platform.target }}
                       path: dist
@@ -1752,7 +1752,7 @@ mod tests {
                       args: --release --out dist
                       sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
                   - name: Upload wheels
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-macos-${{ matrix.platform.target }}
                       path: dist
@@ -1767,7 +1767,7 @@ mod tests {
                       command: sdist
                       args: --out dist
                   - name: Upload sdist
-                    uses: actions/upload-artifact@v5
+                    uses: actions/upload-artifact@v6
                     with:
                       name: wheels-sdist
                       path: dist
@@ -1785,7 +1785,7 @@ mod tests {
                   # Used to generate artifact attestation
                   attestations: write
                 steps:
-                  - uses: actions/download-artifact@v6
+                  - uses: actions/download-artifact@v7
                   - name: Generate artifact attestation
                     uses: actions/attest-build-provenance@v3
                     with:


### PR DESCRIPTION
I used the latest released versions of [`upload-artifact`](https://github.com/actions/upload-artifact) and [`download-artifact`](https://github.com/actions/download-artifact)