### PR TITLE
Release v1.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "anyhow",
  "arwen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["konstin <konstin@mailbox.org>", "messense <messense@icloud.com>"]
 name = "maturin"
-version = "1.13.2"
+version = "1.13.3"
 description = "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages"
 exclude = [
     "test-crates/**/*",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.13.3
+
+* Fix: disable abi3 in pyo3 config for version-specific fallback builds ([#3180](https://github.com/pyo3/maturin/pull/3180))
+
 ## 1.13.2
 
 * Fix: resolve test failures in distro packaging environments ([#3129](https://github.com/pyo3/maturin/pull/3129))


### PR DESCRIPTION
## Summary

* Bump version to 1.13.3, includes the fix from #3180 (disable abi3 in pyo3 config for version-specific fallback builds).