### PR TITLE
fix: resolve test failures in distro packaging environments

### DIFF
--- a/src/module_writer/mock_writer.rs
+++ b/src/module_writer/mock_writer.rs
@@ -111,6 +111,7 @@ fn metadata_hello_world_pep639() -> Result<()> {
 }
 
 #[test]
+#[serial_test::serial]
 fn write_dist_info_uses_license_file_sources() -> Result<()> {
     use pep440_rs::Version;
     use std::str::FromStr;

--- a/src/source_distribution/mod.rs
+++ b/src/source_distribution/mod.rs
@@ -106,7 +106,7 @@ fn resolve_and_add_manifest_asset(
 }
 
 /// Run `cargo package --list --allow-dirty` and return the list of files.
-fn cargo_package_file_list(manifest_path: &Path) -> Result<Vec<String>> {
+fn cargo_package_file_list(manifest_path: &Path, target_dir: &Path) -> Result<Vec<String>> {
     debug!(
         "Getting cargo package file list for {}",
         manifest_path.display()
@@ -115,6 +115,8 @@ fn cargo_package_file_list(manifest_path: &Path) -> Result<Vec<String>> {
     let output = Command::new("cargo")
         .args(args)
         .arg(manifest_path)
+        .arg("--target-dir")
+        .arg(target_dir)
         .output()
         .with_context(|| {
             format!(
@@ -183,8 +185,9 @@ fn add_crate_to_source_distribution(
     readme: Option<&ManifestAsset>,
     license_file: Option<&ManifestAsset>,
     opts: &AddCrateOptions<'_>,
+    target_dir: &Path,
 ) -> Result<()> {
-    let file_list = cargo_package_file_list(manifest_path)?;
+    let file_list = cargo_package_file_list(manifest_path, target_dir)?;
 
     trace!("File list: {:?}", file_list);
 
@@ -575,6 +578,7 @@ fn add_path_dep(
                     .expect("workspace inheritance cache missing entry")
             }),
         },
+        &ctx.project.target_dir,
     )
     .with_context(|| {
         format!(
@@ -687,6 +691,7 @@ fn add_main_crate(writer: &mut VirtualWriter<SDistWriter>, ctx: &SdistContext<'_
             package_metadata: main_crate,
             workspace_inheritance: None,
         },
+        &ctx.project.target_dir,
     )?;
 
     Ok(())


### PR DESCRIPTION
- Mark write_dist_info_uses_license_file_sources as serial to prevent env var race with other tests that set MATURIN_PEP517_METADATA_DIR
- Pass --target-dir to cargo package --list to prevent cargo from creating temp directories inside path dependency crates, which caused git2 directory scanning races in source tarball builds

Fixes #3127
Fixes #3128