### PR TITLE
Fix non-existent comment tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,7 +318,7 @@ jobs:
         run: cargo publish --dry-run
       - name: Authenticate with crates.io
         if: startsWith(github.ref, 'refs/tags/')
-        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
         id: auth
       - name: cargo publish
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Renovate was complaining:

> Dependency Lookup Warnings
>
> Renovate failed to look up the following dependencies:
>
> Could not determine new digest for update (github-tags package rust-lang/crates-io-auth-action)
>
> Files affected:
>.github/workflows/release.yml