### PR TITLE
Switch generation to actions/attest action, upgrade to v4

### DIFF
--- a/src/ci/github/__snapshot__/github_abi3.yml
+++ b/src/ci/github/__snapshot__/github_abi3.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/__snapshot__/github_bin_no_binding.yml
+++ b/src/ci/github/__snapshot__/github_bin_no_binding.yml
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/__snapshot__/github_default.yml
+++ b/src/ci/github/__snapshot__/github_default.yml
@@ -168,7 +168,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/__snapshot__/github_pyproject_detailed_targets.yml
+++ b/src/ci/github/__snapshot__/github_pyproject_detailed_targets.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/__snapshot__/github_pyproject_simple_targets.yml
+++ b/src/ci/github/__snapshot__/github_pyproject_simple_targets.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/__snapshot__/github_zig_pytest.yml
+++ b/src/ci/github/__snapshot__/github_zig_pytest.yml
@@ -245,7 +245,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/src/ci/github/render.rs
+++ b/src/ci/github/render.rs
@@ -509,7 +509,7 @@ fn emit_release_steps(y: &mut Yaml, resolved: &ResolvedCIConfig) {
 fn emit_release_attestation_step(y: &mut Yaml) {
     y.line("- name: Generate artifact attestation");
     y.indent();
-    y.line("uses: actions/attest-build-provenance@v3");
+    y.line("uses: actions/attest@v4");
     y.line("with:");
     y.indent();
     y.line("subject-path: 'wheels-*/*'");


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance#usage

> As of version 4, actions/attest-build-provenance is simply a wrapper
> on top of actions/attest.
>
> Existing applications may continue to use the attest-build-provenance
> action, but new implementations should use actions/attest instead.