### PR TITLE
feat: add automatic Android API Level detection via getprop

### DIFF
--- a/src/target/platform_tag.rs
+++ b/src/target/platform_tag.rs
@@ -414,6 +414,21 @@ fn find_android_api_level(target_triple: &str, manifest_path: &Path) -> Result<S
         return Ok(api_level);
     }
 
+    // 4. Termux/On-device fallback: Try getprop as a last resort
+    if is_android {
+        let output = std::process::Command::new("getprop")
+            .arg("ro.build.version.sdk")
+            .output();
+        if let Ok(out) = output {
+            if out.status.success() {
+                let sdk_version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !sdk_version.is_empty() {
+                    return Ok(sdk_version);
+                }
+            }
+        }
+    }
+
     bail!(
         "Failed to determine Android API level. Please set the ANDROID_API_LEVEL environment variable."
     );


### PR DESCRIPTION
### Description
Currently, `maturin` requires the `ANDROID_API_LEVEL` environment variable to be explicitly set when building on-device in environments like Termux. If missing, the build fails even though the host system is a live Android instance where this information is readily available.

This PR introduces a fallback mechanism:
1. It checks if the current platform is Android.
2. If `ANDROID_API_LEVEL` and other clues (linker/CC) are missing, it attempts to query `getprop ro.build.version.sdk`.
3. This significantly improves the developer experience for users building Rust-based Python packages directly on Android devices.

### Motivation
I encountered this issue while trying to install tools in Termux on my Redmi Note 8 Pro. Automating this step removes a manual barrier for many mobile developers.

### Testing
- Verified on Android 11 (API 30) within Termux.
- Confirmed that manual environment variables still take priority over this fallback.
- 