### PR TITLE
Fix bin bindings with external shared library dependencies

### DIFF
--- a/src/binding_generator/bin_binding.rs
+++ b/src/binding_generator/bin_binding.rs
@@ -4,6 +4,7 @@ use std::str::FromStr as _;
 
 use anyhow::Context;
 use anyhow::Result;
+use path_slash::PathBufExt as _;
 use pep508_rs::Requirement;
 
 use crate::BuildArtifact;
@@ -19,11 +20,18 @@ use super::GeneratorOutput;
 /// A generator for producing bin (and wasm) bindings.
 pub struct BinBindingGenerator<'m> {
     metadata: &'m mut Metadata24,
+    /// When `true`, the real binary is placed in `{dist_name}.scripts/` in
+    /// platlib and a Python shim is placed in `.data/scripts/` instead.
+    /// This is needed when the binary has external shared library
+    /// dependencies that are bundled into the wheel's `.libs/` directory,
+    /// because the relative path from the installed `bin/` to
+    /// `site-packages/{dist}.libs/` is unpredictable across installations.
+    use_shim: bool,
 }
 
 impl<'m> BinBindingGenerator<'m> {
-    pub fn new(metadata: &'m mut Metadata24) -> Self {
-        Self { metadata }
+    pub fn new(metadata: &'m mut Metadata24, use_shim: bool) -> Self {
+        Self { metadata, use_shim }
     }
 }
 
@@ -43,16 +51,48 @@ impl<'m> BindingGenerator for BinBindingGenerator<'m> {
             .to_str()
             .context("binary produced by cargo has non-utf8 filename")?
             .to_string();
+
         let scripts_dir = self.metadata.get_data_dir().join("scripts");
-        let artifact_target = ArtifactTarget::Binary(scripts_dir.join(&bin_name));
 
         let mut additional_files = None;
-        if context.project.target.is_wasi() {
-            update_entry_points(self.metadata, &bin_name)?;
+
+        let artifact_target = if self.use_shim {
+            // The real binary goes into platlib at {dist}.scripts/{bin_name}
+            // so it has a predictable relative path to {dist}.libs/.
+            // A Python shim in .data/scripts/ execs the real binary at runtime.
+            let real_bin_dir = self.metadata.get_scripts_platlib_dir();
+            let shim_path = real_bin_dir.join(&bin_name);
+            let shim_path_str = shim_path.to_slash_lossy();
+            let libs_dir_name = self.metadata.get_distribution_escaped() + ".libs";
+
+            // On Windows, bin_name includes `.exe`. The shim script must NOT
+            // have an `.exe` extension — otherwise Windows treats it as a PE
+            // binary and pip skips wrapper generation. Strip the extension for
+            // the shim entry in .data/scripts/.
+            let shim_name = bin_name.strip_suffix(".exe").unwrap_or(&bin_name);
 
             let mut files = HashMap::new();
             files.insert(
-                Path::new(&self.metadata.get_distribution_escaped())
+                scripts_dir.join(shim_name),
+                ArchiveSource::Generated(GeneratedSourceData {
+                    data: generate_script_shim(&shim_path_str, &libs_dir_name).into(),
+                    path: None,
+                    executable: true,
+                }),
+            );
+            additional_files = Some(files);
+            ArtifactTarget::Binary(real_bin_dir.join(&bin_name))
+        } else {
+            ArtifactTarget::Binary(scripts_dir.join(&bin_name))
+        };
+
+        if context.project.target.is_wasi() {
+            update_entry_points(self.metadata, &bin_name)?;
+
+            let dist_name = self.metadata.get_distribution_escaped();
+            let files = additional_files.get_or_insert_with(HashMap::new);
+            files.insert(
+                Path::new(&dist_name)
                     .join(bin_name.replace('-', "_"))
                     .with_extension("py"),
                 ArchiveSource::Generated(GeneratedSourceData {
@@ -61,7 +101,6 @@ impl<'m> BindingGenerator for BinBindingGenerator<'m> {
                     executable: false,
                 }),
             );
-            additional_files = Some(files);
         }
 
         Ok(GeneratorOutput {
@@ -70,6 +109,38 @@ impl<'m> BindingGenerator for BinBindingGenerator<'m> {
             additional_files,
         })
     }
+}
+
+/// Generate a Python shim script that execs the real binary from platlib.
+///
+/// This is used when a bin-type wheel has external shared library dependencies
+/// that are bundled into `{dist}.libs/` in platlib. The real binary is placed
+/// in `{dist}.scripts/` (also in platlib) so it has a predictable RPATH to
+/// the libs directory. The shim replaces the original script entry and uses
+/// `sysconfig.get_path("platlib")` to locate the real binary at runtime.
+///
+/// On Windows, `os.add_dll_directory()` is called to register the `.libs/`
+/// directory for DLL search before exec'ing the binary, since Windows does
+/// not use RPATH/`@loader_path` for DLL resolution.
+///
+/// This approach matches [auditwheel's handling](https://github.com/pypa/auditwheel/pull/443).
+fn generate_script_shim(binary_path: &str, libs_dir_name: &str) -> String {
+    format!(
+        "#!python\n\
+         import os\n\
+         import sys\n\
+         import sysconfig\n\
+         \n\
+         \n\
+         if __name__ == \"__main__\":\n\
+         \x20   platlib = sysconfig.get_path(\"platlib\")\n\
+         \x20   exe = os.path.join(platlib, \"{binary_path}\")\n\
+         \x20   libs_dir = os.path.join(platlib, \"{libs_dir_name}\")\n\
+         \x20   if sys.platform == \"win32\" and os.path.isdir(libs_dir):\n\
+         \x20       os.add_dll_directory(libs_dir)\n\
+         \x20       os.environ[\"PATH\"] = libs_dir + os.pathsep + os.environ.get(\"PATH\", \"\")\n\
+         \x20   os.execv(exe, [exe] + sys.argv[1:])\n"
+    )
 }
 
 /// Adds a wrapper script that starts the wasm binary through wasmtime.

--- a/src/build_context/repair.rs
+++ b/src/build_context/repair.rs
@@ -135,6 +135,7 @@ impl BuildContext {
         &self,
         writer: &mut VirtualWriter<WheelWriter>,
         audited: &[AuditedArtifact],
+        use_shim: bool,
     ) -> Result<()> {
         if self.project.editable {
             if let Some(repairer) =
@@ -217,7 +218,14 @@ impl BuildContext {
         let (grafted, libs_copied) =
             prepare_grafted_libs(audited, temp_dir.path(), arch_requirements)?;
 
-        let artifact_dir = self.get_artifact_dir();
+        // For bin bindings with external deps (shim mode), the real binary
+        // lives in {dist_name}.scripts/ in platlib rather than .data/scripts/.
+        // This gives us a predictable relative path to the bundled libs directory.
+        let artifact_dir = if use_shim {
+            self.project.metadata24.get_scripts_platlib_dir()
+        } else {
+            self.get_artifact_dir()
+        };
         repairer.patch(audited, &grafted, &libs_dir, &artifact_dir)?;
 
         // Add grafted libraries to the wheel

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -494,7 +494,8 @@ impl<'a> BuildOrchestrator<'a> {
             file_options,
         )?;
         let mut writer = VirtualWriter::new(writer, self.excludes(Format::Wheel)?);
-        self.context.add_external_libs(&mut writer, audited)?;
+        self.context
+            .add_external_libs(&mut writer, audited, false)?;
 
         let temp_dir = writer.temp_dir()?;
         let mut generator = make_generator(temp_dir)?;
@@ -811,9 +812,18 @@ impl<'a> BuildOrchestrator<'a> {
         let writer = WheelWriter::new(&tag, &self.context.artifact.out, &metadata24, file_options)?;
         let mut writer = VirtualWriter::new(writer, self.excludes(Format::Wheel)?);
 
-        self.context.add_external_libs(&mut writer, audited)?;
+        // If any artifact has external shared library dependencies, use the
+        // shim approach: move the real binary to {dist}.scripts/ in platlib
+        // (where it has a predictable relative path to the bundled libs
+        // directory) and place a Python shim in .data/scripts/ that execs
+        // the real binary.
+        // WASI targets use their own launcher mechanism and cannot be shimmed.
+        let use_shim = !self.context.project.target.is_wasi()
+            && audited.iter().any(|a| !a.external_libs.is_empty());
+        self.context
+            .add_external_libs(&mut writer, audited, use_shim)?;
 
-        let mut generator = BinBindingGenerator::new(&mut metadata24);
+        let mut generator = BinBindingGenerator::new(&mut metadata24, use_shim);
         generate_binding(&mut writer, &mut generator, self.context, audited, out_dirs)
             .context("Failed to add the files to the wheel")?;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -765,6 +765,19 @@ impl Metadata24 {
             &self.get_version_escaped()
         ))
     }
+
+    /// Returns the platlib directory for relocated scripts.
+    ///
+    /// When bin bindings have external shared library dependencies, the real
+    /// binary is moved from `.data/scripts/` into this directory in platlib
+    /// so that it has a predictable relative path to the bundled shared
+    /// libraries directory (`.libs/` on Linux/Windows, `.dylibs/` on macOS).
+    /// A Python shim replaces the original script entry.
+    ///
+    /// See <https://github.com/pypa/auditwheel/pull/443>.
+    pub fn get_scripts_platlib_dir(&self) -> PathBuf {
+        PathBuf::from(format!("{}.scripts", &self.get_distribution_escaped()))
+    }
 }
 
 /// Split a list of contacts (authors or maintainers) into separate


### PR DESCRIPTION
When bin-type wheels have external shared library dependencies, the bundled `.libs/` directory ends up in `site-packages/` while the binary goes to `bin/` via `.data/scripts/`. The relative path between them is unpredictable, so RPATH cannot be set correctly.

Fix this by adopting auditwheel's approach (`pypa/auditwheel#443`):
- Move the real binary to `{dist}.scripts/` in platlib where it has a predictable relative path to `{dist}.libs/` (or `.dylibs/` on macOS)
- Place a Python shim (`#!python`) in `.data/scripts/` that uses `sysconfig.get_path("platlib")` to locate and `os.execv()` the real binary
- On Windows, the shim also sets up DLL search paths via `os.add_dll_directory()` before exec'ing

This works across all three platform repairers (Linux/ELF, macOS/Mach-O, Windows/PE) since they all use the `artifact_dir` parameter for relative path calculations.

Additional fixes:
- Strip `.exe` extension from shim name on Windows so pip generates proper launcher wrappers
- Guard against WASI targets which have their own launcher mechanism
- Extract `Metadata24::get_scripts_platlib_dir()` to avoid path duplication

Closes #1182