### PR TITLE
Keep cargo build artifact at original path after staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "pretty_assertions",
  "pyproject-toml",
  "python-pkginfo",
+ "reflink-copy",
  "regex",
  "rstest",
  "rustc_version",
@@ -2394,6 +2395,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbed272e39c47a095a5242218a67412a220006842558b03fe2935e8f3d7b92"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
 ]
 
 [[package]]
@@ -3786,10 +3799,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3882,6 +3990,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ pretty_assertions = { version = "1.3.0", optional = true }
 which = { version = "8.0.0", optional = true }
 
 memmap2 = "0.9.9"
+reflink-copy = "0.1.28"
 
 [dev-dependencies]
 expect-test = "1.4.1"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -861,9 +861,10 @@ fn compile_target(
 pub fn warn_missing_py_init(artifact: &Path, module_name: &str) -> Result<()> {
     let py_init = format!("PyInit_{module_name}");
     let fd = File::open(artifact)?;
-    // SAFETY: The caller stages (moves/copies) the artifact into a private
-    // directory before invoking this function, so no concurrent process
-    // (e.g. cargo / rust-analyzer) can modify it while we have it mapped.
+    // SAFETY: The caller stages (moves or copies) the artifact into a
+    // private directory before invoking this function, so no concurrent
+    // process (e.g. cargo / rust-analyzer) can modify it while we have
+    // it mapped.
     let mmap = unsafe { memmap2::Mmap::map(&fd).context("mmap failed")? };
     let mut found = false;
     match goblin::Object::parse(&mmap)? {


### PR DESCRIPTION
Previously `stage_artifact()` used `fs::rename` to move the artifact from the cargo output directory (e.g. `target/release/`) to a private staging directory (`target/maturin/`). This meant users could no longer find the built .so/.dylib/.dll at the standard cargo output location.

Now `stage_artifact()` still uses an atomic `fs::rename` into the staging directory (protecting against concurrent modification by cargo or rust-analyzer), then copies the staged file back to the original location via reflink (copy-on-write) when the filesystem supports it, falling back to a regular `fs::copy` otherwise. The copy-back is best-effort and does not fail the build. When fs::rename itself fails (e.g. cross-device), we fall back to reflink-or-copy directly.

On Linux, ioctl_ficlone does not preserve file permissions, so we explicitly copy them after the reflink. On macOS, clonefile preserves all metadata natively. This approach is adapted from uv's reflink_with_permissions implementation.

Refs: https://github.com/astral-sh/uv/blob/main/crates/uv-fs/src/link.rs
Refs: https://github.com/astral-sh/uv/issues/18181

Fixes https://github.com/PyO3/maturin/pull/2950#issuecomment-3979694037