### PR TITLE
Sync legacy_py.rs with upstream PyPI warehouse legacy.py

### DIFF
--- a/src/target/legacy_py.rs
+++ b/src/target/legacy_py.rs
@@ -50,7 +50,7 @@ pub(super) static WINDOWS_ARCHES: &[&str] = &["x86_64", "i686", "aarch64"];
 pub(super) static MACOS_ARCHES: &[&str] = &["x86_64", "arm64", "i686", "universal2"];
 
 /// Those are actually hardcoded in warehouse in the same way.
-pub(super) static MACOS_MAJOR_VERSIONS: &[&str] = &["10", "11", "12", "13", "14", "15"];
+pub(super) static MACOS_MAJOR_VERSIONS: &[&str] = &["10", "11", "12", "13", "14", "15", "26"];
 
 pub(super) static IOS_ARCHES: &[&str] = &["arm64", "x86_64"];
 
@@ -60,5 +60,6 @@ pub(super) static MANYLINUX_ARCHES: &[&str] = &[
     "x86_64", "i686", "aarch64", "armv7l", "ppc64le", "s390x", "ppc64", "riscv64",
 ];
 
-pub(super) static MUSLLINUX_ARCHES: &[&str] =
-    &["x86_64", "i686", "aarch64", "armv7l", "ppc64le", "s390x"];
+pub(super) static MUSLLINUX_ARCHES: &[&str] = &[
+    "x86_64", "i686", "aarch64", "armv7l", "ppc64le", "s390x", "riscv64",
+];

--- a/src/target/pypi_tags.rs
+++ b/src/target/pypi_tags.rs
@@ -191,7 +191,7 @@ mod tests {
             ("manylinux_2_39_riscv64", true),
             // musllinux platforms
             ("musllinux_1_1_x86_64", true),
-            ("musllinux_1_1_riscv64", false),
+            ("musllinux_1_1_riscv64", true),
             // Old arm versions
             // https://github.com/pypi/warehouse/blob/556e1e3390999381c382873b003a779a1363cb4d/warehouse/forklift/legacy.py#L122-L123
             ("linux_armv6l", true),
@@ -200,6 +200,7 @@ mod tests {
             ("macosx_9_0_x86_64", false), // Invalid major version
             ("macosx_10_9_x86_64", true),
             ("macosx_11_0_arm64", true),
+            ("macosx_26_0_arm64", true),
             // iOS platforms
             ("ios_14_0_arm64_iphoneos", true),
             ("ios_14_0_x86_64_iphonesimulator", true),


### PR DESCRIPTION
- Add macOS 26 to `MACOS_MAJOR_VERSIONS`
- Add riscv64 to `MUSLLINUX_ARCHES` (upstream unified manylinux/musllinux arches)