### PR TITLE
Documentation: fix the update_readme script

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -71,8 +71,8 @@ Options:
 
           This options offers both fine-grained control over the linux libc tag and a more automatic PyPI-compatibility option.
 
-          The `pypi` option applies on all platforms and ensure that only tags that can be uploaded to PyPI are used. The linux-specific options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example `musllinux_1_2`), and `linux` for the native linux tag. They are
-          ignored on non-linux platforms.
+          The `pypi` option applies on all platforms and ensure that only tags that can be uploaded to PyPI are used. The linux-specific options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example `musllinux_1_2`), and
+          `linux` for the native linux tag. They are ignored on non-linux platforms.
 
           Note that `manylinux1` and `manylinux2010` are unsupported by the rust compiler. Wheels with the native `linux` tag will be rejected by pypi, unless they are separately validated by `auditwheel`.
 
@@ -84,6 +84,7 @@ Options:
           Possible values:
           - repair: Audit and repair wheel for manylinux compliance
           - check:  Check wheel for manylinux compliance, but do not repair
+          - warn:   Audit wheel and warn about external libraries, but do not fail or repair
           - skip:   Don't check for manylinux compliance
 
       --zig
@@ -307,11 +308,9 @@ Options:
   -v, --verbose...
           Use verbose output.
 
-          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`.
-          * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`. * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
 
-          You can configure fine-grained logging using the `RUST_LOG` environment variable.
-          (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+          You can configure fine-grained logging using the `RUST_LOG` environment variable. (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
 
   -o, --output <PATH>
           Output path
@@ -319,9 +318,7 @@ Options:
           [default: -]
 
       --platform <platform>...
-          Platform support
-
-          [default: linux musllinux windows macos]
+          Platform support [deprecated: use [tool.maturin.generate-ci.github] and set 'platforms' in pyproject.toml]
 
           Possible values:
           - all:        All
@@ -330,15 +327,16 @@ Options:
           - windows:    Windows
           - macos:      macOS
           - emscripten: Emscripten
+          - android:    Android
 
       --pytest
-          Enable pytest
+          Enable pytest [deprecated: use [tool.maturin.generate-ci.github] in pyproject.toml]
 
       --zig
-          Use zig to do cross compilation
+          Use zig to do cross compilation [deprecated: use [tool.maturin.generate-ci.github] in pyproject.toml]
 
       --skip-attestation
-          Skip artifact attestation
+          Skip artifact attestation [deprecated: use [tool.maturin.generate-ci.github] in pyproject.toml]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -71,8 +71,8 @@ Options:
 
           This options offers both fine-grained control over the linux libc tag and a more automatic PyPI-compatibility option.
 
-          The `pypi` option applies on all platforms and ensure that only tags that can be uploaded to PyPI are used. The linux-specific options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example `musllinux_1_2`), and
-          `linux` for the native linux tag. They are ignored on non-linux platforms.
+          The `pypi` option applies on all platforms and ensure that only tags that can be uploaded to PyPI are used. The linux-specific options are `manylinux` tags (for example `manylinux2014`/`manylinux_2_24`) or `musllinux` tags (for example
+          `musllinux_1_2`), and `linux` for the native linux tag. They are ignored on non-linux platforms.
 
           Note that `manylinux1` and `manylinux2010` are unsupported by the rust compiler. Wheels with the native `linux` tag will be rejected by pypi, unless they are separately validated by `auditwheel`.
 
@@ -318,7 +318,7 @@ Options:
           [default: -]
 
       --platform <platform>...
-          Platform support [deprecated: use [tool.maturin.generate-ci.github] and set 'platforms' in pyproject.toml]
+          Platform support [deprecated: use [tool.maturin.generate-ci.github."PLATFORM NAME"] in pyproject.toml]
 
           Possible values:
           - all:        All

--- a/guide/src/tutorial.md
+++ b/guide/src/tutorial.md
@@ -67,14 +67,33 @@ Create a new cargo project
 Usage: maturin new [OPTIONS] <PATH>
 
 Arguments:
-  <PATH>  Project path
+  <PATH>
+          Project path
 
 Options:
-      --name <NAME>          Set the resulting package name, defaults to the directory name
-      --mixed                Use mixed Rust/Python project layout
-      --src                  Use Python first src layout for mixed Rust/Python project
-  -b, --bindings <BINDINGS>  Which kind of bindings to use [possible values: pyo3, cffi, uniffi, bin]
-  -h, --help                 Print help information
+      --name <NAME>
+          Set the resulting package name, defaults to the directory name
+
+  -v, --verbose...
+          Use verbose output.
+
+          * Default: Show build information and `cargo build` output. * `-v`: Use `cargo build -v`. * `-vv`: Show debug logging and use `cargo build -vv`. * `-vvv`: Show trace logging.
+
+          You can configure fine-grained logging using the `RUST_LOG` environment variable. (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
+
+      --mixed
+          Use mixed Rust/Python project layout
+
+      --src
+          Use Python first src layout for mixed Rust/Python project
+
+  -b, --bindings <BINDINGS>
+          Which kind of bindings to use
+
+          [possible values: pyo3, cffi, uniffi, bin]
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 The above process can be achieved by running `maturin new -b pyo3 guessing_game`

--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -179,7 +179,7 @@ pub struct GenerateCI {
     /// Output path
     #[arg(short = 'o', long, value_name = "PATH", default_value = "-")]
     pub output: PathBuf,
-    /// Platform support [deprecated: use [tool.maturin.generate-ci.github] in pyproject.toml]
+    /// Platform support [deprecated: use [tool.maturin.generate-ci.github."PLATFORM NAME"] in pyproject.toml]
     #[arg(
         id = "platform",
         long,

--- a/test-crates/update_readme.py
+++ b/test-crates/update_readme.py
@@ -18,7 +18,7 @@ def main():
     for path in FILES:
         content = root.joinpath(path).read_text()
 
-        matcher = re.compile(r"```\nUsage: maturin (\w+) (.*?)```", re.MULTILINE | re.DOTALL)
+        matcher = re.compile(r"Usage: maturin ([\w-]+) (.*?)```", re.MULTILINE | re.DOTALL)
 
         replaces = {}
         for command, old in matcher.findall(content):

--- a/tests/cmd/generate-ci.stdout
+++ b/tests/cmd/generate-ci.stdout
@@ -28,7 +28,8 @@ Options:
           [default: -]
 
       --platform <platform>...
-          Platform support [deprecated: use [tool.maturin.generate-ci.github] in pyproject.toml]
+          Platform support [deprecated: use [tool.maturin.generate-ci.github."PLATFORM NAME"] in
+          pyproject.toml]
 
           Possible values:
           - all:        All


### PR DESCRIPTION
Hello maturin maintainers :wave: 

This PR does two things: 

## fixes the script `update readme.py`

The regexp was failing in two cases: 

- if the documentation had `bash\nUsage:` instead of `Usage:`
- if the command had a dash (as in `generate-ci`)

Now that it works I ran it and the documentation is up to date again.

## adds a precision in `generate-ci` doc

Took me some time to understand how to set the platforms from the pyproject file. Thought I'd add a hint.