### PR TITLE
feat: add Profile-Guided Optimization (PGO) support

### DIFF
--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -29,6 +29,7 @@ pub struct BuildContextBuilder {
     editable: bool,
     sdist_only: bool,
     pyproject_toml_path: Option<PathBuf>,
+    pgo: bool,
 }
 
 impl BuildContextBuilder {
@@ -39,6 +40,7 @@ impl BuildContextBuilder {
             editable: false,
             sdist_only: false,
             pyproject_toml_path: None,
+            pgo: false,
         }
     }
 
@@ -62,6 +64,11 @@ impl BuildContextBuilder {
         self
     }
 
+    pub fn pgo(mut self, pgo: bool) -> Self {
+        self.pgo = pgo;
+        self
+    }
+
     #[instrument(skip_all)]
     pub fn build(self) -> Result<BuildContext> {
         let Self {
@@ -70,6 +77,7 @@ impl BuildContextBuilder {
             editable,
             sdist_only,
             pyproject_toml_path: explicit_pyproject_path,
+            pgo,
         } = self;
         build_options.compression.validate();
         let ProjectResolver {
@@ -215,6 +223,20 @@ impl BuildContextBuilder {
             Vec::new()
         };
 
+        let pgo_command = if pgo {
+            let cmd = pyproject
+                .and_then(|p| p.pgo_command())
+                .map(|s| s.to_string());
+            if cmd.is_none() {
+                bail!(
+                    "--pgo requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml"
+                );
+            }
+            cmd
+        } else {
+            None
+        };
+
         Ok(BuildContext {
             target,
             compile_targets,
@@ -243,6 +265,8 @@ impl BuildContextBuilder {
             include_import_lib,
             include_debuginfo,
             conditional_features,
+            pgo_phase: None,
+            pgo_command,
         })
     }
 

--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -226,10 +226,11 @@ impl BuildContextBuilder {
         let pgo_command = if pgo {
             let cmd = pyproject
                 .and_then(|p| p.pgo_command())
-                .map(|s| s.to_string());
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
             if cmd.is_none() {
                 bail!(
-                    "--pgo requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml"
+                    "--pgo requires a non-empty `pgo-command` to be set in `[tool.maturin]` in pyproject.toml"
                 );
             }
             cmd

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -11,6 +11,7 @@ use crate::build_options::CargoOptions;
 use crate::compile::CompileTarget;
 use crate::compression::CompressionOptions;
 use crate::module_writer::{WheelWriter, write_pth};
+use crate::pgo::{PgoContext, PgoPhase};
 use crate::project_layout::ProjectLayout;
 use crate::pyproject_toml::ConditionalFeature;
 use crate::sbom::generate_sbom_data;
@@ -87,6 +88,10 @@ pub struct BuildContext {
     pub include_debuginfo: bool,
     /// Cargo features conditionally enabled based on the target Python version/implementation
     pub conditional_features: Vec<ConditionalFeature>,
+    /// Current PGO build phase (if PGO is enabled)
+    pub pgo_phase: Option<PgoPhase>,
+    /// PGO training command from pyproject.toml (only set when --pgo is passed)
+    pub pgo_command: Option<String>,
 }
 
 /// The wheel file location and its Python version tag (e.g. `py3`).
@@ -100,6 +105,14 @@ impl BuildContext {
     /// correct builder.
     #[instrument(skip_all)]
     pub fn build_wheels(&self) -> Result<Vec<BuiltWheelMetadata>> {
+        if self.pgo_command.is_some() {
+            return self.build_wheels_pgo();
+        }
+        self.build_wheels_inner()
+    }
+
+    /// Standard wheel build pipeline (no PGO).
+    fn build_wheels_inner(&self) -> Result<Vec<BuiltWheelMetadata>> {
         fs::create_dir_all(&self.out)
             .context("Failed to create the target directory for the wheels")?;
 
@@ -136,6 +149,174 @@ impl BuildContext {
             }
         }
 
+        Ok(wheels)
+    }
+
+    /// PGO three-phase build: instrumented → instrumentation → optimized.
+    ///
+    /// For non-abi3 PyO3 builds each interpreter gets its own
+    /// instrument → train → optimize cycle, because different Python
+    /// versions produce different compiled code via PyO3's build-time
+    /// configuration, so sharing a single profile across interpreters
+    /// causes "function control flow change detected (hash mismatch)"
+    /// warnings and defeats the purpose of PGO.
+    ///
+    /// For single-artifact builds (abi3, cffi, uniffi, bin) the compiled
+    /// code is identical across interpreters, so one PGO cycle suffices.
+    fn build_wheels_pgo(&self) -> Result<Vec<BuiltWheelMetadata>> {
+        let pgo_command = self
+            .pgo_command
+            .as_ref()
+            .expect("pgo_command must be set when build_wheels_pgo is called");
+
+        let needs_per_interpreter_pgo = matches!(
+            self.bridge(),
+            BridgeModel::PyO3(crate::PyO3 { abi3: None, .. })
+        );
+
+        eprintln!("🚀 Starting PGO build...");
+
+        // Verify llvm-profdata is available before starting
+        PgoContext::find_llvm_profdata()?;
+
+        if needs_per_interpreter_pgo {
+            self.build_wheels_pgo_per_interpreter(pgo_command)
+        } else {
+            self.build_wheels_pgo_single_pass(pgo_command)
+        }
+    }
+
+    /// Clone this context with PGO disabled (to prevent recursion) and
+    /// the given PGO phase set.
+    fn clone_for_pgo(&self, phase: PgoPhase) -> Self {
+        let mut ctx = self.clone();
+        ctx.pgo_command = None;
+        ctx.pgo_phase = Some(phase);
+        ctx
+    }
+
+    /// Single-pass PGO for abi3, cffi, uniffi, and bin builds where the
+    /// compiled artifact is the same regardless of the Python interpreter.
+    fn build_wheels_pgo_single_pass(&self, pgo_command: &str) -> Result<Vec<BuiltWheelMetadata>> {
+        let instrumentation_python = self
+            .interpreter
+            .first()
+            .context(
+                "PGO builds require a Python interpreter. \
+                 Please specify one with `--interpreter`.",
+            )?
+            .executable
+            .clone();
+
+        let pgo_ctx = PgoContext::new(pgo_command.to_owned())?;
+
+        // Phase 1: Instrumented build
+        eprintln!("📊 Phase 1/3: Building instrumented wheel...");
+        let mut instrumented_ctx = self.clone_for_pgo(PgoPhase::Generate(
+            pgo_ctx.profdata_dir_path().to_path_buf(),
+        ));
+        let instrumented_out =
+            tempfile::TempDir::new().context("Failed to create temp dir for instrumented wheel")?;
+        instrumented_ctx.out = instrumented_out.path().to_path_buf();
+        let instrumented_wheels = instrumented_ctx.build_wheels_inner()?;
+
+        // Phase 2: Instrumentation
+        eprintln!("🔬 Phase 2/3: Running PGO instrumentation...");
+        let instrumented_wheel_path = &instrumented_wheels
+            .first()
+            .context("No instrumented wheel was built")?
+            .0;
+        pgo_ctx.run_instrumentation(&instrumentation_python, instrumented_wheel_path, self)?;
+        pgo_ctx.merge_profiles()?;
+
+        // Phase 3: Optimized build
+        eprintln!("⚡ Phase 3/3: Building PGO-optimized wheel...");
+        let optimized_ctx =
+            self.clone_for_pgo(PgoPhase::Use(pgo_ctx.merged_profdata_path().to_path_buf()));
+        let wheels = optimized_ctx.build_wheels_inner()?;
+
+        eprintln!("🎉 PGO build complete!");
+        Ok(wheels)
+    }
+
+    /// Per-interpreter PGO for non-abi3 PyO3 builds. Each interpreter gets
+    /// its own instrument → train → optimize cycle so that profiles match
+    /// the exact compiled code for that Python version.
+    fn build_wheels_pgo_per_interpreter(
+        &self,
+        pgo_command: &str,
+    ) -> Result<Vec<BuiltWheelMetadata>> {
+        fs::create_dir_all(&self.out)
+            .context("Failed to create the target directory for the wheels")?;
+
+        let sbom_data = generate_sbom_data(self)?;
+        let mut wheels = Vec::new();
+
+        for (i, python_interpreter) in self.interpreter.iter().enumerate() {
+            eprintln!(
+                "📊 [{}/{}] PGO cycle for {} {}.{}...",
+                i + 1,
+                self.interpreter.len(),
+                python_interpreter.interpreter_kind,
+                python_interpreter.major,
+                python_interpreter.minor,
+            );
+
+            let pgo_ctx = PgoContext::new(pgo_command.to_owned())?;
+
+            // Phase 1: Build instrumented wheel for this interpreter
+            eprintln!("  📊 Phase 1/3: Building instrumented wheel...");
+            let mut instrumented_ctx = self.clone_for_pgo(PgoPhase::Generate(
+                pgo_ctx.profdata_dir_path().to_path_buf(),
+            ));
+            let instrumented_out = tempfile::TempDir::new()
+                .context("Failed to create temp dir for instrumented wheel")?;
+            instrumented_ctx.out = instrumented_out.path().to_path_buf();
+            let (instrumented_wheel_path, _) =
+                instrumented_ctx.build_single_pyo3_wheel(python_interpreter, &sbom_data)?;
+
+            // Phase 2: Run instrumentation with this interpreter
+            eprintln!("  🔬 Phase 2/3: Running PGO instrumentation...");
+            pgo_ctx.run_instrumentation(
+                &python_interpreter.executable,
+                &instrumented_wheel_path,
+                self,
+            )?;
+            pgo_ctx.merge_profiles()?;
+
+            // Phase 3: Build optimized wheel for this interpreter
+            eprintln!("  ⚡ Phase 3/3: Building PGO-optimized wheel...");
+            let optimized_ctx =
+                self.clone_for_pgo(PgoPhase::Use(pgo_ctx.merged_profdata_path().to_path_buf()));
+            let (wheel_path, tag) =
+                optimized_ctx.build_single_pyo3_wheel(python_interpreter, &sbom_data)?;
+
+            eprintln!(
+                "  📦 Built PGO-optimized wheel for {} {}.{}{} to {}",
+                python_interpreter.interpreter_kind,
+                python_interpreter.major,
+                python_interpreter.minor,
+                python_interpreter.abiflags,
+                wheel_path.display()
+            );
+            wheels.push((wheel_path, tag));
+        }
+
+        // Validate wheel filenames against PyPI platform tag rules if requested
+        if self.pypi_validation {
+            for (wheel_path, _) in &wheels {
+                let filename = wheel_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .ok_or_else(|| anyhow!("Invalid wheel filename: {:?}", wheel_path))?;
+
+                if let Err(error) = validate_wheel_filename_for_pypi(filename) {
+                    bail!("PyPI validation failed: {}", error);
+                }
+            }
+        }
+
+        eprintln!("🎉 PGO build complete!");
         Ok(wheels)
     }
 

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -210,11 +210,14 @@ impl BuildContext {
 
         let pgo_ctx = PgoContext::new(pgo_command.to_owned())?;
 
-        // Phase 1: Instrumented build
+        // Phase 1: Build a single instrumented wheel for training.
+        // We only need one wheel for profiling — the compiled native code is
+        // identical across interpreters for abi3/cffi/uniffi/bin builds.
         eprintln!("📊 Phase 1/3: Building instrumented wheel...");
         let mut instrumented_ctx = self.clone_for_pgo(PgoPhase::Generate(
             pgo_ctx.profdata_dir_path().to_path_buf(),
         ));
+        instrumented_ctx.interpreter = vec![self.interpreter[0].clone()];
         let instrumented_out =
             tempfile::TempDir::new().context("Failed to create temp dir for instrumented wheel")?;
         instrumented_ctx.out = instrumented_out.path().to_path_buf();

--- a/src/build_context/wheels.rs
+++ b/src/build_context/wheels.rs
@@ -214,6 +214,34 @@ impl BuildContext {
         )
     }
 
+    /// Compile, audit, and write a single PyO3 wheel for one interpreter.
+    ///
+    /// This is the core pipeline shared by [`build_pyo3_wheels`] and the
+    /// per-interpreter PGO path in [`build_wheels_pgo_per_interpreter`].
+    pub(super) fn build_single_pyo3_wheel(
+        &self,
+        python_interpreter: &PythonInterpreter,
+        sbom_data: &Option<SbomData>,
+    ) -> Result<BuiltWheelMetadata> {
+        let (artifact, out_dirs) = self.compile_cdylib(
+            Some(python_interpreter),
+            Some(&self.project_layout.extension_name),
+        )?;
+        let (policy, external_libs) =
+            self.auditwheel(&artifact, &self.platform_tag, Some(python_interpreter))?;
+        let platform_tags = self.resolve_platform_tags(&policy);
+        let wheel_path = self.write_pyo3_wheel(
+            python_interpreter,
+            artifact,
+            &platform_tags,
+            external_libs,
+            sbom_data,
+            &out_dirs,
+        )?;
+        let tag = format!("cp{}{}", python_interpreter.major, python_interpreter.minor);
+        Ok((wheel_path, tag))
+    }
+
     /// Builds wheels for a pyo3 extension for all given python versions.
     /// Return type is the same as [BuildContext::build_wheels()]
     ///
@@ -228,21 +256,7 @@ impl BuildContext {
     ) -> Result<Vec<BuiltWheelMetadata>> {
         let mut wheels = Vec::new();
         for python_interpreter in interpreters {
-            let (artifact, out_dirs) = self.compile_cdylib(
-                Some(python_interpreter),
-                Some(&self.project_layout.extension_name),
-            )?;
-            let (policy, external_libs) =
-                self.auditwheel(&artifact, &self.platform_tag, Some(python_interpreter))?;
-            let platform_tags = self.resolve_platform_tags(&policy);
-            let wheel_path = self.write_pyo3_wheel(
-                python_interpreter,
-                artifact,
-                &platform_tags,
-                external_libs,
-                sbom_data,
-                &out_dirs,
-            )?;
+            let (wheel_path, tag) = self.build_single_pyo3_wheel(python_interpreter, sbom_data)?;
             eprintln!(
                 "📦 Built wheel for {} {}.{}{} to {}",
                 python_interpreter.interpreter_kind,
@@ -251,8 +265,6 @@ impl BuildContext {
                 python_interpreter.abiflags,
                 wheel_path.display()
             );
-
-            let tag = format!("cp{}{}", python_interpreter.major, python_interpreter.minor);
             wheels.push((wheel_path, tag));
         }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -249,6 +249,22 @@ fn cargo_build_command(
         .unwrap_or_default();
     let original_rustflags = rustflags.flags.clone();
 
+    // Inject PGO flags if a PGO build phase is active
+    if let Some(ref pgo_phase) = context.pgo_phase {
+        match pgo_phase {
+            crate::pgo::PgoPhase::Generate(profdata_dir) => {
+                rustflags
+                    .flags
+                    .push(format!("-Cprofile-generate={}", profdata_dir.display()));
+            }
+            crate::pgo::PgoPhase::Use(profdata_path) => {
+                rustflags
+                    .flags
+                    .push(format!("-Cprofile-use={}", profdata_path.display()));
+            }
+        }
+    }
+
     let bridge_model = &compile_target.bridge_model;
     configure_bin_lib_flags(
         &mut cargo_rustc,

--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -1,4 +1,4 @@
-mod install_backend;
+pub(crate) mod install_backend;
 
 use crate::BuildContext;
 use crate::BuildOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod ci;
 mod compile;
 mod compression;
 mod cross_compile;
-mod develop;
+pub(crate) mod develop;
 mod generate_json_schema;
 mod metadata;
 mod module_writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ mod metadata;
 mod module_writer;
 #[cfg(feature = "scaffolding")]
 mod new_project;
+/// Profile-Guided Optimization (PGO) orchestration
+pub(crate) mod pgo;
 mod project_layout;
 pub mod pyproject_toml;
 mod python_interpreter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,13 @@ enum Command {
         /// used to build the project from source.
         #[arg(long)]
         sdist: bool,
+        /// Build with Profile-Guided Optimization (PGO).
+        ///
+        /// Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml.
+        /// This performs a three-phase build: instrumented build, profile training,
+        /// and optimized rebuild.
+        #[arg(long)]
+        pgo: bool,
         #[command(flatten)]
         build: BuildOptions,
     },
@@ -105,6 +112,11 @@ enum Command {
         /// Don't build a source distribution
         #[arg(long = "no-sdist")]
         no_sdist: bool,
+        /// Build with Profile-Guided Optimization (PGO).
+        ///
+        /// Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml.
+        #[arg(long)]
+        pgo: bool,
         #[command(flatten)]
         publish: PublishOpt,
         #[command(flatten)]
@@ -405,6 +417,7 @@ fn run() -> Result<()> {
             release,
             strip_opt,
             sdist,
+            pgo,
         } => {
             let strip = strip_opt.strip;
             // set profile to release if specified; `--release` and `--profile` are mutually exclusive
@@ -427,6 +440,7 @@ fn run() -> Result<()> {
                 .strip(strip)
                 .editable(false)
                 .pyproject_toml_path(sdist_pyproject_path)
+                .pgo(pgo)
                 .build()?;
             let wheels = build_context.build_wheels()?;
             assert!(!wheels.is_empty());
@@ -438,6 +452,7 @@ fn run() -> Result<()> {
             debug,
             no_strip,
             no_sdist,
+            pgo,
         } => {
             // set profile to dev if specified; `--debug` and `--profile` are mutually exclusive
             //
@@ -465,6 +480,7 @@ fn run() -> Result<()> {
                 .strip(Some(!no_strip))
                 .editable(false)
                 .pyproject_toml_path(sdist_pyproject_path)
+                .pgo(pgo)
                 .build()?;
 
             // ensure profile always set when publishing

--- a/src/pgo.rs
+++ b/src/pgo.rs
@@ -1,3 +1,4 @@
+use crate::develop::install_backend::{find_uv_bin, find_uv_python};
 use anyhow::{Context, Result, bail};
 use fs_err as fs;
 use std::path::{Path, PathBuf};
@@ -118,7 +119,7 @@ impl PgoContext {
 
     /// Run the PGO instrumentation workload.
     ///
-    /// 1. Create a temporary venv
+    /// 1. Create a temporary venv (using `uv` when available, otherwise `python -m venv`)
     /// 2. Install the instrumented wheel
     /// 3. Install dependencies
     /// 4. Run the instrumentation command
@@ -131,14 +132,31 @@ impl PgoContext {
         let venv_dir = TempDir::new().context("Failed to create temporary venv directory")?;
         let venv_path = venv_dir.path();
 
+        // Detect uv: try the binary first, then the Python module
+        let uv = find_uv_python(python).or_else(|_| find_uv_bin()).ok();
+
         // Create venv
-        let status = Command::new(python)
-            .args(["-m", "venv"])
-            .arg(venv_path)
-            .status()
-            .context("Failed to create virtual environment")?;
-        if !status.success() {
-            bail!("Failed to create virtual environment (exit status: {status})");
+        if let Some((uv_path, uv_args)) = &uv {
+            debug!("Creating venv with uv");
+            let status = Command::new(uv_path)
+                .args(uv_args.iter().copied())
+                .args(["venv", "--python"])
+                .arg(python)
+                .arg(venv_path)
+                .status()
+                .context("Failed to create virtual environment with uv")?;
+            if !status.success() {
+                bail!("Failed to create virtual environment with uv (exit status: {status})");
+            }
+        } else {
+            let status = Command::new(python)
+                .args(["-m", "venv"])
+                .arg(venv_path)
+                .status()
+                .context("Failed to create virtual environment")?;
+            if !status.success() {
+                bail!("Failed to create virtual environment (exit status: {status})");
+            }
         }
         debug!("Created temporary venv at {}", venv_path.display());
 
@@ -155,11 +173,12 @@ impl PgoContext {
 
         // Install the instrumented wheel
         eprintln!("📦 Installing instrumented wheel into temporary venv...");
-        let status = Command::new(&venv_python)
-            .args(["-m", "pip", "install", "--force-reinstall", "--no-deps"])
-            .arg(wheel_path)
-            .status()
-            .context("Failed to install instrumented wheel")?;
+        let status = self.pip_install(
+            &uv,
+            &venv_python,
+            &["--force-reinstall", "--no-deps"],
+            &[wheel_path],
+        )?;
         if !status.success() {
             bail!("Failed to install instrumented wheel (exit status: {status})");
         }
@@ -167,45 +186,43 @@ impl PgoContext {
         // Install requires_dist dependencies
         if !build_context.metadata24.requires_dist.is_empty() {
             debug!("Installing requires_dist dependencies");
-            let mut args = vec!["-m".to_string(), "pip".to_string(), "install".to_string()];
-            args.extend(
-                build_context
-                    .metadata24
-                    .requires_dist
-                    .iter()
-                    .map(|x| x.to_string()),
-            );
-            let status = Command::new(&venv_python)
-                .args(&args)
-                .status()
-                .context("Failed to install dependencies")?;
+            let deps: Vec<String> = build_context
+                .metadata24
+                .requires_dist
+                .iter()
+                .map(|x| x.to_string())
+                .collect();
+            let dep_refs: Vec<&Path> = deps.iter().map(|s| Path::new(s.as_str())).collect();
+            let status = self.pip_install(&uv, &venv_python, &[], &dep_refs)?;
             if !status.success() {
                 bail!("Failed to install dependencies (exit status: {status})");
             }
         }
 
-        // Install dev dependency group if present
-        let has_dev_group = build_context
-            .pyproject_toml
-            .as_ref()
-            .and_then(|p| p.dependency_groups.as_ref())
-            .is_some_and(|dg| dg.0.contains_key("dev"));
-        if has_dev_group {
-            let project_dir = build_context
-                .pyproject_toml_path
-                .parent()
-                .context("Failed to get project directory")?;
-            debug!("Installing dev dependency group");
-            let status = Command::new(&venv_python)
-                .args(["-m", "pip", "install", "--group", "dev"])
-                .current_dir(project_dir)
-                .status()
-                .context("Failed to install dev dependency group")?;
-            if !status.success() {
-                eprintln!(
-                    "⚠️  Warning: failed to install dev dependency group \
-                     (pip >= 25.1 required for --group support)"
-                );
+        // Install dev dependency group if present (pip only — uv doesn't support --group yet)
+        if uv.is_none() {
+            let has_dev_group = build_context
+                .pyproject_toml
+                .as_ref()
+                .and_then(|p| p.dependency_groups.as_ref())
+                .is_some_and(|dg| dg.0.contains_key("dev"));
+            if has_dev_group {
+                let project_dir = build_context
+                    .pyproject_toml_path
+                    .parent()
+                    .context("Failed to get project directory")?;
+                debug!("Installing dev dependency group");
+                let status = Command::new(&venv_python)
+                    .args(["-m", "pip", "install", "--group", "dev"])
+                    .current_dir(project_dir)
+                    .status()
+                    .context("Failed to install dev dependency group")?;
+                if !status.success() {
+                    eprintln!(
+                        "⚠️  Warning: failed to install dev dependency group \
+                         (pip >= 25.1 required for --group support)"
+                    );
+                }
             }
         }
 
@@ -258,6 +275,34 @@ impl PgoContext {
 
         eprintln!("✅ PGO instrumentation completed successfully");
         Ok(())
+    }
+
+    /// Run `pip install` or `uv pip install` depending on what's available.
+    fn pip_install(
+        &self,
+        uv: &Option<(PathBuf, Vec<&'static str>)>,
+        venv_python: &Path,
+        extra_args: &[&str],
+        packages: &[&Path],
+    ) -> Result<std::process::ExitStatus> {
+        let status = if let Some((uv_path, uv_args)) = uv {
+            Command::new(uv_path)
+                .args(uv_args.iter().copied())
+                .args(["pip", "install", "--python"])
+                .arg(venv_python)
+                .args(extra_args)
+                .args(packages)
+                .status()
+                .context("Failed to run uv pip install")?
+        } else {
+            Command::new(venv_python)
+                .args(["-m", "pip", "install"])
+                .args(extra_args)
+                .args(packages)
+                .status()
+                .context("Failed to run pip install")?
+        };
+        Ok(status)
     }
 
     /// Merge .profraw files into a single .profdata file

--- a/src/pgo.rs
+++ b/src/pgo.rs
@@ -1,0 +1,313 @@
+use anyhow::{Context, Result, bail};
+use fs_err as fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+use tracing::debug;
+
+/// The current phase of a PGO build
+#[derive(Debug, Clone)]
+pub enum PgoPhase {
+    /// Instrumented build: `-Cprofile-generate=<dir>`
+    Generate(PathBuf),
+    /// Optimized build: `-Cprofile-use=<path>`
+    Use(PathBuf),
+}
+
+/// Manages the PGO build lifecycle: profdata directory, llvm-profdata resolution, instrumentation
+pub struct PgoContext {
+    /// Temporary directory for .profraw files
+    profdata_dir: TempDir,
+    /// Path to the merged .profdata file
+    merged_profdata: PathBuf,
+    /// The instrumentation command to run
+    pgo_command: String,
+}
+
+impl PgoContext {
+    /// Create a new PGO context with a temporary directory for profile data
+    pub fn new(pgo_command: String) -> Result<Self> {
+        let profdata_dir =
+            TempDir::new().context("Failed to create temporary directory for PGO profdata")?;
+        let merged_profdata = profdata_dir.path().join("merged.profdata");
+        Ok(Self {
+            profdata_dir,
+            merged_profdata,
+            pgo_command,
+        })
+    }
+
+    /// Returns the path to the profdata directory
+    pub fn profdata_dir_path(&self) -> &Path {
+        self.profdata_dir.path()
+    }
+
+    /// Returns the path to the merged profdata file
+    pub fn merged_profdata_path(&self) -> &Path {
+        &self.merged_profdata
+    }
+
+    /// Find the `llvm-profdata` binary.
+    ///
+    /// Strategy:
+    /// 1. Look in the rustup toolchain sysroot
+    /// 2. Fall back to PATH
+    pub fn find_llvm_profdata() -> Result<PathBuf> {
+        // Try rustup toolchain first
+        if let Ok(path) = Self::find_llvm_profdata_from_rustup() {
+            return Ok(path);
+        }
+
+        // Fall back to PATH
+        let profdata_name = format!("llvm-profdata{}", std::env::consts::EXE_SUFFIX);
+        if let Ok(output) = Command::new(&profdata_name).arg("--version").output()
+            && output.status.success()
+        {
+            debug!("Found llvm-profdata in PATH");
+            return Ok(PathBuf::from(profdata_name));
+        }
+
+        bail!(
+            "Could not find `llvm-profdata`. Install it with:\n\
+             \n  rustup component add llvm-tools\n"
+        )
+    }
+
+    fn find_llvm_profdata_from_rustup() -> Result<PathBuf> {
+        let sysroot_output = Command::new("rustc")
+            .arg("--print")
+            .arg("sysroot")
+            .output()
+            .context("Failed to run `rustc --print sysroot`")?;
+        if !sysroot_output.status.success() {
+            bail!("rustc --print sysroot failed");
+        }
+        let sysroot = std::str::from_utf8(&sysroot_output.stdout)
+            .context("Invalid UTF-8 from rustc --print sysroot")?
+            .trim();
+
+        let verbose_output = Command::new("rustc")
+            .arg("-vV")
+            .output()
+            .context("Failed to run `rustc -vV`")?;
+        if !verbose_output.status.success() {
+            bail!("rustc -vV failed");
+        }
+        let verbose =
+            std::str::from_utf8(&verbose_output.stdout).context("Invalid UTF-8 from rustc -vV")?;
+        let host = verbose
+            .lines()
+            .find_map(|line| line.strip_prefix("host: "))
+            .context("Could not determine host triple from `rustc -vV`")?;
+
+        let profdata_name = format!("llvm-profdata{}", std::env::consts::EXE_SUFFIX);
+        let profdata_path = PathBuf::from(sysroot)
+            .join("lib")
+            .join("rustlib")
+            .join(host)
+            .join("bin")
+            .join(profdata_name);
+
+        if profdata_path.exists() {
+            debug!("Found llvm-profdata at {}", profdata_path.display());
+            return Ok(profdata_path);
+        }
+
+        bail!("llvm-profdata not found at {}", profdata_path.display())
+    }
+
+    /// Run the PGO instrumentation workload.
+    ///
+    /// 1. Create a temporary venv
+    /// 2. Install the instrumented wheel
+    /// 3. Install dependencies
+    /// 4. Run the instrumentation command
+    pub fn run_instrumentation(
+        &self,
+        python: &Path,
+        wheel_path: &Path,
+        build_context: &crate::BuildContext,
+    ) -> Result<()> {
+        let venv_dir = TempDir::new().context("Failed to create temporary venv directory")?;
+        let venv_path = venv_dir.path();
+
+        // Create venv
+        let status = Command::new(python)
+            .args(["-m", "venv"])
+            .arg(venv_path)
+            .status()
+            .context("Failed to create virtual environment")?;
+        if !status.success() {
+            bail!("Failed to create virtual environment (exit status: {status})");
+        }
+        debug!("Created temporary venv at {}", venv_path.display());
+
+        let venv_bin_dir = if cfg!(windows) {
+            venv_path.join("Scripts")
+        } else {
+            venv_path.join("bin")
+        };
+        let venv_python = venv_bin_dir.join(if cfg!(windows) {
+            "python.exe"
+        } else {
+            "python"
+        });
+
+        // Install the instrumented wheel
+        eprintln!("📦 Installing instrumented wheel into temporary venv...");
+        let status = Command::new(&venv_python)
+            .args(["-m", "pip", "install", "--force-reinstall", "--no-deps"])
+            .arg(wheel_path)
+            .status()
+            .context("Failed to install instrumented wheel")?;
+        if !status.success() {
+            bail!("Failed to install instrumented wheel (exit status: {status})");
+        }
+
+        // Install requires_dist dependencies
+        if !build_context.metadata24.requires_dist.is_empty() {
+            debug!("Installing requires_dist dependencies");
+            let mut args = vec!["-m".to_string(), "pip".to_string(), "install".to_string()];
+            args.extend(
+                build_context
+                    .metadata24
+                    .requires_dist
+                    .iter()
+                    .map(|x| x.to_string()),
+            );
+            let status = Command::new(&venv_python)
+                .args(&args)
+                .status()
+                .context("Failed to install dependencies")?;
+            if !status.success() {
+                bail!("Failed to install dependencies (exit status: {status})");
+            }
+        }
+
+        // Install dev dependency group if present
+        let has_dev_group = build_context
+            .pyproject_toml
+            .as_ref()
+            .and_then(|p| p.dependency_groups.as_ref())
+            .is_some_and(|dg| dg.0.contains_key("dev"));
+        if has_dev_group {
+            let project_dir = build_context
+                .pyproject_toml_path
+                .parent()
+                .context("Failed to get project directory")?;
+            debug!("Installing dev dependency group");
+            let status = Command::new(&venv_python)
+                .args(["-m", "pip", "install", "--group", "dev"])
+                .current_dir(project_dir)
+                .status()
+                .context("Failed to install dev dependency group")?;
+            if !status.success() {
+                eprintln!(
+                    "⚠️  Warning: failed to install dev dependency group \
+                     (pip >= 25.1 required for --group support)"
+                );
+            }
+        }
+
+        // Run the instrumentation command
+        if self.pgo_command.is_empty() {
+            bail!("PGO command is empty");
+        }
+
+        eprintln!("🏃 Running instrumentation command: {}", self.pgo_command);
+        let profraw_pattern = self
+            .profdata_dir
+            .path()
+            .join("%m_%p.profraw")
+            .to_string_lossy()
+            .to_string();
+
+        let current_path = std::env::var("PATH").unwrap_or_default();
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        let path_env = format!("{}{sep}{current_path}", venv_bin_dir.display());
+
+        // Run through the system shell with the venv's bin dir prepended to PATH,
+        // so that `python`, `pytest`, etc. resolve to the venv's copies.
+        let mut cmd = if cfg!(windows) {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", &self.pgo_command]);
+            cmd
+        } else {
+            let mut cmd = Command::new("sh");
+            cmd.args(["-c", &self.pgo_command]);
+            cmd
+        };
+
+        cmd.env("LLVM_PROFILE_FILE", &profraw_pattern)
+            .env("PATH", &path_env)
+            .env("VIRTUAL_ENV", venv_path);
+
+        let status = cmd.status().with_context(|| {
+            format!(
+                "Failed to run PGO instrumentation command: {}",
+                self.pgo_command
+            )
+        })?;
+        if !status.success() {
+            bail!(
+                "PGO instrumentation command failed (exit status: {}): {}",
+                status,
+                self.pgo_command
+            );
+        }
+
+        eprintln!("✅ PGO instrumentation completed successfully");
+        Ok(())
+    }
+
+    /// Merge .profraw files into a single .profdata file
+    pub fn merge_profiles(&self) -> Result<()> {
+        eprintln!("🔗 Merging PGO profiles...");
+
+        let llvm_profdata = Self::find_llvm_profdata()?;
+
+        // Collect .profraw files explicitly
+        let profraws: Vec<PathBuf> = fs::read_dir(self.profdata_dir.path())
+            .context("Failed to read profdata directory")?
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|path| path.extension().is_some_and(|ext| ext == "profraw"))
+            .collect();
+
+        if profraws.is_empty() {
+            bail!(
+                "PGO instrumentation completed but no .profraw files were generated.\n\
+                 Make sure the instrumentation command exercises the compiled code."
+            );
+        }
+
+        debug!("Found {} .profraw file(s) to merge", profraws.len());
+
+        let status = Command::new(&llvm_profdata)
+            .arg("merge")
+            .arg("-o")
+            .arg(&self.merged_profdata)
+            .args(&profraws)
+            .status()
+            .with_context(|| format!("Failed to run `{} merge`", llvm_profdata.display()))?;
+        if !status.success() {
+            bail!("llvm-profdata merge failed (exit status: {})", status);
+        }
+
+        if !self.merged_profdata.exists() {
+            bail!(
+                "Merged profdata file not found at {}",
+                self.merged_profdata.display()
+            );
+        }
+
+        let metadata = fs::metadata(&self.merged_profdata)
+            .context("Failed to read merged profdata metadata")?;
+        debug!(
+            "Merged profdata: {} ({} bytes)",
+            self.merged_profdata.display(),
+            metadata.len()
+        );
+        eprintln!("✅ Merged PGO profiles successfully");
+        Ok(())
+    }
+}

--- a/src/pgo.rs
+++ b/src/pgo.rs
@@ -226,11 +226,6 @@ impl PgoContext {
             }
         }
 
-        // Run the instrumentation command
-        if self.pgo_command.is_empty() {
-            bail!("PGO command is empty");
-        }
-
         eprintln!("🏃 Running instrumentation command: {}", self.pgo_command);
         let profraw_pattern = self
             .profdata_dir
@@ -242,6 +237,8 @@ impl PgoContext {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let sep = if cfg!(windows) { ";" } else { ":" };
         let path_env = format!("{}{sep}{current_path}", venv_bin_dir.display());
+
+        let project_dir = build_context.project_layout.project_root.as_path();
 
         // Run through the system shell with the venv's bin dir prepended to PATH,
         // so that `python`, `pytest`, etc. resolve to the venv's copies.
@@ -255,7 +252,8 @@ impl PgoContext {
             cmd
         };
 
-        cmd.env("LLVM_PROFILE_FILE", &profraw_pattern)
+        cmd.current_dir(project_dir)
+            .env("LLVM_PROFILE_FILE", &profraw_pattern)
             .env("PATH", &path_env)
             .env("VIRTUAL_ENV", venv_path);
 
@@ -311,10 +309,13 @@ impl PgoContext {
 
         let llvm_profdata = Self::find_llvm_profdata()?;
 
-        // Collect .profraw files explicitly
+        // Collect .profraw files, propagating any IO errors
         let profraws: Vec<PathBuf> = fs::read_dir(self.profdata_dir.path())
             .context("Failed to read profdata directory")?
-            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to read entry in profdata directory")?
+            .into_iter()
+            .map(|e| e.path())
             .filter(|path| path.extension().is_some_and(|ext| ext == "profraw"))
             .collect();
 

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -429,6 +429,10 @@ pub struct ToolMaturin {
     /// Include the import library (.dll.lib) in the wheel on Windows
     #[serde(default)]
     pub include_import_lib: bool,
+    /// Command to run for PGO profile generation.
+    /// Executed in a temporary virtualenv with the instrumented wheel installed.
+    /// Example: `python -m pytest tests/benchmarks`
+    pub pgo_command: Option<String>,
     /// CI generation configuration
     pub generate_ci: Option<GenerateCIConfig>,
 }
@@ -583,6 +587,11 @@ impl PyProjectToml {
     /// Returns the value of `[tool.maturin.bindings]` in pyproject.toml
     pub fn bindings(&self) -> Option<&str> {
         self.maturin()?.bindings.as_deref()
+    }
+
+    /// Returns the PGO training command from `[tool.maturin]`
+    pub fn pgo_command(&self) -> Option<&str> {
+        self.maturin().and_then(|m| m.pgo_command.as_deref())
     }
 
     /// Returns the value of `[tool.maturin.compatibility]` in pyproject.toml

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -1255,4 +1255,47 @@ mod tests {
             Some("yum install -y openssl-devel".to_string())
         );
     }
+
+    #[test]
+    fn test_pgo_command() {
+        let tmp_dir = TempDir::new().unwrap();
+        let pyproject_file = tmp_dir.path().join("pyproject.toml");
+
+        fs::write(
+            &pyproject_file,
+            r#"[build-system]
+            requires = ["maturin"]
+            build-backend = "maturin"
+
+            [tool.maturin]
+            pgo-command = "python -m pytest tests/benchmarks"
+            "#,
+        )
+        .unwrap();
+        let pyproject = PyProjectToml::new(pyproject_file).unwrap();
+        assert_eq!(
+            pyproject.pgo_command(),
+            Some("python -m pytest tests/benchmarks")
+        );
+    }
+
+    #[test]
+    fn test_pgo_command_absent() {
+        let tmp_dir = TempDir::new().unwrap();
+        let pyproject_file = tmp_dir.path().join("pyproject.toml");
+
+        fs::write(
+            &pyproject_file,
+            r#"[build-system]
+            requires = ["maturin"]
+            build-backend = "maturin"
+
+            [tool.maturin]
+            manylinux = "2010"
+            "#,
+        )
+        .unwrap();
+        let pyproject = PyProjectToml::new(pyproject_file).unwrap();
+        assert_eq!(pyproject.pgo_command(), None);
+    }
 }

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -20,6 +20,12 @@ Options:
           This verifies that the source distribution is complete and can be used to build the
           project from source.
 
+      --pgo
+          Build with Profile-Guided Optimization (PGO).
+          
+          Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml. This performs a
+          three-phase build: instrumented build, profile training, and optimized rebuild.
+
       --compatibility [<compatibility>...]
           Control the platform tag and PyPI compatibility.
           

--- a/tests/cmd/publish.stdout
+++ b/tests/cmd/publish.stdout
@@ -16,6 +16,11 @@ Options:
       --no-sdist
           Don't build a source distribution
 
+      --pgo
+          Build with Profile-Guided Optimization (PGO).
+          
+          Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml.
+
   -r, --repository <REPOSITORY>
           The repository (package index) to upload the package to. Should be a section in the config
           file.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -172,10 +172,13 @@ pub fn check_installed(package: &Path, python: &Path) -> Result<()> {
         );
     }
 
-    let message = str::from_utf8(&output.stdout).unwrap().trim();
+    let stdout = str::from_utf8(&output.stdout).unwrap().trim();
+    // Check the last line only: some interpreters (e.g. PyPy) may emit
+    // extra debug output to stdout before our print("SUCCESS").
+    let last_line = stdout.lines().last().unwrap_or("");
 
-    if message != "SUCCESS" {
-        panic!("Not SUCCESS: {message}");
+    if last_line != "SUCCESS" {
+        panic!("Not SUCCESS: {stdout}");
     }
 
     Ok(())


### PR DESCRIPTION
Add `--pgo` CLI flag and `pgo-command` config in `[tool.maturin]` to enable PGO builds via a three-phase pipeline:

1. Build instrumented wheel with `-Cprofile-generate`
2. Install in temp venv and run the user's pgo-command to collect `.profraw` files
3. Merge profiles with `llvm-profdata` and rebuild with `-Cprofile-use`

For non-abi3 PyO3 builds, each interpreter gets its own instrument-train-optimize cycle via `build_single_pyo3_wheel()`, since different Python versions produce different compiled code through PyO3's build-time configuration. For abi3/cffi/uniffi/bin builds, a single PGO pass suffices.

Key components:
- `PgoContext` in `src/pgo.rs`: manages temp dirs, `llvm-profdata` resolution, venv creation, dependency installation, and profile merging
- `PgoPhase` enum injected into `BuildContext.pgo_phase`, read in `compile.rs` to add rustc flags
- `clone_for_pgo()` helper to reduce context-setup boilerplate
- `build_single_pyo3_wheel()` extracted from `build_pyo3_wheels()` to share the compile-audit-write pipeline with the PGO path

Closes #1840 