### PR TITLE
fix: set explicit lib_name in pyo3 config for Android abi3 cross-compilation

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -842,7 +842,7 @@ fn configure_pyo3_env(
             // and legacy pyo3 versions
             build_command.env("PYTHON_SYS_EXECUTABLE", &interpreter.executable);
         } else if bridge_model.is_pyo3() && env::var_os("PYO3_CONFIG_FILE").is_none() {
-            let pyo3_config = interpreter.pyo3_config_file();
+            let pyo3_config = interpreter.pyo3_config_file(target, bridge_model.is_abi3());
             let maturin_target_dir = ensure_target_maturin_dir(&context.project.target_dir);
             let config_file = maturin_target_dir.join(format!(
                 "pyo3-config-{}-{}.{}.txt",

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -457,7 +457,7 @@ impl InterpreterConfig {
     }
 
     /// Generate pyo3 config file content
-    pub fn pyo3_config_file(&self) -> String {
+    pub fn pyo3_config_file(&self, target: &Target, abi3: bool) -> String {
         let build_flags = if self.gil_disabled {
             "Py_GIL_DISABLED"
         } else {
@@ -467,13 +467,29 @@ impl InterpreterConfig {
             r#"implementation={implementation}
 version={major}.{minor}
 shared=true
-abi3=false
+abi3={abi3}
 build_flags={build_flags}
 suppress_build_script_link_lines=false"#,
             implementation = self.interpreter_kind,
             major = self.major,
             minor = self.minor,
         );
+        // On Android, pyo3 forces linking libpython. When abi3 is enabled,
+        // pyo3's fixup_for_abi3_version downgrades the version to the abi3
+        // minimum (e.g. 3.7) and derives a wrong lib_name like "python3.7m".
+        // Set lib_name explicitly so pyo3 uses the correct library.
+        // For abi3, link against the unversioned libpython3.so (stable ABI).
+        // For non-abi3, link against the version-specific libpython3.X.so.
+        // See https://github.com/PyO3/pyo3/issues/5960
+        // See https://github.com/python/cpython/issues/148544
+        if target.is_android() && self.interpreter_kind == InterpreterKind::CPython {
+            let lib_name = if abi3 {
+                format!("python{}", self.major)
+            } else {
+                format!("python{}.{}{}", self.major, self.minor, self.abiflags)
+            };
+            write!(content, "\nlib_name={lib_name}").unwrap();
+        }
         if let Some(pointer_width) = self.pointer_width {
             write!(content, "\npointer_width={pointer_width}").unwrap();
         }
@@ -869,14 +885,10 @@ mod tests {
 
     #[test]
     fn test_pyo3_config_file() {
-        let sysconfig = InterpreterConfig::lookup_one(
-            &Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap(),
-            InterpreterKind::CPython,
-            (3, 10),
-            "",
-        )
-        .unwrap();
-        let config_file = sysconfig.pyo3_config_file();
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
+        let sysconfig =
+            InterpreterConfig::lookup_one(&target, InterpreterKind::CPython, (3, 10), "").unwrap();
+        let config_file = sysconfig.pyo3_config_file(&target, false);
         let expected = expect![[r#"
             implementation=CPython
             version=3.10
@@ -890,15 +902,11 @@ mod tests {
 
     #[test]
     fn test_pyo3_config_file_free_threaded_python_3_13() {
-        let sysconfig = InterpreterConfig::lookup_one(
-            &Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap(),
-            InterpreterKind::CPython,
-            (3, 13),
-            "t",
-        )
-        .unwrap();
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
+        let sysconfig =
+            InterpreterConfig::lookup_one(&target, InterpreterKind::CPython, (3, 13), "t").unwrap();
         assert_eq!(sysconfig.ext_suffix, ".cpython-313t-x86_64-linux-gnu.so");
-        let config_file = sysconfig.pyo3_config_file();
+        let config_file = sysconfig.pyo3_config_file(&target, false);
         let expected = expect![[r#"
             implementation=CPython
             version=3.13
@@ -912,15 +920,11 @@ mod tests {
 
     #[test]
     fn test_pyo3_config_file_musl_python_3_11() {
-        let sysconfig = InterpreterConfig::lookup_one(
-            &Target::from_resolved_target_triple("x86_64-unknown-linux-musl").unwrap(),
-            InterpreterKind::CPython,
-            (3, 11),
-            "",
-        )
-        .unwrap();
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-musl").unwrap();
+        let sysconfig =
+            InterpreterConfig::lookup_one(&target, InterpreterKind::CPython, (3, 11), "").unwrap();
         assert_eq!(sysconfig.ext_suffix, ".cpython-311-x86_64-linux-musl.so");
-        let config_file = sysconfig.pyo3_config_file();
+        let config_file = sysconfig.pyo3_config_file(&target, false);
         let expected = expect![[r#"
             implementation=CPython
             version=3.11
@@ -928,6 +932,46 @@ mod tests {
             abi3=false
             build_flags=
             suppress_build_script_link_lines=false
+            pointer_width=64"#]];
+        expected.assert_eq(&config_file);
+    }
+
+    #[test]
+    fn test_pyo3_config_file_android() {
+        let target = Target::from_resolved_target_triple("aarch64-linux-android").unwrap();
+        let config = InterpreterConfig {
+            major: 3,
+            minor: 14,
+            interpreter_kind: InterpreterKind::CPython,
+            abiflags: String::new(),
+            ext_suffix: ".cpython-314-aarch64-linux-android.so".to_string(),
+            pointer_width: Some(64),
+            gil_disabled: false,
+        };
+        // Non-abi3: links against version-specific libpython3.14.so
+        let config_file = config.pyo3_config_file(&target, false);
+        let expected = expect![[r#"
+            implementation=CPython
+            version=3.14
+            shared=true
+            abi3=false
+            build_flags=
+            suppress_build_script_link_lines=false
+            lib_name=python3.14
+            pointer_width=64"#]];
+        expected.assert_eq(&config_file);
+
+        // Abi3: links against unversioned libpython3.so (stable ABI)
+        // See https://github.com/python/cpython/issues/148544
+        let config_file = config.pyo3_config_file(&target, true);
+        let expected = expect![[r#"
+            implementation=CPython
+            version=3.14
+            shared=true
+            abi3=true
+            build_flags=
+            suppress_build_script_link_lines=false
+            lib_name=python3
             pointer_width=64"#]];
         expected.assert_eq(&config_file);
     }


### PR DESCRIPTION
On Android, pyo3 forces linking libpython. When abi3 is enabled, pyo3's fixup_for_abi3_version downgrades the version to the abi3 minimum (e.g. 3.7) and derives a wrong lib_name like 'python3.7m'. Set lib_name explicitly in the pyo3 config file so pyo3 uses the actual target Python version instead of computing one from the downgraded abi3 minimum.

See https://github.com/PyO3/pyo3/issues/5960