### PR TITLE
Treat pyo3 0.29.0+ as having Windows import lib support (raw-dylib)

### DIFF
--- a/src/bridge/detection.rs
+++ b/src/bridge/detection.rs
@@ -186,7 +186,9 @@ pub fn upgrade_bridge_abi3(
 ///
 /// pyo3 0.16.4+ supports building abi3 wheels without a working Python interpreter
 /// for Windows when `generate-import-lib` feature is enabled.
-pub fn is_generating_import_lib(cargo_metadata: &Metadata) -> Result<bool> {
+/// pyo3 0.29.0+ uses raw-dylib linking on Windows, so import library generation
+/// is no longer needed and this effectively always returns true.
+pub fn has_windows_import_lib_support(cargo_metadata: &Metadata) -> Result<bool> {
     let resolve = cargo_metadata
         .resolve
         .as_ref()
@@ -200,6 +202,10 @@ pub fn is_generating_import_lib(cargo_metadata: &Metadata) -> Result<bool> {
             .collect::<Vec<_>>();
         match pyo3_packages.as_slice() {
             &[pyo3_crate] => {
+                let pyo3_version = &cargo_metadata[&pyo3_crate.id].version;
+                if pyo3_version >= &semver::Version::new(0, 29, 0) {
+                    return Ok(true);
+                }
                 let generate_import_lib = pyo3_crate
                     .features
                     .iter()

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,6 +1,6 @@
 mod detection;
 
-pub use detection::{find_bridge, is_generating_import_lib, upgrade_bridge_abi3};
+pub use detection::{find_bridge, has_windows_import_lib_support, upgrade_bridge_abi3};
 
 use std::{fmt, str::FromStr};
 

--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -1,5 +1,5 @@
 use crate::auditwheel::{AuditWheelMode, PlatformTag};
-use crate::bridge::{find_bridge, is_generating_import_lib, upgrade_bridge_abi3};
+use crate::bridge::{find_bridge, has_windows_import_lib_support, upgrade_bridge_abi3};
 use crate::build_options::{BuildOptions, TargetTriple};
 use crate::compile::filter_cargo_targets;
 use crate::metadata::Metadata24;
@@ -325,7 +325,7 @@ impl BuildContextBuilder {
         metadata24: &Metadata24,
         cargo_metadata: &cargo_metadata::Metadata,
     ) -> Result<(Vec<PythonInterpreter>, Option<PathBuf>)> {
-        let generate_import_lib = is_generating_import_lib(cargo_metadata)?;
+        let has_import_lib_support = has_windows_import_lib_support(cargo_metadata)?;
         if sdist_only && env::var_os("MATURIN_TEST_PYTHON").is_none() {
             return Ok((Vec::new(), None));
         }
@@ -345,7 +345,7 @@ impl BuildContextBuilder {
             metadata24.requires_python.as_ref(),
             &user_interpreters,
             build_options.python.find_interpreter,
-            generate_import_lib,
+            has_import_lib_support,
         );
         resolver.resolve()
     }

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -193,7 +193,7 @@ pub struct InterpreterResolver<'a> {
     requires_python: Option<&'a VersionSpecifiers>,
     user_interpreters: &'a [PathBuf],
     find_interpreter: bool,
-    generate_import_lib: bool,
+    has_import_lib_support: bool,
 }
 
 impl<'a> InterpreterResolver<'a> {
@@ -204,7 +204,7 @@ impl<'a> InterpreterResolver<'a> {
         requires_python: Option<&'a VersionSpecifiers>,
         user_interpreters: &'a [PathBuf],
         find_interpreter: bool,
-        generate_import_lib: bool,
+        has_import_lib_support: bool,
     ) -> Self {
         Self {
             target,
@@ -212,7 +212,7 @@ impl<'a> InterpreterResolver<'a> {
             requires_python,
             user_interpreters,
             find_interpreter,
-            generate_import_lib,
+            has_import_lib_support,
         }
     }
 
@@ -424,7 +424,7 @@ impl<'a> InterpreterResolver<'a> {
 
         // --- Step 3: Nothing found — try abi3 sysconfig fallback ---
         if fixed_abi3.is_some() {
-            if self.target.is_windows() && !self.generate_import_lib {
+            if self.target.is_windows() && !self.has_import_lib_support {
                 bail!(
                     "Need a Python interpreter to compile for Windows without \
                      PyO3's `generate-import-lib` feature"
@@ -509,7 +509,7 @@ impl<'a> InterpreterResolver<'a> {
             let sysconfig_interps = self.find_in_sysconfig(&missing)?;
             if !sysconfig_interps.is_empty()
                 && self.target.is_windows()
-                && !self.generate_import_lib
+                && !self.has_import_lib_support
             {
                 let names = sysconfig_interps
                     .iter()
@@ -700,7 +700,7 @@ impl<'a> InterpreterResolver<'a> {
     ) -> Result<Vec<PythonInterpreter>> {
         let interpreters = Self::candidates_to_interpreters(candidates);
 
-        if self.generate_import_lib {
+        if self.has_import_lib_support {
             eprintln!(
                 "🐍 Not using a specific python interpreter \
                  (automatically generating windows import library)"


### PR DESCRIPTION
Upcoming pyo3 0.29.0 release will [use `raw-dylib` linking on Windows](https://github.com/PyO3/pyo3/pull/5866), eliminating the need for the `generate-import-lib` feature. Detect the pyo3 version and treat >= 0.29.0 as always having import library support.

Also rename `is_generating_import_lib` to `has_windows_import_lib_support` to better reflect the broader meaning.