### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
           brew install gnu-tar
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
 
-      # Those two will also create target/maturin/maturin
       - name: Build wheel (linux x86_64)
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
@@ -111,15 +110,15 @@ jobs:
       - name: Archive binary (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          cd target/maturin
-          7z a ../../${{ matrix.name }} ${{ github.event.repository.name }}.exe
+          cd target/${{ matrix.target }}/release
+          7z a ../../../${{ matrix.name }} ${{ github.event.repository.name }}.exe
           cd -
 
       - name: Archive binary (linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cd target/maturin
-          tar czvf ../../${{ matrix.name }} ${{ github.event.repository.name }}
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../${{ matrix.name }} ${{ github.event.repository.name }}
           cd -
 
       - name: Archive binary (macOS x86_64)
@@ -220,7 +219,7 @@ jobs:
             --compatibility ${{ matrix.platform.compatibility }} \
             --features password-storage
       - name: Archive binary
-        run: tar czvf target/release/maturin-${{ matrix.platform.target }}.tar.gz -C target/maturin maturin
+        run: tar czvf target/release/maturin-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release maturin
       - name: Upload wheel artifacts
         # loongarch64 is not allowed to publish to pypi currently, see https://github.com/pypi/warehouse/blob/348117529910181cb8c14e9b5fb00fcf4dbaf07c/warehouse/forklift/legacy.py#L114-L185
         if: ${{ !contains(fromJson('["loongarch64-unknown-linux-musl"]'), matrix.platform.target) }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Project overview
+
+maturin builds and publishes Rust crates with pyo3, cffi, and uniffi bindings (and standalone Rust binaries) as Python packages. The core is written in Rust (`src/`) and exposed both as a CLI (`maturin`) and as a PEP 517 build backend through a small Python shim (`maturin/`).
+
+- `src/` — Rust source for the CLI, build backend, and library crate.
+- `maturin/` — Python package: PEP 517 bootstrap backend, `__main__` shim, and the import hook.
+- `tests/` — Rust integration tests (`cli.rs`, `run.rs`, helpers in `common/`, `cmd/`).
+- `test-crates/` — Fixture crates exercised by integration tests; do not commit changes here unless updating fixtures intentionally.
+- `guide/` — mdBook user documentation published at https://maturin.rs.
+- `sysconfig/` — Captured Python sysconfigs used for cross-compilation; treat as data.
+- `src/templates/` — `cargo-generate` templates for `maturin new`/`init`. Excluded from formatters/linters.
+- `noxfile.py` — Maintenance automation (e.g. `update-pyo3`, pyodide setup).
+
+## Build & run
+
+- Build the CLI: `cargo build` (or `cargo build --release`).
+- Run the CLI from source: `cargo run -- <args>`.
+
+## Tests
+
+- Rust unit + integration tests: `cargo test --all-features`.
+- A single integration test: `cargo test --test run -- <substring>`.
+- Python tests: `pytest tests/` (some require a built `maturin` on `PATH`).
+- Long-running cross-compile / manylinux tests live in `tests/manylinux_*.sh` and `tests/run.rs`; many require Docker, zig, or specific Python interpreters and are skipped by default.
+
+Always run the relevant tests for code you touched and report failures faithfully.
+
+## Lint & format
+
+Before finishing a change, run:
+
+- `cargo fmt --all`
+- `cargo clippy --tests --all-features -- -D warnings`
+- `cargo deny --all-features check` (when touching dependencies)
+- `pre-commit run --all-files` for Python / general hooks; `pre-commit run --hook-stage manual --all-files` to also run cargo-check and clippy.
+
+Python code uses `ruff` and `black` (line length 120, target py37) and `mypy` with strict untyped-def checks; see `pyproject.toml`.
+
+## Conventions
+
+- Rust edition and MSRV are pinned in `Cargo.toml` (`rust-version`); do not bump casually.
+- Keep public CLI flags and `pyproject.toml` `[tool.maturin]` keys backward compatible; document changes in `Changelog.md` under the Unreleased section.
+- When adding a CLI option, regenerate the JSON schema via `cargo run --bin generate_json_schema` (see `src/generate_json_schema.rs`) so `maturin.schema.json` stays in sync.
+- Do not edit files under `src/templates/` to satisfy formatters; they are intentionally excluded.
+- Do not modify `sysconfig/` snapshots by hand.


### PR DESCRIPTION
Do not rely on the existence of `target/maturin/maturin`