### PR TITLE
Switch to actions/attest from attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           subject-path: |
@@ -290,7 +290,7 @@ jobs:
           pattern: binaries-*
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           subject-path: |


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance#usage

> As of version 4, actions/attest-build-provenance is simply a wrapper
> on top of actions/attest.
>
> Existing applications may continue to use the attest-build-provenance
> action, but new implementations should use actions/attest instead.