### PR TITLE
Don't depend on CFFI on PyPy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * `--find-interpreter` now discovers free-threaded CPython interpreters (`python3.14t` and newer) on all platforms. The experimental 3.13t is no longer built by default; build it explicitly with `-i python3.13t`.
+* `cffi` is no longer automatically added as a build dependency of maturin on PyPy, which has `cffi` pre-installed as part of the PyPy distribution
 
 ## 1.13.3
 

--- a/maturin/__init__.py
+++ b/maturin/__init__.py
@@ -163,7 +163,7 @@ def build_sdist(sdist_directory: str, config_settings: Optional[Mapping[str, Any
 
 # noinspection PyUnusedLocal
 def get_requires_for_build_wheel(config_settings: Optional[Mapping[str, Any]] = None) -> List[str]:
-    if get_config().get("bindings") == "cffi":
+    if get_config().get("bindings") == "cffi" and platform.python_implementation() != "PyPy":
         requirements = ["cffi"]
     else:
         requirements = []

--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 {% if bindings == "cffi" -%}
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 {% endif -%}
 dynamic = ["version"]
 {% if mixed_non_src -%}

--- a/test-crates/cffi-mixed-implicit/pyproject.toml
+++ b/test-crates/cffi-mixed-implicit/pyproject.toml
@@ -8,7 +8,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Rust"
 ]
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-mixed-include-exclude/pyproject.toml
+++ b/test-crates/cffi-mixed-include-exclude/pyproject.toml
@@ -7,7 +7,7 @@ name = "cffi-mixed-include-exclude"
 readme = "README.md"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 requires-python = ">=3.7"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-mixed-py-subdir/pyproject.toml
+++ b/test-crates/cffi-mixed-py-subdir/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
     "Programming Language :: Rust"
 ]
 requires-python = ">=3.6"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version", "description"]  # Allow description from Cargo.toml to be used
 
 [tool.maturin]

--- a/test-crates/cffi-mixed-src/pyproject.toml
+++ b/test-crates/cffi-mixed-src/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Rust"
 ]
 requires-python = ">=3.7"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-mixed-submodule/pyproject.toml
+++ b/test-crates/cffi-mixed-submodule/pyproject.toml
@@ -8,7 +8,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Rust"
 ]
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-mixed-with-path-dep/pyproject.toml
+++ b/test-crates/cffi-mixed-with-path-dep/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Rust"
 ]
 requires-python = ">=3.7"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-mixed/pyproject.toml
+++ b/test-crates/cffi-mixed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cffi-mixed"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-pure/pyproject.toml
+++ b/test-crates/cffi-pure/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cffi-pure"
-dependencies = ["cffi"]
+#dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/cffi-pure/pyproject.toml
+++ b/test-crates/cffi-pure/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cffi-pure"
-#dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]
 
 [tool.maturin]

--- a/test-crates/with-data/pyproject.toml
+++ b/test-crates/with-data/pyproject.toml
@@ -4,5 +4,5 @@ build-backend = "maturin"
 
 [project]
 name = "with-data"
-dependencies = ["cffi"]
+dependencies = ["cffi; platform_python_implementation != 'PyPy'"]
 dynamic = ["version"]


### PR DESCRIPTION
Per [the CFFI docs](https://cffi.readthedocs.io/en/latest/installation.html#installation-and-status), PyPy vendors CFFI and installing it and requiring it is unnecessary. This is particularly annoying because cffi doesn't ship PyPy wheels, so it triggers an unnecessary C build at install time.

Also see, for example, the way [cryptography handles this](https://github.com/pyca/cryptography/blob/ba936e527bc4e3948c338a7bde54c3bd81957c61/pyproject.toml#L8).

I noticed this was an issue in the CI for #3113, which saw failures related to the unnecessary CFFI builds failing.