### PR TITLE
Update PyPI platform tag validation

### DIFF
--- a/src/target/legacy_py.rs
+++ b/src/target/legacy_py.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 pub(super) static MACOS_PLATFORM_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^macosx_(?P<major>\d+)_(?:\d+)_(?P<arch>.+)$").unwrap());
+    Lazy::new(|| Regex::new(r"^macosx_(?P<major>\d+)_(?P<minor>\d+)_(?P<arch>.+)$").unwrap());
 
 pub(super) static IOS_PLATFORM_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^ios_(?:\d+)_(?:\d+)_(?P<arch>.+)_(?:iphoneos|iphonesimulator)$").unwrap()
@@ -18,6 +18,9 @@ pub(super) static ANDROID_PLATFORM_RE: Lazy<Regex> =
 pub(super) static LINUX_PLATFORM_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^(?P<libc>(?:many|musl))linux_(?:\d+)_(?:\d+)_(?P<arch>.+)$").unwrap()
 });
+
+pub(super) static PYEMSCRIPTEN_PLATFORM_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^pyemscripten_(?:\d+)_(?:\d+)_wasm32$").unwrap());
 
 /// Contains also non-Rust platforms to match `legacy.py` verbatim.
 pub(super) static ALLOWED_PLATFORMS: &[&str] = &[
@@ -49,8 +52,8 @@ pub(super) static WINDOWS_ARCHES: &[&str] = &["x86_64", "i686", "aarch64"];
 /// Reduced list only containing targets support by both Rust/maturin and PyPI.
 pub(super) static MACOS_ARCHES: &[&str] = &["x86_64", "arm64", "i686", "universal2"];
 
-/// Those are actually hardcoded in warehouse in the same way.
-pub(super) static MACOS_MAJOR_VERSIONS: &[&str] = &["10", "11", "12", "13", "14", "15", "26"];
+/// macOS 10 is handled separately because `macosx_10_{minor}` tags allow any minor version.
+pub(super) static MACOS_MAJOR_VERSIONS: &[&str] = &["11", "12", "13", "14", "15", "26"];
 
 pub(super) static IOS_ARCHES: &[&str] = &["arm64", "x86_64"];
 

--- a/src/target/pypi_tags.rs
+++ b/src/target/pypi_tags.rs
@@ -17,11 +17,12 @@
 //! - macOS: x86_64, arm64, i686 (Tier 3), universal2 (maturin special target)
 //! - iOS: arm64, x86_64 (simulator)
 //! - Android: armeabi_v7a (armv7l), arm64_v8a (aarch64), x86 (i686), x86_64
+//! - Emscripten: wasm32
 
 use crate::target::legacy_py::{
     ALLOWED_PLATFORMS, ANDROID_ARCHES, ANDROID_PLATFORM_RE, IOS_ARCHES, IOS_PLATFORM_RE,
     LINUX_PLATFORM_RE, MACOS_ARCHES, MACOS_MAJOR_VERSIONS, MACOS_PLATFORM_RE, MANYLINUX_ARCHES,
-    MUSLLINUX_ARCHES, WINDOWS_ARCHES,
+    MUSLLINUX_ARCHES, PYEMSCRIPTEN_PLATFORM_RE, WINDOWS_ARCHES,
 };
 use crate::target::{Arch, Os, Target};
 use anyhow::{Result, anyhow, bail};
@@ -62,6 +63,7 @@ pub fn is_arch_supported_by_pypi(target: &Target) -> bool {
             };
             ANDROID_ARCHES.contains(&android_arch)
         }
+        Os::Emscripten => arch == Arch::Wasm32,
         Os::Linux => {
             // Old arm versions
             // https://github.com/pypi/warehouse/blob/556e1e3390999381c382873b003a779a1363cb4d/warehouse/forklift/legacy.py#L122-L123
@@ -98,9 +100,16 @@ fn is_platform_tag_allowed_by_pypi(platform_tag: &str) -> bool {
     // macOS
     if let Some(captures) = MACOS_PLATFORM_RE.captures(platform_tag) {
         let major = captures.name("major").unwrap().as_str();
+        let minor = captures.name("minor").unwrap().as_str();
         let arch = captures.name("arch").unwrap().as_str();
 
-        return MACOS_MAJOR_VERSIONS.contains(&major) && MACOS_ARCHES.contains(&arch);
+        if major == "10" && MACOS_ARCHES.contains(&arch) {
+            return true;
+        }
+
+        return MACOS_MAJOR_VERSIONS.contains(&major)
+            && minor == "0"
+            && MACOS_ARCHES.contains(&arch);
     }
 
     // manylinux/musllinux
@@ -131,6 +140,11 @@ fn is_platform_tag_allowed_by_pypi(platform_tag: &str) -> bool {
     if let Some(captures) = ANDROID_PLATFORM_RE.captures(platform_tag) {
         let arch = captures.name("arch").unwrap().as_str();
         return ANDROID_ARCHES.contains(&arch);
+    }
+
+    // Emscripten / Pyodide, PEP 783
+    if PYEMSCRIPTEN_PLATFORM_RE.is_match(platform_tag) {
+        return true;
     }
 
     false
@@ -200,6 +214,7 @@ mod tests {
             ("macosx_9_0_x86_64", false), // Invalid major version
             ("macosx_10_9_x86_64", true),
             ("macosx_11_0_arm64", true),
+            ("macosx_11_1_arm64", false), // Only macOS 10 allows arbitrary minor versions
             ("macosx_26_0_arm64", true),
             // iOS platforms
             ("ios_14_0_arm64_iphoneos", true),
@@ -211,6 +226,9 @@ mod tests {
             ("android_21_x86", true),
             ("android_21_x86_64", true),
             ("android_21_mips", false), // Unsupported architecture
+            // Emscripten / Pyodide, PEP 783
+            ("pyemscripten_2025_0_wasm32", true),
+            ("pyodide_2025_0_wasm32", false),
         ];
 
         for (platform_tag, expected) in tags {
@@ -252,7 +270,7 @@ mod tests {
             ("x86_64-unknown-freebsd", false), // Now unsupported (no lazy validation)
             ("powerpc64-unknown-linux-gnu", true), // PPC64 on Linux is supported
             ("s390x-unknown-linux-gnu", true), // s390x on Linux is supported
-            ("wasm32-unknown-emscripten", false), // Emscripten is unsupported
+            ("wasm32-unknown-emscripten", true), // Emscripten uses PEP 783 pyemscripten tags
             ("i686-pc-windows-msvc", true),    // i686 Windows is supported
         ];
 


### PR DESCRIPTION
Sync validation with current Warehouse behavior for macOS platform tags and PEP 783 pyemscripten tags.

Accept wasm32 Emscripten targets for PyPI when using `pyemscripten_*_wasm32`, and add focused tests for the updated rules.