### PR TITLE
Fix Pyodide Emscripten platform tags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,14 +241,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cover the two Emscripten platform-tag families exposed by current
-        # Pyodide releases:
-        # - Pyodide 0.29 (Python 3.13) → `pyodide_2025_0_wasm32`
-        #   (pre-PEP 783, exposed via `info.abi_version` in pyodide-lock.json).
+        # Cover the PEP 783 Emscripten platform tags exposed by current
+        # Pyodide releases. Pyodide 0.29 still stores the version in the
+        # historical `info.abi_version` field, but maturin should emit the
+        # PyPI-accepted `pyemscripten_*` tag for it.
+        # - Pyodide 0.29 (Python 3.13) → `pyemscripten_2025_0_wasm32`.
         # - Pyodide 314.0.0-alpha.1 (Python 3.14) → `pyemscripten_2026_0_wasm32`
-        #   (PEP 783, see https://peps.python.org/pep-0783/). The lock file
-        #   only exposes `info.abi_version = 2026_0`, so noxfile uses the
-        #   Python version to pick the new `pyemscripten_*` tag.
+        #   (see https://peps.python.org/pep-0783/).
         # The legacy `emscripten_<emcc-version>_wasm32` family (Pyodide
         # <= 0.27) is no longer exercised end-to-end because no maintained
         # Pyodide release uses it; it remains covered by the cascade unit

--- a/guide/src/environment-variables.md
+++ b/guide/src/environment-variables.md
@@ -58,14 +58,15 @@ Config-settings take priority over `MATURIN_PEP517_ARGS`; the environment variab
 * `SOURCE_DATE_EPOCH`: The time to use for the timestamp in the wheel metadata
 * `MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION` / `PYEMSCRIPTEN_PLATFORM_VERSION`: The
   [PEP 783](https://peps.python.org/pep-0783/) PyEmscripten platform version
-  (e.g. `2026_0`) used to derive the `pyemscripten_<year>_<patch>_wasm32`
-  wheel platform tag. Pyodide 0.30+ exposes this via
-  `sysconfig.get_config_var("PYEMSCRIPTEN_PLATFORM_VERSION")` and `pyodide
-  config get pyemscripten_platform_version`.
-* `MATURIN_PYODIDE_ABI_VERSION` / `PYODIDE_ABI_VERSION`: Pre-PEP 783 Pyodide
-  ABI version (e.g. `2025_0`) used to derive the
-  `pyodide_<year>_<patch>_wasm32` tag. Used when targeting Pyodide
-  0.28 / 0.29. Available via `pyodide config get pyodide_abi_version`.
+  (e.g. `2025_0`) used to derive the `pyemscripten_<year>_<patch>_wasm32`
+  wheel platform tag. Pyodide exposes this via
+  `sysconfig.get_config_var("PYEMSCRIPTEN_PLATFORM_VERSION")`; maturin also
+  checks `pyodide config get pyemscripten_platform_version` when available.
+* `MATURIN_PYODIDE_ABI_VERSION` / `PYODIDE_ABI_VERSION`: Historical Pyodide
+  ABI version variable name (e.g. `2025_0`) used to derive the PEP 783
+  `pyemscripten_<year>_<patch>_wasm32` tag. Available via `pyodide config get
+  pyodide_abi_version`. Pyodide previously referred to the same platform as
+  `pyodide_<year>_<patch>`, but PyPI accepts the PEP 783 `pyemscripten_*` tag.
 * `MATURIN_EMSCRIPTEN_VERSION`: The version of emscripten to use for emscripten
   builds (legacy `emscripten_<emcc-version>_wasm32` tag, used for Pyodide
   &le; 0.27 only). Prefer `MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION` /

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,10 +103,10 @@ def _resolve_pyodide_platform_inputs(info: dict) -> dict:
 
     * `info.platform` is `emscripten_<X>_<Y>_<Z>` and contains the emcc
       version that built the runtime (used by `setup-emsdk`).
-    * `info.abi_version` (Pyodide >= 0.28) is `<year>_<patch>` and drives either
-      the pre-PEP 783 `pyodide_<year>_<patch>_wasm32` wheel tag, or the PEP 783
-      `pyemscripten_<year>_<patch>_wasm32` tag for Python 3.14+ lock files.
-    * A future `info.pyemscripten_platform_version` (Pyodide >= 0.30) drives
+    * `info.abi_version` (Pyodide >= 0.28) is `<year>_<patch>` and drives the
+      PEP 783 `pyemscripten_<year>_<patch>_wasm32` tag through maturin's
+      historical `PYODIDE_ABI_VERSION` env var.
+    * A future `info.pyemscripten_platform_version` drives
       the PEP 783 `pyemscripten_<year>_<patch>_wasm32` wheel tag.
 
     See https://peps.python.org/pep-0783/.
@@ -129,23 +129,13 @@ def _resolve_pyodide_platform_inputs(info: dict) -> dict:
     if pyemscripten:
         env["PYEMSCRIPTEN_PLATFORM_VERSION"] = pyemscripten
         env["EXPECTED_PLATFORM_TAG"] = f"pyemscripten_{pyemscripten}_wasm32"
-    elif abi_version and _pyodide_python_at_least(info, 3, 14):
-        env["PYEMSCRIPTEN_PLATFORM_VERSION"] = abi_version
-        env["EXPECTED_PLATFORM_TAG"] = f"pyemscripten_{abi_version}_wasm32"
     elif abi_version:
         env["PYODIDE_ABI_VERSION"] = abi_version
-        env["EXPECTED_PLATFORM_TAG"] = f"pyodide_{abi_version}_wasm32"
+        env["EXPECTED_PLATFORM_TAG"] = f"pyemscripten_{abi_version}_wasm32"
     elif emscripten_version:
         legacy = emscripten_version.replace(".", "_").replace("-", "_")
         env["EXPECTED_PLATFORM_TAG"] = f"emscripten_{legacy}_wasm32"
     return env
-
-
-def _pyodide_python_at_least(info: dict, major: int, minor: int) -> bool:
-    match = re.match(r"^(\d+)\.(\d+)", info.get("python", ""))
-    if not match:
-        return False
-    return (int(match.group(1)), int(match.group(2))) >= (major, minor)
 
 
 @nox.session(name="setup-pyodide", python=False)

--- a/src/ci/github/__snapshot__/github_emscripten.yml
+++ b/src/ci/github/__snapshot__/github_emscripten.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
           echo PYTHON_VERSION=$(pyodide config get python_version | cut -d '.' -f 1-2) >> $GITHUB_ENV
-          if v=$(pyodide config get pyodide_abi_version 2>/dev/null); then echo PYODIDE_ABI_VERSION=$v >> $GITHUB_ENV; fi
+          if v=$(pyodide config get pyemscripten_platform_version 2>/dev/null); then echo PYEMSCRIPTEN_PLATFORM_VERSION=$v >> $GITHUB_ENV; elif v=$(pyodide config get pyodide_abi_version 2>/dev/null); then echo PYODIDE_ABI_VERSION=$v >> $GITHUB_ENV; fi
           pip uninstall -y pyodide-build
       - uses: emscripten-core/setup-emsdk@v16
         with:

--- a/src/ci/github/render.rs
+++ b/src/ci/github/render.rs
@@ -284,18 +284,18 @@ fn emit_emscripten_setup(y: &mut Yaml) {
         .indent();
     y.line("echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV");
     y.line("echo PYTHON_VERSION=$(pyodide config get python_version | cut -d '.' -f 1-2) >> $GITHUB_ENV");
-    // Pre-PEP 783 ABI / PEP 783 platform-tag input. Pyodide >= 0.28 exposes
-    // `pyodide_abi_version` (e.g. `2025_0` for 0.28/0.29 on Python 3.13,
-    // `2026_0` for 0.30 / 314.0.0a1 on Python 3.14). `pyodide config get`
-    // exits 1 and prints an error to stdout for unknown keys, so we use an
-    // `if` to only export `PYODIDE_ABI_VERSION` when the key is recognised.
-    // Older Pyodide releases simply leave it unset and maturin falls back to
-    // the legacy `emscripten_*` tag. PEP 783 (pyemscripten_*) is then
-    // selected by the cascade in `src/target/platform_tag.rs` based on
-    // `PYTHON_VERSION` (>= 3.14).
-    y.line(
-        "if v=$(pyodide config get pyodide_abi_version 2>/dev/null); then echo PYODIDE_ABI_VERSION=$v >> $GITHUB_ENV; fi",
-    );
+    // PEP 783 platform-tag input. Current pyodide-build exposes the version
+    // through the historical `pyodide_abi_version` key (e.g. `2025_0` for
+    // Python 3.13 / `pyemscripten_2025_0`). `pyodide config get` exits 1 and
+    // prints an error to stdout for unknown keys, so we only export a value
+    // when a key is recognised. Older Pyodide releases simply leave it unset
+    // and maturin falls back to the legacy `emscripten_*` tag.
+    y.line(concat!(
+        "if v=$(pyodide config get pyemscripten_platform_version 2>/dev/null); then ",
+        "echo PYEMSCRIPTEN_PLATFORM_VERSION=$v >> $GITHUB_ENV; ",
+        "elif v=$(pyodide config get pyodide_abi_version 2>/dev/null); then ",
+        "echo PYODIDE_ABI_VERSION=$v >> $GITHUB_ENV; fi"
+    ));
     y.line("pip uninstall -y pyodide-build");
     y.dedent_by(2)
         .line("- uses: emscripten-core/setup-emsdk@v16")

--- a/src/target/platform_tag.rs
+++ b/src/target/platform_tag.rs
@@ -335,21 +335,21 @@ pub(crate) fn rustc_macosx_target_version(target: &str) -> (u16, u16) {
 /// Resolve the platform tag for `wasm32-unknown-emscripten`.
 ///
 /// This implements the priority cascade required to support both
-/// [PEP 783](https://peps.python.org/pep-0783/) and pre-PEP 783 Pyodide
-/// releases:
+/// [PEP 783](https://peps.python.org/pep-0783/) and older Pyodide config
+/// variable names:
 ///
-/// 1. **PEP 783** (Pyodide >= 0.30, Python 3.14+) — emit
-///    `pyemscripten_{YEAR}_{PATCH}_wasm32`. Resolved from
-///    `MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION` /
-///    `PYEMSCRIPTEN_PLATFORM_VERSION` (the sysconfig variable Pyodide 0.30+
-///    exposes), falling back to `pyodide config get
-///    pyemscripten_platform_version`.
-/// 2. **Pre-PEP 783 standardized tag** (Pyodide 0.28 / 0.29) — emit
-///    `pyodide_{YEAR}_{PATCH}_wasm32`. Resolved from
-///    `MATURIN_PYODIDE_ABI_VERSION` / `PYODIDE_ABI_VERSION`, falling back to
-///    `pyodide config get pyodide_abi_version`. For Python 3.14+ lock
-///    files the same input maps to the PEP 783 `pyemscripten_*` tag.
-/// 3. **Legacy** (Pyodide <= 0.27) — emit
+/// 1. **PEP 783 env override** — emit `pyemscripten_{YEAR}_{PATCH}_wasm32`
+///    from `MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION` /
+///    `PYEMSCRIPTEN_PLATFORM_VERSION` (the sysconfig variable named by
+///    PEP 783).
+/// 2. **Historical Pyodide env override** — emit the same PEP 783 tag from
+///    `MATURIN_PYODIDE_ABI_VERSION` / `PYODIDE_ABI_VERSION`. Pyodide used to
+///    refer to the same platform version as `pyodide_{YEAR}_{PATCH}`, but PyPI
+///    only accepts the PEP 783 `pyemscripten_*` platform tag.
+/// 3. **Pyodide config auto-detection** — try `pyodide config get
+///    pyemscripten_platform_version`, then `pyodide config get
+///    pyodide_abi_version`.
+/// 4. **Legacy** (Pyodide <= 0.27) — emit
 ///    `emscripten_{EMCC_VERSION}_wasm32`. Resolved from
 ///    `MATURIN_EMSCRIPTEN_VERSION` or `emcc -dumpversion`. Emits a warning
 ///    explaining that the tag is not PEP 783 compliant.
@@ -357,30 +357,32 @@ fn emscripten_platform_tag() -> Result<String> {
     if let Some(ver) = first_non_empty_env(&[
         "MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION",
         "PYEMSCRIPTEN_PLATFORM_VERSION",
-    ])
-    .or_else(|| pyodide_config_get("pyemscripten_platform_version"))
-    {
-        return Ok(format!("pyemscripten_{ver}_wasm32"));
+    ]) {
+        return Ok(pep783_emscripten_platform_tag(&ver));
     }
     if let Some(ver) = first_non_empty_env(&["MATURIN_PYODIDE_ABI_VERSION", "PYODIDE_ABI_VERSION"])
-        .or_else(|| pyodide_config_get("pyodide_abi_version"))
     {
-        let py = first_non_empty_env(&["PYTHON_VERSION"])
-            .or_else(|| pyodide_config_get("python_version"));
-        return Ok(if is_python_3_14_or_later(py.as_deref()) {
-            format!("pyemscripten_{ver}_wasm32")
-        } else {
-            format!("pyodide_{ver}_wasm32")
-        });
+        return Ok(pep783_emscripten_platform_tag(&ver));
+    }
+    if let Some(ver) = pyodide_config_get("pyemscripten_platform_version") {
+        return Ok(pep783_emscripten_platform_tag(&ver));
+    }
+    if let Some(ver) = pyodide_config_get("pyodide_abi_version") {
+        return Ok(pep783_emscripten_platform_tag(&ver));
     }
     let release = emscripten_version()?.replace(['.', '-'], "_");
     eprintln!(
         "⚠️  Falling back to legacy `emscripten_{release}_wasm32` platform tag. \
          This wheel will not be installable on PEP 783-compliant Pyodide runtimes. \
          Set `MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION` (PEP 783) or \
-         `MATURIN_PYODIDE_ABI_VERSION` (Pyodide 0.28+) to produce a portable tag."
+         `MATURIN_PYODIDE_ABI_VERSION` (historical Pyodide ABI version env var) \
+         to produce a portable tag."
     );
     Ok(format!("emscripten_{release}_wasm32"))
+}
+
+fn pep783_emscripten_platform_tag(version: &str) -> String {
+    format!("pyemscripten_{version}_wasm32")
 }
 
 /// Return the first env var in `names` that is set to a non-empty (after
@@ -392,20 +394,6 @@ fn first_non_empty_env(names: &[&str]) -> Option<String> {
             (!t.is_empty()).then(|| t.to_string())
         })
     })
-}
-
-fn is_python_3_14_or_later(version: Option<&str>) -> bool {
-    let Some(version) = version else {
-        return false;
-    };
-    let mut parts = version.split('.');
-    let Some(Ok(major)) = parts.next().map(str::parse::<u32>) else {
-        return false;
-    };
-    let Some(Ok(minor)) = parts.next().map(str::parse::<u32>) else {
-        return false;
-    };
-    (major, minor) >= (3, 14)
 }
 
 /// Best-effort `pyodide config get <key>` invocation.
@@ -523,20 +511,69 @@ fn find_android_api_level(target_triple: &str, manifest_path: &Path) -> Result<S
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_android_api_level, iphoneos_deployment_target, is_python_3_14_or_later,
-        macosx_deployment_target,
+        emscripten_platform_tag, extract_android_api_level, iphoneos_deployment_target,
+        macosx_deployment_target, pep783_emscripten_platform_tag,
     };
     use pretty_assertions::assert_eq;
+    use std::env;
+    use std::ffi::OsString;
+
+    struct EnvVarRestore {
+        vars: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl EnvVarRestore {
+        fn new(names: &[&'static str]) -> Self {
+            let vars = names
+                .iter()
+                .map(|&name| (name, env::var_os(name)))
+                .collect();
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvVarRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.vars {
+                unsafe {
+                    if let Some(value) = value {
+                        env::set_var(name, value);
+                    } else {
+                        env::remove_var(name);
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
-    fn test_is_python_3_14_or_later() {
-        assert!(is_python_3_14_or_later(Some("3.14")));
-        assert!(is_python_3_14_or_later(Some("3.14.2")));
-        assert!(is_python_3_14_or_later(Some("3.15.0")));
-        assert!(!is_python_3_14_or_later(Some("3.13.9")));
-        assert!(!is_python_3_14_or_later(Some("3")));
-        assert!(!is_python_3_14_or_later(Some("invalid")));
-        assert!(!is_python_3_14_or_later(None));
+    fn test_pep783_emscripten_platform_tag() {
+        assert_eq!(
+            pep783_emscripten_platform_tag("2025_0"),
+            "pyemscripten_2025_0_wasm32"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_emscripten_platform_tag_uses_pyodide_abi_version_for_pep783() {
+        let _guard = EnvVarRestore::new(&[
+            "MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION",
+            "PYEMSCRIPTEN_PLATFORM_VERSION",
+            "MATURIN_PYODIDE_ABI_VERSION",
+            "PYODIDE_ABI_VERSION",
+        ]);
+        unsafe {
+            env::remove_var("MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION");
+            env::remove_var("PYEMSCRIPTEN_PLATFORM_VERSION");
+            env::set_var("MATURIN_PYODIDE_ABI_VERSION", "2025_0");
+            env::remove_var("PYODIDE_ABI_VERSION");
+        }
+
+        assert_eq!(
+            emscripten_platform_tag().unwrap(),
+            "pyemscripten_2025_0_wasm32"
+        );
     }
 
     #[test]

--- a/tests/emscripten_runner.js
+++ b/tests/emscripten_runner.js
@@ -1,4 +1,7 @@
-const { opendir } = require("node:fs/promises");
+const fs = require("node:fs");
+const { copyFile, mkdtemp, opendir } = require("node:fs/promises");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
 const { loadPyodide } = require("pyodide");
 
 async function findWheel(distDir) {
@@ -7,8 +10,8 @@ async function findWheel(distDir) {
   // `{name}-{ver}-{python tag}-{abi tag}-{platform tag}.whl`, so anchor to
   // the trailing `-{platform tag}.whl` segment to avoid false positives
   // from a project name that happens to contain `pyodide_` etc.
-  // - `pyemscripten_<year>_<patch>_wasm32` (PEP 783, Pyodide >= 0.30)
-  // - `pyodide_<year>_<patch>_wasm32`     (pre-PEP 783, Pyodide 0.28/0.29)
+  // - `pyemscripten_<year>_<patch>_wasm32` (PEP 783)
+  // - `pyodide_<year>_<patch>_wasm32`     (legacy pre-PEP 783 naming)
   // - `emscripten_<emcc-version>_wasm32`  (legacy, Pyodide <= 0.27)
   const tagRegex = /-(pyemscripten|pyodide|emscripten)_[^-]+_wasm32\.whl$/;
   const dir = await opendir(distDir);
@@ -17,6 +20,32 @@ async function findWheel(distDir) {
       return dirent.name;
     }
   }
+}
+
+async function wheelPathForRuntime(distDir, wheelName, pyodide) {
+  const pep783PlatformVersion = pyodide.runPython(`
+import sysconfig
+sysconfig.get_config_var("PYEMSCRIPTEN_PLATFORM_VERSION")
+`);
+  if (pep783PlatformVersion) {
+    return `${distDir}/${wheelName}`;
+  }
+
+  // Pyodide 0.28/0.29 runtimes still validate wheel filenames using the
+  // pre-PEP 783 `pyodide_<year>_<patch>_wasm32` spelling. Maturin should build
+  // the PyPI-accepted `pyemscripten_*` filename, but for the runtime smoke test
+  // we need a compatibility copy with the old platform-tag spelling.
+  const legacyName = wheelName.replace(
+    /-pyemscripten_(\d+_\d+)_wasm32\.whl$/,
+    "-pyodide_$1_wasm32.whl",
+  );
+  if (legacyName === wheelName) {
+    return `${distDir}/${wheelName}`;
+  }
+  const runtimeDir = await mkdtemp(join(tmpdir(), "maturin-pyodide-runtime-"));
+  const runtimePath = `${runtimeDir}/${legacyName}`;
+  await copyFile(`${distDir}/${wheelName}`, runtimePath);
+  return runtimePath;
 }
 
 function make_tty_ops(stream){
@@ -89,10 +118,11 @@ const testDir = pkgDir + "/tests";
 
 async function main() {
   const wheelName = await findWheel(distDir);
-  const wheelURL = `file:${distDir}/${wheelName}`;
 
   try {
     pyodide = await loadPyodide();
+    const wheelPath = await wheelPathForRuntime(distDir, wheelName, pyodide);
+    const wheelURL = `file:${wheelPath}`;
     const FS = pyodide.FS;
     setupStreams(FS, pyodide._module.TTY);
     const NODEFS = FS.filesystems.NODEFS;


### PR DESCRIPTION
Emit PEP 783 `pyemscripten_*` platform tags whenever maturin receives a Pyodide ABI/platform version, including the historical `PYODIDE_ABI_VERSION` path used for Python 3.13. This matches current Pyodide docs and avoids generating `pyodide_2025_0_wasm32`, which PyPI rejects.