### PR TITLE
fix: avoid duplicate `--interpreter` panic in PEP 517 backend

### DIFF
--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -67,6 +67,14 @@ def _additional_pep517_args() -> List[str]:
     return []
 
 
+def _has_interpreter_arg(args: List[str]) -> bool:
+    """Return True if `args` already contains a `--interpreter`/`-i` flag."""
+    for arg in args:
+        if arg in ("--interpreter", "-i") or arg.startswith("--interpreter="):
+            return True
+    return False
+
+
 def _get_env() -> Optional[Dict[str, str]]:
     if not os.environ.get("MATURIN_NO_INSTALL_RUST") and not shutil.which("cargo"):
         from puccinialin import setup_rust
@@ -87,13 +95,7 @@ def _build_wheel(
 ) -> str:
     # PEP 517 specifies that only `sys.executable` points to the correct
     # python interpreter
-    base_command = [
-        "maturin",
-        "pep517",
-        "build-wheel",
-        "-i",
-        _get_sys_executable(),
-    ]
+    base_command = ["maturin", "pep517", "build-wheel"]
     options = _additional_pep517_args()
     if editable:
         options.append("--editable")
@@ -101,6 +103,11 @@ def _build_wheel(
     pep517_args = get_maturin_pep517_args(config_settings)
     if pep517_args:
         options.extend(pep517_args)
+
+    # Only auto-inject the interpreter if the user has not already supplied one
+    # via MATURIN_PEP517_ARGS / config_settings.
+    if not _has_interpreter_arg(options):
+        base_command.extend(["-i", _get_sys_executable()])
 
     if "--compatibility" not in options and "--manylinux" not in options:
         # default to off if not otherwise specified
@@ -218,15 +225,18 @@ def prepare_metadata_for_build_wheel(
         "write-dist-info",
         "--metadata-directory",
         metadata_directory,
-        # PEP 517 specifies that only `sys.executable` points to the correct
-        # python interpreter
-        "--interpreter",
-        _get_sys_executable(),
     ]
     command.extend(_additional_pep517_args())
     pep517_args = get_maturin_pep517_args(config_settings)
     if pep517_args:
         command.extend(pep517_args)
+
+    # PEP 517 specifies that only `sys.executable` points to the correct python
+    # interpreter. Only auto-inject it if the user has not already supplied one
+    # via MATURIN_PEP517_ARGS / config_settings, otherwise we'd pass
+    # `--interpreter` twice and trip the strict arity check in maturin.
+    if not _has_interpreter_arg(command):
+        command.extend(["--interpreter", _get_sys_executable()])
 
     print("Running `{}`".format(" ".join(command)))
     try:

--- a/src/commands/pep517.rs
+++ b/src/commands/pep517.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use ignore::overrides::Override;
 use maturin::{
@@ -64,11 +64,29 @@ pub fn pep517(subcommand: Pep517Command) -> Result<()> {
 
     match subcommand {
         Pep517Command::WriteDistInfo {
-            build_options,
+            mut build_options,
             metadata_directory,
             strip_opt,
         } => {
-            assert_eq!(build_options.python.interpreter.len(), 1);
+            // PEP 517's `prepare_metadata_for_build_wheel` operates on a single
+            // interpreter (the one running pip). If duplicates of the same path
+            // were supplied (e.g. user-set `MATURIN_PEP517_ARGS=--interpreter ...`
+            // combined with the auto-injected one), collapse them. Otherwise
+            // bail with a clear message instead of panicking.
+            {
+                let mut seen = std::collections::HashSet::new();
+                build_options
+                    .python
+                    .interpreter
+                    .retain(|p| seen.insert(p.clone()));
+            }
+            if build_options.python.interpreter.len() > 1 {
+                bail!(
+                    "`maturin pep517 write-dist-info` expects exactly one --interpreter, got {}: {:?}",
+                    build_options.python.interpreter.len(),
+                    build_options.python.interpreter,
+                );
+            }
             let mut context = build_options
                 .into_build_context()
                 .strip(strip_opt.strip)


### PR DESCRIPTION
When users set `MATURIN_PEP517_ARGS=--interpreter <python>` (common on Termux/Android where the auto-detected interpreter path may need to be overridden), the Python PEP 517 shim still appended its own `--interpreter $(sys.executable)`, producing two `--interpreter` flags. The Rust side then tripped `assert_eq!(... == 1)` in `Pep517Command::WriteDistInfo`, surfacing as a 'this is a bug in maturin' panic to end users (see #3174).

Two changes:

* `maturin/__init__.py`: introduce `_has_interpreter_arg()` and only auto-inject `--interpreter <sys.executable>` in `_build_wheel` and `prepare_metadata_for_build_wheel` when the user-supplied args don't already contain one.
* `src/commands/pep517.rs`: defensively dedup identical interpreter paths and replace the `assert_eq!` with an `anyhow::bail!` carrying a clear message, so an actual misconfiguration is reported as an error instead of a panic.

Closes #3174