### PR TITLE
fix: disable abi3 in pyo3 config for version-specific fallback builds

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 
 use crate::python_interpreter::{
     MAXIMUM_PYPY_MINOR, MAXIMUM_PYTHON_MINOR, MINIMUM_PYPY_MINOR, MINIMUM_PYTHON_MINOR,
+    PythonInterpreter,
 };
 
 /// pyo3 binding crate
@@ -335,16 +336,35 @@ impl BridgeModel {
         }
     }
 
-    /// Is using abi3
-    pub fn is_abi3(&self) -> bool {
+    /// Returns `true` if the bridge model carries stable-ABI metadata (e.g. abi3).
+    ///
+    /// This is a project-level check — it does not consider whether a particular
+    /// interpreter meets the abi3 minimum version.  For per‑interpreter checks
+    /// use [`is_abi3_for_interpreter`](Self::is_abi3_for_interpreter).
+    pub fn has_stable_abi(&self) -> bool {
         self.pyo3()
-            .and_then(|pyo3| match pyo3.stable_abi {
-                Some(stable_abi) => match stable_abi.kind {
-                    StableAbiKind::Abi3 => Some(true),
-                },
-                None => None,
+            .and_then(|pyo3| pyo3.stable_abi.as_ref())
+            .is_some()
+    }
+
+    /// Check whether abi3 should be enabled for a specific interpreter.
+    ///
+    /// Returns `true` only when the bridge model has stable abi support **and**
+    /// the given interpreter meets the abi3 minimum version.  Version‑specific
+    /// fallback builds (e.g. Python 3.10 when abi3 targets ≥ 3.11) return
+    /// `false` so that `Py_LIMITED_API` is not defined and interpreter‑specific
+    /// linker names are used.
+    pub fn is_abi3_for_interpreter(&self, interpreter: &PythonInterpreter) -> bool {
+        self.pyo3()
+            .and_then(|pyo3| pyo3.stable_abi.as_ref())
+            .is_some_and(|stable_abi| {
+                match stable_abi.version.min_version() {
+                    Some((major, minor)) => {
+                        (interpreter.major as u8, interpreter.minor as u8) >= (major, minor)
+                    }
+                    None => true, // CurrentPython → always compatible
+                }
             })
-            .is_some_and(|x| x)
     }
 
     /// free-threaded Python support

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -350,20 +350,22 @@ impl BridgeModel {
     /// Check whether abi3 should be enabled for a specific interpreter.
     ///
     /// Returns `true` only when the bridge model has stable abi support **and**
-    /// the given interpreter meets the abi3 minimum version.  Version‑specific
-    /// fallback builds (e.g. Python 3.10 when abi3 targets ≥ 3.11) return
-    /// `false` so that `Py_LIMITED_API` is not defined and interpreter‑specific
-    /// linker names are used.
+    /// the given interpreter supports the stable ABI **and** meets the abi3
+    /// minimum version. Version‑specific fallback builds (e.g. Python 3.10 when
+    /// abi3 targets ≥ 3.11) return `false` so that `Py_LIMITED_API` is not
+    /// defined and interpreter‑specific linker names are used.
     pub fn is_abi3_for_interpreter(&self, interpreter: &PythonInterpreter) -> bool {
+        if !interpreter.has_stable_api() {
+            return false;
+        }
+
         self.pyo3()
             .and_then(|pyo3| pyo3.stable_abi.as_ref())
-            .is_some_and(|stable_abi| {
-                match stable_abi.version.min_version() {
-                    Some((major, minor)) => {
-                        (interpreter.major as u8, interpreter.minor as u8) >= (major, minor)
-                    }
-                    None => true, // CurrentPython → always compatible
+            .is_some_and(|stable_abi| match stable_abi.version.min_version() {
+                Some((major, minor)) => {
+                    (interpreter.major as u8, interpreter.minor as u8) >= (major, minor)
                 }
+                None => true, // CurrentPython → compatible when stable ABI is supported
             })
     }
 

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -307,7 +307,7 @@ mod tests {
         // find_bridge alone never includes conditional features → no abi3
         let bridge = find_bridge(&metadata, None).unwrap();
         assert!(
-            !bridge.is_abi3(),
+            !bridge.has_stable_abi(),
             "find_bridge should not infer abi3 from conditional features"
         );
 
@@ -328,7 +328,10 @@ mod tests {
             std::slice::from_ref(&py310),
         )
         .unwrap();
-        assert!(!bridge.is_abi3(), "should not infer abi3 for Python 3.10");
+        assert!(
+            !bridge.has_stable_abi(),
+            "should not infer abi3 for Python 3.10"
+        );
 
         // With a Python 3.11 interpreter, condition matches → abi3
         let py311 = crate::PythonInterpreter::from_config(
@@ -348,7 +351,7 @@ mod tests {
             std::slice::from_ref(&py311),
         )
         .unwrap();
-        assert!(bridge.is_abi3(), "should infer abi3 for Python 3.11");
+        assert!(bridge.has_stable_abi(), "should infer abi3 for Python 3.11");
 
         // With mixed interpreters [3.10, 3.11], abi3 IS inferred because
         // at least one interpreter (3.11) matches the condition. This is safe
@@ -358,7 +361,7 @@ mod tests {
         let bridge =
             upgrade_bridge_abi3(base_bridge, &metadata, Some(&pyproject), &[py310, py311]).unwrap();
         assert!(
-            bridge.is_abi3(),
+            bridge.has_stable_abi(),
             "should infer abi3 for mixed [3.10, 3.11] (build_stable_abi_wheels handles the split)"
         );
     }

--- a/src/ci/github/render.rs
+++ b/src/ci/github/render.rs
@@ -87,7 +87,7 @@ pub(crate) fn generate_github(
     sdist: bool,
     min_python_minor: Option<u8>,
 ) -> Result<String> {
-    let is_abi3 = bridge_model.is_abi3();
+    let is_abi3 = bridge_model.has_stable_abi();
     let is_bin = bridge_model.is_bin();
     let setup_python = resolved.pytest
         || matches!(

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -620,7 +620,9 @@ fn configure_macos_pyo3_linker_args(
     }
 
     // install_name is specific to the top-level output, so keep it in cargo_rustc.args
-    let so_filename = if bridge_model.is_abi3() {
+    let use_abi3_suffix =
+        python_interpreter.is_some_and(|i| bridge_model.is_abi3_for_interpreter(i));
+    let so_filename = if use_abi3_suffix {
         format!("{module_name}.abi3.so")
     } else {
         python_interpreter
@@ -852,7 +854,10 @@ fn configure_pyo3_env(
     target: &Target,
     target_triple: &str,
 ) -> Result<()> {
-    if bridge_model.is_abi3() {
+    // Only set PYO3_NO_PYTHON for true abi3 builds where the interpreter meets
+    // the abi3 minimum version.  Version-specific fallback builds (e.g. Python
+    // 3.10 when abi3 targets ≥ 3.11) must not set PYO3_NO_PYTHON.
+    if python_interpreter.is_some_and(|i| bridge_model.is_abi3_for_interpreter(i)) {
         let is_pypy_or_graalpy = python_interpreter
             .map(|p| p.interpreter_kind.is_pypy() || p.interpreter_kind.is_graalpy())
             .unwrap_or(false);
@@ -892,7 +897,8 @@ fn configure_pyo3_env(
             // and legacy pyo3 versions
             build_command.env("PYTHON_SYS_EXECUTABLE", &interpreter.executable);
         } else if bridge_model.is_pyo3() && env::var_os("PYO3_CONFIG_FILE").is_none() {
-            let pyo3_config = interpreter.pyo3_config_file(target, bridge_model.is_abi3());
+            let use_abi3 = bridge_model.is_abi3_for_interpreter(interpreter);
+            let pyo3_config = interpreter.pyo3_config_file(target, use_abi3);
             let maturin_target_dir = ensure_target_maturin_dir(&context.project.target_dir);
             let config_file = maturin_target_dir.join(format!(
                 "pyo3-config-{}-{}.{}.txt",


### PR DESCRIPTION
## Summary

- Fixes #3179 — abi3 fallback for older interpreters incorrectly sets `Py_LIMITED_API` in pyo3 config

## Problem

When maturin builds abi3 wheels for multiple interpreters and one interpreter is older than the abi3 minimum version (e.g. Python 3.10 with `abi3-py311`), it falls back to a version-specific build. However, the project-global `BridgeModel::is_abi3()` was used in compilation paths (`configure_pyo3_env`, `configure_macos_pyo3_linker_args`), causing:
- `Py_LIMITED_API` to be defined via `pyo3-config-*.txt` 
- `PYO3_NO_PYTHON` to be set incorrectly
- `.abi3.so` filename suffix on macOS

All of these leaked into version-specific fallback builds.

## Fix

Replaced `is_abi3()` with two clearer methods on `BridgeModel`:

- **`has_stable_abi()`** — project-level check used by the orchestrator, CI generator, and tests (does the bridge carry abi3 metadata at all?)
- **`is_abi3_for_interpreter(interpreter)`** — per-interpreter check used by all compilation paths to decide whether to actually enable `Py_LIMITED_API`, `PYO3_NO_PYTHON`, and `.abi3.so` suffixes for the current interpreter. Returns `false` for interpreters that do not meet the abi3 minimum version.

## Testing

- Verified against the reproduction case from #3179 (`bencode-rs` with `--interpreter python3.13 --interpreter 3.10`)
- Both the abi3 wheel (cp311-abi3) and version-specific fallback wheel (cp310-cp310) build successfully
- All 199 unit tests pass, including `test_find_bridge_conditional_abi3_filtered_by_interpreter`