### PR TITLE
fix: skip interpreters with empty output for WSL2 cross-compile

### DIFF
--- a/src/python_interpreter/discovery.rs
+++ b/src/python_interpreter/discovery.rs
@@ -297,8 +297,23 @@ pub(super) fn check_executable(
                     "pyenv: {}: command not found",
                     executable.as_ref().display()
                 )) {
+                    // pyenv shim reports "command not found" when the actual interpreter
+                    // doesn't exist (e.g. pyenv install version was never installed)
                     eprintln!(
                         "⚠️  Warning: skipped unavailable python interpreter '{}' from pyenv",
+                        executable.as_ref().display()
+                    );
+                    return Ok(None);
+                } else if stderr.is_empty() {
+                    // Empty stderr typically indicates a stub/placeholder executable that
+                    // fails silently without producing any output. This happens on WSL2
+                    // when PATH includes Windows Store Python stubs at:
+                    //   /mnt/c/Users/<user>/AppData/Local/Microsoft/WindowsApps/python.exe
+                    // These stubs exist but don't function as real Python interpreters -
+                    // they just exit with an error code and no output.
+                    // Skip them gracefully instead of failing the build.
+                    eprintln!(
+                        "⚠️  Warning: skipped python interpreter '{}' with empty output",
                         executable.as_ref().display()
                     );
                     return Ok(None);


### PR DESCRIPTION
## Summary

- Skip Python interpreters that exit with empty output when checking executable metadata
- Separate handling for pyenv "command not found" vs empty stderr cases with different warning messages

## Problem

When cross-compiling from WSL2 to Windows (e.g. using `cargo-xwin`), PATH may include Windows Store Python stubs at:
```
/mnt/c/Users/<user>/AppData/Local/Microsoft/WindowsApps/python.exe
```

These stub executables exist but don't function as real Python interpreters - they just exit with an error code and produce no output (empty stderr). This caused maturin to fail with:
```
💥 maturin failed
  Caused by: Trying to get metadata from the python interpreter 'python.exe' failed
```

## Solution

Gracefully skip interpreters with empty stderr output instead of failing the build. This allows cross-compilation workflows (like `maturin build --target x86_64-pc-windows-msvc` in WSL2) to proceed when using `generate-import-lib` feature.

## Test Plan

Manually tested cross-compilation from WSL2 to Windows with `cargo-xwin`:
```bash
maturin build --release --sdist -o dist --target x86_64-pc-windows-msvc
```

Fixes #3135