### PR TITLE
Fix python versions used in integration_pyo3_mixed_conda

### DIFF
--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -360,7 +360,7 @@ pub fn test_integration_conda(
     // Create environments to build against, prepended with "A" to ensure that integration
     // tests are executed with these environments
     let mut interpreters = Vec::new();
-    for minor in 9..=12 {
+    for minor in 10..=14 {
         let (_, venv_python) = create_conda_env(&format!("maturin-{case_id}-3{minor}"), 3, minor)?;
         interpreters.push(venv_python);
     }


### PR DESCRIPTION
The default anaconda channel shipped a pip version that is broken on Python 3.9, so I bumped the minimum version on Python 3.10.

I also bumped the maximum version as well.

This fixes the CI failures seen in https://github.com/PyO3/maturin/pull/3206 when @messense tried to merge it.