### PR TITLE
fix: support pixi-managed virtualenvs in maturin develop

### DIFF
--- a/src/develop/install_backend.rs
+++ b/src/develop/install_backend.rs
@@ -175,3 +175,40 @@ pub(crate) fn is_uv_venv(venv_dir: &Path) -> bool {
         Err(_) => false,
     }
 }
+
+/// Check if a virtualenv is created by pixi by checking for `conda-meta/pixi_env_prefix`
+pub(crate) fn is_pixi_venv(venv_dir: &Path) -> bool {
+    venv_dir.join("conda-meta").join("pixi_env_prefix").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_pixi_venv;
+    use fs_err as fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_is_pixi_venv_detects_marker() {
+        let tmp = TempDir::new().unwrap();
+        let conda_meta = tmp.path().join("conda-meta");
+        fs::create_dir_all(&conda_meta).unwrap();
+        fs::write(conda_meta.join("pixi_env_prefix"), "").unwrap();
+        assert!(is_pixi_venv(tmp.path()));
+    }
+
+    #[test]
+    fn test_is_pixi_venv_rejects_plain_venv() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("pyvenv.cfg"), "home = /usr/bin\n").unwrap();
+        assert!(!is_pixi_venv(tmp.path()));
+    }
+
+    #[test]
+    fn test_is_pixi_venv_rejects_vanilla_conda() {
+        let tmp = TempDir::new().unwrap();
+        let conda_meta = tmp.path().join("conda-meta");
+        fs::create_dir_all(&conda_meta).unwrap();
+        fs::write(conda_meta.join("python-3.12.0-h12345.json"), "{}").unwrap();
+        assert!(!is_pixi_venv(tmp.path()));
+    }
+}

--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -13,7 +13,9 @@ use crate::{
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use cargo_options::heading;
 use fs_err as fs;
-use install_backend::{InstallBackend, check_pip_exists, find_uv_bin, find_uv_python, is_uv_venv};
+use install_backend::{
+    InstallBackend, check_pip_exists, find_uv_bin, find_uv_python, is_pixi_venv, is_uv_venv,
+};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::path::Path;
@@ -361,7 +363,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
                 anyhow!("Expected `python` to be a python interpreter inside a virtualenv ಠ_ಠ")
             })?;
 
-    let uv_venv = is_uv_venv(venv_dir);
+    let uv_venv = is_uv_venv(venv_dir) || is_pixi_venv(venv_dir);
     let uv_info = if uv || uv_venv {
         match find_uv_python(&interpreter.executable).or_else(|_| find_uv_bin()) {
             Ok(uv_info) => Some(Ok(uv_info)),
@@ -369,7 +371,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
                 if uv {
                     Some(Err(e))
                 } else {
-                    // Ignore error and try pip instead if it's a uv venv but `--uv` is not specified
+                    // Ignore error and try pip instead if it's a uv/pixi venv but `--uv` is not specified
                     None
                 }
             }


### PR DESCRIPTION
Fixes #2713.

Pixi sets `CONDA_PREFIX` and creates an environment without `pyvenv.cfg`, so `is_uv_venv` returned false. `maturin develop` then fell back to pip. Pixi does not preinstall pip, so users saw "Failed to find pip" on every invocation.

`is_pixi_venv` checks for the `conda-meta/pixi_env_prefix` marker file (written by pixi 0.43+) and routes detected envs through the same uv backend path used for uv-created venvs.
