### PR TITLE
fix: two-phase bridge detection for conditional abi3 features

### DIFF
--- a/src/auditwheel/sbom.rs
+++ b/src/auditwheel/sbom.rs
@@ -72,7 +72,7 @@ pub fn create_auditwheel_sbom(
     // Sort by filepath for deterministic SBOM output (HashMap iteration
     // order is non-deterministic).
     let mut sorted_packages: Vec<_> = packages.iter().collect();
-    sorted_packages.sort_by(|(a, _), (b, _)| a.cmp(b));
+    sorted_packages.sort_by_key(|(a, _)| *a);
 
     for (filepath, provided_by) in sorted_packages {
         // Use a hash of the filepath to disambiguate components from the same

--- a/src/bridge/detection.rs
+++ b/src/bridge/detection.rs
@@ -8,7 +8,7 @@ use super::{
     BridgeModel, PyO3, PyO3Crate, PyO3MetadataRaw, StableAbi, StableAbiKind, StableAbiVersion,
 };
 use crate::PyProjectToml;
-use crate::pyproject_toml::FeatureSpec;
+use crate::pyproject_toml::{FeatureConditionEnv, FeatureSpec};
 use anyhow::{Context, Result, bail};
 use cargo_metadata::{CrateType, Metadata, Node, PackageId, TargetKind};
 use std::collections::{HashMap, HashSet};
@@ -21,12 +21,12 @@ const PYO3_BINDING_CRATES: [PyO3Crate; 2] = [PyO3Crate::PyO3Ffi, PyO3Crate::PyO3
 /// Inspects cargo metadata to detect pyo3/cffi/uniffi bindings, abi3 support,
 /// and extension-module feature usage. If `bridge` is `Some`, the binding type
 /// is forced; otherwise it's auto-detected from dependencies and target types.
-pub fn find_bridge(
-    cargo_metadata: &Metadata,
-    bridge: Option<&str>,
-    pyproject: Option<&PyProjectToml>,
-) -> Result<BridgeModel> {
-    let extra_pyo3_features = pyo3_features_from_conditional(pyproject);
+///
+/// Conditional pyo3/pyo3-ffi features from pyproject.toml are excluded from
+/// abi3 inference here. Use [`upgrade_bridge_abi3`] after interpreter resolution
+/// to evaluate them.
+pub fn find_bridge(cargo_metadata: &Metadata, bridge: Option<&str>) -> Result<BridgeModel> {
+    let no_extra_features = HashMap::new();
     let deps = current_crate_dependencies(cargo_metadata)?;
     let packages: HashMap<&str, &cargo_metadata::Package> = cargo_metadata
         .packages
@@ -99,7 +99,6 @@ pub fn find_bridge(
     };
 
     if !bridge.is_pyo3() {
-        eprintln!("🔗 Found {bridge} bindings");
         return Ok(bridge);
     }
 
@@ -124,9 +123,7 @@ pub fn find_bridge(
                 }
             }
 
-            return if let Some(stable_abi) = has_stable_abi(&deps, &extra_pyo3_features)? {
-                let kind = stable_abi.kind;
-                eprintln!("🔗 Found {lib} bindings with {kind} support");
+            return if let Some(stable_abi) = has_stable_abi(&deps, &no_extra_features)? {
                 let pyo3 = bridge.pyo3().expect("should be pyo3 bindings");
                 let bindings = PyO3 {
                     crate_name: lib,
@@ -136,10 +133,50 @@ pub fn find_bridge(
                 };
                 Ok(BridgeModel::PyO3(bindings))
             } else {
-                eprintln!("🔗 Found {lib} bindings");
                 Ok(bridge)
             };
         }
+    }
+
+    Ok(bridge)
+}
+
+/// Upgrade a bridge model to abi3 if conditional pyo3/pyo3-ffi features
+/// from pyproject.toml match at least one of the given interpreters.
+///
+/// This is the second phase of bridge detection: [`find_bridge`] excludes
+/// conditional features, then after interpreter resolution this function
+/// re-checks whether any conditional abi3 feature applies.
+pub fn upgrade_bridge_abi3(
+    bridge: BridgeModel,
+    cargo_metadata: &Metadata,
+    pyproject: Option<&PyProjectToml>,
+    interpreters: &[crate::PythonInterpreter],
+) -> Result<BridgeModel> {
+    // Only relevant for pyo3 bridges without abi3 already set
+    let Some(pyo3) = bridge.pyo3() else {
+        return Ok(bridge);
+    };
+    if pyo3.stable_abi.is_some() {
+        return Ok(bridge);
+    }
+
+    let extra_pyo3_features = pyo3_features_from_conditional(pyproject, interpreters);
+    if extra_pyo3_features.is_empty() {
+        return Ok(bridge);
+    }
+
+    let deps = current_crate_dependencies(cargo_metadata)?;
+    if let Some(stable_abi) = has_stable_abi(&deps, &extra_pyo3_features)? {
+        let upgraded = PyO3 {
+            stable_abi: Some(stable_abi),
+            ..pyo3.clone()
+        };
+        return Ok(match bridge {
+            BridgeModel::PyO3(_) => BridgeModel::PyO3(upgraded),
+            BridgeModel::Bin(Some(_)) => BridgeModel::Bin(Some(upgraded)),
+            _ => return Ok(bridge),
+        });
     }
 
     Ok(bridge)
@@ -335,6 +372,7 @@ fn current_crate_dependencies(cargo_metadata: &Metadata) -> Result<HashMap<&str,
 /// for the corresponding binding crate.
 fn pyo3_features_from_conditional(
     pyproject: Option<&PyProjectToml>,
+    interpreters: &[crate::PythonInterpreter],
 ) -> HashMap<&'static str, Vec<String>> {
     let mut extra: HashMap<&'static str, Vec<String>> = HashMap::new();
     let features = match pyproject
@@ -345,15 +383,31 @@ fn pyo3_features_from_conditional(
         None => return extra,
     };
     let (_plain, conditional) = FeatureSpec::split(features);
-    let crate_names: &[&'static str] = &["pyo3", "pyo3-ffi"];
-    for cond in &conditional {
-        for &crate_name in crate_names {
-            let prefix = format!("{crate_name}/");
-            if let Some(feat_name) = cond.feature.strip_prefix(&prefix) {
-                extra
-                    .entry(crate_name)
-                    .or_default()
-                    .push(feat_name.to_string());
+    let crate_names: &[&str] = &["pyo3", "pyo3-ffi"];
+
+    // Collect the union of conditional features across all interpreters.
+    // A feature is included if ANY interpreter satisfies its condition.
+    // This is safe because build_stable_abi_wheels splits interpreters
+    // into abi3-capable vs version-specific groups based on min_version,
+    // so interpreters that don't qualify get version-specific wheels.
+    let mut seen = HashSet::new();
+    for interp in interpreters {
+        let env = FeatureConditionEnv {
+            major: interp.major,
+            minor: interp.minor,
+            implementation_name: &interp.implementation_name,
+        };
+        for feature in FeatureSpec::resolve_conditional(&conditional, &env) {
+            if seen.insert(feature.clone()) {
+                for &crate_name in crate_names {
+                    let prefix = format!("{crate_name}/");
+                    if let Some(feat_name) = feature.strip_prefix(&prefix) {
+                        extra
+                            .entry(crate_name)
+                            .or_default()
+                            .push(feat_name.to_string());
+                    }
+                }
             }
         }
     }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,6 +1,6 @@
 mod detection;
 
-pub use detection::{find_bridge, is_generating_import_lib};
+pub use detection::{find_bridge, is_generating_import_lib, upgrade_bridge_abi3};
 
 use std::{fmt, str::FromStr};
 

--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -1,5 +1,5 @@
 use crate::auditwheel::{AuditWheelMode, PlatformTag};
-use crate::bridge::{find_bridge, is_generating_import_lib};
+use crate::bridge::{find_bridge, is_generating_import_lib, upgrade_bridge_abi3};
 use crate::build_options::{BuildOptions, TargetTriple};
 use crate::compile::filter_cargo_targets;
 use crate::metadata::Metadata24;
@@ -100,19 +100,37 @@ impl BuildContextBuilder {
         )?;
         let pyproject = pyproject_toml.as_ref();
 
-        let bridge = find_bridge(
-            &cargo_metadata,
-            build_options.python.bindings.as_deref().or_else(|| {
-                pyproject.and_then(|x| {
-                    if x.bindings().is_some() {
-                        pyproject_toml_maturin_options.push("bindings");
-                    }
-                    x.bindings()
-                })
-            }),
-            pyproject,
-        )?;
-        debug!("Resolved bridge model: {:?}", bridge);
+        let bindings = build_options.python.bindings.as_deref().or_else(|| {
+            pyproject.and_then(|x| {
+                if x.bindings().is_some() {
+                    pyproject_toml_maturin_options.push("bindings");
+                }
+                x.bindings()
+            })
+        });
+
+        // Check whether conditional pyo3/pyo3-ffi features exist in pyproject.toml
+        // AND pyproject features are actually active (not overridden by CLI --features).
+        // When CLI --features is set, pyproject features are ignored at compile time
+        // (see cargo_options.merge_with_pyproject_toml), so bridge inference must
+        // ignore them too to stay in sync.
+        let has_conditional_pyo3_features = pyproject
+            .and_then(|p| p.maturin())
+            .and_then(|m| m.features.as_ref())
+            .is_some_and(|specs| {
+                // Only consider conditional features when pyproject features
+                // were actually adopted (not overridden by CLI).
+                let cli_overrides = !cargo_options.features.is_empty()
+                    && !pyproject_toml_maturin_options.contains(&"features");
+                !cli_overrides
+                    && FeatureSpec::split(specs.clone()).1.iter().any(|c| {
+                        c.feature.starts_with("pyo3/") || c.feature.starts_with("pyo3-ffi/")
+                    })
+            });
+
+        // Detect bridge without conditional pyo3 features — those are
+        // evaluated after interpreter resolution via upgrade_bridge_abi3.
+        let bridge = find_bridge(&cargo_metadata, bindings)?;
 
         if !bridge.is_bin() && project_layout.extension_name.contains('-') {
             bail!(
@@ -140,6 +158,24 @@ impl BuildContextBuilder {
             &metadata24,
             &cargo_metadata,
         )?;
+
+        // Upgrade bridge to abi3 if conditional pyo3 features
+        // (e.g. abi3-py311 gated on python-version>=3.11) match any
+        // of the resolved interpreters.
+        let bridge = if has_conditional_pyo3_features {
+            upgrade_bridge_abi3(bridge, &cargo_metadata, pyproject, &interpreter)?
+        } else {
+            bridge
+        };
+        debug!("Resolved bridge model: {:?}", bridge);
+        if let Some(stable_abi) = bridge.pyo3().and_then(|p| p.stable_abi.as_ref()) {
+            eprintln!(
+                "🔗 Found {bridge} bindings with {} support",
+                stable_abi.kind
+            );
+        } else {
+            eprintln!("🔗 Found {bridge} bindings");
+        }
 
         // Set PYO3_PYTHON for cross-compilation so pyo3's build script
         // can find the host interpreter.

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -171,11 +171,11 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            find_bridge(&pyo3_mixed, None, None),
+            find_bridge(&pyo3_mixed, None),
             Ok(BridgeModel::PyO3 { .. })
         ));
         assert!(matches!(
-            find_bridge(&pyo3_mixed, Some("pyo3"), None),
+            find_bridge(&pyo3_mixed, Some("pyo3")),
             Ok(BridgeModel::PyO3 { .. })
         ));
     }
@@ -204,8 +204,8 @@ mod tests {
                 },
             }),
         });
-        assert_eq!(find_bridge(&pyo3_pure, None, None).unwrap(), bridge);
-        assert_eq!(find_bridge(&pyo3_pure, Some("pyo3"), None).unwrap(), bridge);
+        assert_eq!(find_bridge(&pyo3_pure, None).unwrap(), bridge);
+        assert_eq!(find_bridge(&pyo3_pure, Some("pyo3")).unwrap(), bridge);
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod tests {
             .exec()
             .unwrap();
 
-        assert!(find_bridge(&pyo3_pure, None, None).is_err());
+        assert!(find_bridge(&pyo3_pure, None).is_err());
 
         let pyo3_pure = MetadataCommand::new()
             .manifest_path(test_crate_path("pyo3-feature").join("Cargo.toml"))
@@ -224,7 +224,7 @@ mod tests {
             .unwrap();
 
         assert!(matches!(
-            find_bridge(&pyo3_pure, None, None).unwrap(),
+            find_bridge(&pyo3_pure, None).unwrap(),
             BridgeModel::PyO3 { .. }
         ));
     }
@@ -237,15 +237,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            find_bridge(&cffi_pure, Some("cffi"), None).unwrap(),
+            find_bridge(&cffi_pure, Some("cffi")).unwrap(),
             BridgeModel::Cffi
         );
-        assert_eq!(
-            find_bridge(&cffi_pure, None, None).unwrap(),
-            BridgeModel::Cffi
-        );
+        assert_eq!(find_bridge(&cffi_pure, None).unwrap(), BridgeModel::Cffi);
 
-        assert!(find_bridge(&cffi_pure, Some("pyo3"), None).is_err());
+        assert!(find_bridge(&cffi_pure, Some("pyo3")).is_err());
     }
 
     #[test]
@@ -256,28 +253,114 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            find_bridge(&hello_world, Some("bin"), None).unwrap(),
+            find_bridge(&hello_world, Some("bin")).unwrap(),
             BridgeModel::Bin(None)
         );
         assert_eq!(
-            find_bridge(&hello_world, None, None).unwrap(),
+            find_bridge(&hello_world, None).unwrap(),
             BridgeModel::Bin(None)
         );
 
-        assert!(find_bridge(&hello_world, Some("pyo3"), None).is_err());
+        assert!(find_bridge(&hello_world, Some("pyo3")).is_err());
 
         let pyo3_bin = MetadataCommand::new()
             .manifest_path(test_crate_path("pyo3-bin").join("Cargo.toml"))
             .exec()
             .unwrap();
         assert!(matches!(
-            find_bridge(&pyo3_bin, Some("bin"), None).unwrap(),
+            find_bridge(&pyo3_bin, Some("bin")).unwrap(),
             BridgeModel::Bin(Some(_))
         ));
         assert!(matches!(
-            find_bridge(&pyo3_bin, None, None).unwrap(),
+            find_bridge(&pyo3_bin, None).unwrap(),
             BridgeModel::Bin(Some(_))
         ));
+    }
+
+    #[test]
+    fn test_find_bridge_conditional_abi3_filtered_by_interpreter() {
+        use crate::bridge::upgrade_bridge_abi3;
+        use crate::python_interpreter::InterpreterConfig;
+
+        // A pyproject.toml with pyo3/abi3-py311 gated on python-version >= 3.11
+        let pyproject: crate::PyProjectToml = toml::from_str(
+            r#"
+            [build-system]
+            requires = ["maturin"]
+            build-backend = "maturin"
+
+            [tool.maturin]
+            features = [{ feature = "pyo3/abi3-py311", python-version = ">=3.11" }]
+            "#,
+        )
+        .unwrap();
+
+        // Use pyo3-mixed which has no abi3 in Cargo.toml, so abi3 inference
+        // depends entirely on the conditional pyproject feature.
+        let metadata = MetadataCommand::new()
+            .manifest_path(test_crate_path("pyo3-mixed").join("Cargo.toml"))
+            .exec()
+            .unwrap();
+
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
+
+        // find_bridge alone never includes conditional features → no abi3
+        let bridge = find_bridge(&metadata, None).unwrap();
+        assert!(
+            !bridge.is_abi3(),
+            "find_bridge should not infer abi3 from conditional features"
+        );
+
+        // With a Python 3.10 interpreter, condition doesn't match → no abi3
+        let py310 = crate::PythonInterpreter::from_config(
+            InterpreterConfig::lookup_one(
+                &target,
+                crate::python_interpreter::InterpreterKind::CPython,
+                (3, 10),
+                "",
+            )
+            .unwrap(),
+        );
+        let bridge = upgrade_bridge_abi3(
+            bridge,
+            &metadata,
+            Some(&pyproject),
+            std::slice::from_ref(&py310),
+        )
+        .unwrap();
+        assert!(!bridge.is_abi3(), "should not infer abi3 for Python 3.10");
+
+        // With a Python 3.11 interpreter, condition matches → abi3
+        let py311 = crate::PythonInterpreter::from_config(
+            InterpreterConfig::lookup_one(
+                &target,
+                crate::python_interpreter::InterpreterKind::CPython,
+                (3, 11),
+                "",
+            )
+            .unwrap(),
+        );
+        let base_bridge = find_bridge(&metadata, None).unwrap();
+        let bridge = upgrade_bridge_abi3(
+            base_bridge,
+            &metadata,
+            Some(&pyproject),
+            std::slice::from_ref(&py311),
+        )
+        .unwrap();
+        assert!(bridge.is_abi3(), "should infer abi3 for Python 3.11");
+
+        // With mixed interpreters [3.10, 3.11], abi3 IS inferred because
+        // at least one interpreter (3.11) matches the condition. This is safe
+        // because build_stable_abi_wheels splits interpreters by min_version:
+        // 3.10 gets a version-specific wheel, 3.11+ gets the abi3 wheel.
+        let base_bridge = find_bridge(&metadata, None).unwrap();
+        let bridge =
+            upgrade_bridge_abi3(base_bridge, &metadata, Some(&pyproject), &[py310, py311]).unwrap();
+        assert!(
+            bridge.is_abi3(),
+            "should infer abi3 for mixed [3.10, 3.11] (build_stable_abi_wheels handles the split)"
+        );
     }
 
     #[test]

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -403,7 +403,12 @@ impl<'a> BuildOrchestrator<'a> {
             .python
             .interpreter
             .iter()
-            .filter(|interp| !interp.has_stable_api())
+            .filter(|interp| {
+                !interp.has_stable_api()
+                    || min_version.is_some_and(|(major, minor)| {
+                        (interp.major as u8, interp.minor as u8) < (major, minor)
+                    })
+            })
             .collect();
 
         if stable_abi_interps.is_empty() && version_specific_abi_interps.is_empty() {

--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -260,11 +260,7 @@ impl GenerateCI {
             ..
         } = ProjectResolver::resolve(self.manifest_path.clone(), cargo_options, false, None)?;
         let pyproject = pyproject_toml.as_ref();
-        let bridge = find_bridge(
-            &cargo_metadata,
-            pyproject.and_then(|x| x.bindings()),
-            pyproject,
-        )?;
+        let bridge = find_bridge(&cargo_metadata, pyproject.and_then(|x| x.bindings()))?;
         let project_name = pyproject
             .and_then(|project| project.project_name())
             .unwrap_or(&project_layout.extension_name);


### PR DESCRIPTION
Fixes #3142.

## Problem

Since maturin 1.13.0, conditional `pyo3/abi3` features gated on `python-version` in `pyproject.toml` were applied unconditionally during bridge detection. This caused builds to fail when the target interpreter didn't match the condition:

```
💥 maturin failed
  Caused by: None of the found Python interpreters (CPython 3.10) are compatible
  with the abi3 minimum version (>= 3.11).
```

## Solution

Split bridge detection into two phases:

1. **`find_bridge()`** — detects the bridge model from Cargo metadata only, excluding conditional pyproject features. The `pyproject` parameter is removed since it's no longer needed here.

2. **`upgrade_bridge_abi3()`** — after interpreter resolution, evaluates conditional `pyo3`/`pyo3-ffi` features against the resolved interpreters using `matches_any` semantics, upgrading the bridge to abi3 if any interpreter qualifies.

The `matches_any` approach is safe because `build_stable_abi_wheels` already splits interpreters into abi3-capable vs version-specific groups by `min_version`, producing e.g. `cp310 + abi3-cp311` for mixed `[3.10, 3.11]`.

## Additional fixes

- Skip conditional pyproject features when CLI `--features` overrides pyproject features, keeping bridge detection in sync with compile-time feature resolution.
- Move bridge binding log messages from `find_bridge()` to the builder so they print once after the final bridge is resolved.

## Validation

- `cargo test --lib test_find_bridge_ -- --nocapture` (6 tests including new conditional abi3 test)
- Manual verification: `>=3.15` with Python 3.14 produces `cp314` wheel (no abi3); `>=3.11` with Python 3.14 produces `abi3-cp311` wheel
