### PR TITLE
Fix abi3 wheel producing version-specific tags for CPython below minimum

### DIFF
--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -181,12 +181,7 @@ impl BuildContext {
         let non_abi3_interps: Vec<_> = self
             .interpreter
             .iter()
-            .filter(|interp| {
-                !interp.has_stable_api()
-                    || min_version.is_some_and(|(major, minor)| {
-                        (interp.major as u8, interp.minor as u8) < (major, minor)
-                    })
-            })
+            .filter(|interp| !interp.has_stable_api())
             .cloned()
             .collect();
 


### PR DESCRIPTION
When abi3 has a fixed minimum version (e.g. abi3-py39), CPython interpreters below that version (e.g. 3.8) were incorrectly routed to the non-abi3 wheel build path, producing cp38-cp38 wheels instead of the correct cp39-abi3 wheel.

Only interpreters that inherently lack stable ABI support (PyPy, GraalPy, free-threaded CPython) should get version-specific wheels.

Fixes #3059