### PR TITLE
Fix `--strip` conflicting with `--include-debuginfo` in develop

### DIFF
--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -169,10 +169,14 @@ impl BuildContextBuilder {
         }
 
         let strip = strip.unwrap_or_else(|| pyproject.map(|x| x.strip()).unwrap_or_default());
-        if strip && build_options.include_debuginfo {
-            bail!("--include-debuginfo cannot be used with --strip");
-        }
-        let include_debuginfo = build_options.include_debuginfo;
+        let include_debuginfo = if strip && build_options.include_debuginfo {
+            tracing::warn!("--strip is enabled, disabling --include-debuginfo");
+            false
+        } else if strip {
+            false
+        } else {
+            build_options.include_debuginfo
+        };
         let skip_auditwheel = pyproject.map(|x| x.skip_auditwheel()).unwrap_or_default()
             || build_options.skip_auditwheel;
         let auditwheel = build_options


### PR DESCRIPTION
When strip is enabled (e.g. via pyproject.toml), let it take precedence over `--include-debuginfo` instead of bailing with an error. This fixes `maturin develop` failing when `tool.maturin.strip = true` is set in pyproject.toml, since develop hard-codes `include_debuginfo = !strip` using the CLI flag which defaults to false.

Emit a warning when `--strip` disables an explicitly set `--include-debuginfo`.

Fixes #3056