### PR TITLE
fix(sdist): handle symlinked `Cargo.toml` pointing outside project root

### DIFF
--- a/src/source_distribution/mod.rs
+++ b/src/source_distribution/mod.rs
@@ -699,7 +699,18 @@ fn add_main_crate(writer: &mut VirtualWriter<SDistWriter>, ctx: &SdistContext<'_
 
 /// Add Cargo.lock to the sdist.
 fn add_cargo_lock(writer: &mut VirtualWriter<SDistWriter>, ctx: &SdistContext<'_>) -> Result<()> {
-    let manifest_cargo_lock_path = ctx.abs_manifest_dir.join("Cargo.lock");
+    // `abs_manifest_dir` is canonicalized (symlinks resolved). Use the
+    // logical absolute manifest dir from `project.manifest_path` so the
+    // resulting `Cargo.lock` path is consistent with `project_root` (also a
+    // logical path) when `Cargo.toml` is a symlink pointing outside the
+    // project root (#3177).
+    let manifest_dir = ctx
+        .project
+        .manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| ctx.abs_manifest_dir.clone());
+    let manifest_cargo_lock_path = manifest_dir.join("Cargo.lock");
     let workspace_cargo_lock = ctx.workspace_root.join("Cargo.lock").into_std_path_buf();
     let cargo_lock_path = if manifest_cargo_lock_path.exists() {
         Some(manifest_cargo_lock_path)
@@ -738,15 +749,18 @@ fn add_workspace_manifest(
     // the crate's own directory as `workspace_root`, so this check correctly
     // skips adding the parent workspace Cargo.toml for excluded crates.
     //
-    // We normalize workspace_root to match abs_manifest_dir (also normalized) so
-    // that symlinks or .. components don't cause a false positive.
-    let normalized_workspace_root = ctx
-        .workspace_root
-        .as_std_path()
-        .normalize()
-        .map(|p| p.into_path_buf())
-        .unwrap_or_else(|_| ctx.workspace_root.as_std_path().to_path_buf());
-    let is_in_workspace = normalized_workspace_root != ctx.abs_manifest_dir;
+    // `abs_manifest_dir` is canonicalized while `workspace_root` (from cargo
+    // metadata) is not. Comparing them directly produces a false positive when
+    // `Cargo.toml` is a symlink pointing outside the workspace, so use the
+    // logical absolute manifest dir from `project.manifest_path` instead
+    // (#3177).
+    let logical_manifest_dir = ctx
+        .project
+        .manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| ctx.abs_manifest_dir.clone());
+    let is_in_workspace = ctx.workspace_root.as_std_path() != logical_manifest_dir;
     if !is_in_workspace {
         return Ok(());
     }
@@ -760,8 +774,7 @@ fn add_workspace_manifest(
     // Collect all crates that must remain in `workspace.members`:
     // the known path dependencies plus the main Python binding crate itself.
     let mut deps_to_keep = ctx.known_path_deps.clone();
-    let main_member_name = ctx
-        .abs_manifest_dir
+    let main_member_name = logical_manifest_dir
         .strip_prefix(ctx.workspace_root)
         .unwrap()
         .to_slash()


### PR DESCRIPTION
`SdistContext::abs_manifest_dir` is canonicalized via `normpath::normalize`, which resolves symlinks on Unix. When `Cargo.toml` is a symlink containing `..` that points outside the project root (e.g.
`Cargo.toml -> ../../common/rust/Cargo.toml`), `abs_manifest_dir` ends up outside `project_root` / `workspace_root` (which come from cargo metadata and `pyproject.toml` as logical, non-canonicalized paths). This caused two panics in sdist generation:

- `add_cargo_lock`: `cargo_lock_path.strip_prefix(project_root).unwrap()`
- `add_workspace_manifest`: `is_in_workspace` false-positive followed by `abs_manifest_dir.strip_prefix(workspace_root).unwrap()`

Use the logical absolute manifest dir from `project.manifest_path.parent()` (still absolute — `ProjectResolver::resolve` normalizes the path and `debug_assert!`s `is_absolute()`) for these comparisons so they stay consistent with cargo's view of the workspace. Other uses of `abs_manifest_dir` compare against canonical paths and are left untouched.

Fixes #3177