### PR TITLE
fix: only shim bin wheels during auditwheel repair

### DIFF
--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -1,4 +1,4 @@
-use crate::auditwheel::{AuditedArtifact, PlatformTag, Policy};
+use crate::auditwheel::{AuditWheelMode, AuditedArtifact, PlatformTag, Policy};
 use crate::binding_generator::{
     BinBindingGenerator, BindingGenerator, CffiBindingGenerator, Pyo3BindingGenerator,
     UniFfiBindingGenerator, generate_binding,
@@ -815,14 +815,18 @@ impl<'a> BuildOrchestrator<'a> {
         let writer = WheelWriter::new(&tag, &self.context.artifact.out, &metadata24, file_options)?;
         let mut writer = VirtualWriter::new(writer, self.excludes(Format::Wheel)?);
 
-        // If any artifact has external shared library dependencies, use the
-        // shim approach: move the real binary to {dist}.scripts/ in platlib
-        // (where it has a predictable relative path to the bundled libs
-        // directory) and place a Python shim in .data/scripts/ that execs
+        // When repair mode bundles external shared library dependencies, use
+        // the shim approach: move the real binary to {dist}.scripts/ in
+        // platlib (where it has a predictable relative path to the bundled
+        // libs directory) and place a Python shim in .data/scripts/ that execs
         // the real binary.
         // WASI targets use their own launcher mechanism and cannot be shimmed.
-        let use_shim = !self.context.project.target.is_wasi()
-            && audited.iter().any(|a| !a.external_libs.is_empty());
+        let has_external_libs = audited.iter().any(|a| !a.external_libs.is_empty());
+        let use_shim = should_use_bin_shim(
+            self.context.python.auditwheel,
+            self.context.project.target.is_wasi(),
+            has_external_libs,
+        );
         self.context
             .add_external_libs(&mut writer, audited, use_shim)?;
 
@@ -950,5 +954,26 @@ impl<'a> BuildOrchestrator<'a> {
             }
             _ => bail!("Stub generation  is only possible in PyO3 projects"),
         }
+    }
+}
+
+fn should_use_bin_shim(auditwheel: AuditWheelMode, is_wasi: bool, has_external_libs: bool) -> bool {
+    matches!(auditwheel, AuditWheelMode::Repair) && !is_wasi && has_external_libs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_use_bin_shim;
+    use crate::auditwheel::AuditWheelMode;
+
+    #[test]
+    fn test_should_use_bin_shim_only_for_repair_with_external_libs() {
+        assert!(should_use_bin_shim(AuditWheelMode::Repair, false, true));
+
+        assert!(!should_use_bin_shim(AuditWheelMode::Warn, false, true));
+        assert!(!should_use_bin_shim(AuditWheelMode::Check, false, true));
+        assert!(!should_use_bin_shim(AuditWheelMode::Skip, false, true));
+        assert!(!should_use_bin_shim(AuditWheelMode::Repair, true, true));
+        assert!(!should_use_bin_shim(AuditWheelMode::Repair, false, false));
     }
 }


### PR DESCRIPTION
## Summary
- only enable the bin-wheel shim layout when `auditwheel=repair` will bundle external libraries
- keep `auditwheel=warn`, `check`, `skip`, no-library, and WASI builds on the normal `.data/scripts/` layout
- add a focused unit test for the shim decision matrix

## Rationale
Maturin 1.13.2 started moving bin artifacts into `{dist}.scripts/` whenever external libraries were detected. On macOS and Windows, the default auditwheel mode is `warn`, which reports external libraries but does not graft them into the wheel. That produced shim-only wheel layouts without bundled `.dylibs`/`.libs`, which changed wheel contents unexpectedly for consumers such as astral-sh/uv#19468.

The shim is only needed when repair mode copies libraries into platlib and the binary needs a predictable relative path to those bundled libraries.

## Checks
- `cargo fmt --all`
- `cargo test --lib build_orchestrator::tests::test_should_use_bin_shim_only_for_repair_with_external_libs -- --nocapture`
- `cargo test --lib`
- `cargo clippy --tests --all-features -- -D warnings`
- `git diff --check`
- pre-commit commit hooks (`cargo fmt`, `cargo deny`, general hooks)
