### PR TITLE
Add PEP 740 publish attestations to PyPI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,13 @@ jobs:
             ./*.tar.gz
             ./*.whl
       - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+      - name: Generate PyPI publish attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        with:
+          paths: |
+            ./*.tar.gz
+            ./*.whl
       - name: Publish (dry run)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: uv publish --dry-run '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,8 +240,6 @@ jobs:
       id-token: write
       # Used to upload release artifacts.
       contents: write
-      # Use to generate artifact attestation.
-      attestations: write
     name: Publish to PyPI
     runs-on: ubuntu-latest
     environment:
@@ -253,13 +251,6 @@ jobs:
         with:
           pattern: wheels-*
           merge-multiple: true
-      - name: Generate artifact attestation
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        with:
-          subject-path: |
-            ./*.tar.gz
-            ./*.whl
       - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
       - name: Generate PyPI publish attestations
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,8 +238,6 @@ jobs:
       # Used to sign the release's artifacts
       # and upload to PyPI using trusted publisher.
       id-token: write
-      # Used to upload release artifacts.
-      contents: write
     name: Publish to PyPI
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Context

The `release-pypi` job in `release.yml` publishes to PyPI over Trusted Publishing but uploads no [PEP 740](https://peps.python.org/pep-0740/) attestations, so the wheels get no index-served provenance (e.g., none of the v1.14.0 files carry a `provenance` in the [JSON API](https://pypi.org/pypi/maturin/1.14.0/json)).

There's already an [`actions/attest`](https://github.com/PyO3/maturin/blob/6a7ab7f9a349ee9d3b3c0ca4c1639dd99e8a079f/.github/workflows/release.yml#L256-L262) step in that job, but it seems to mirror [`release-github`](https://github.com/PyO3/maturin/blob/6a7ab7f9a349ee9d3b3c0ca4c1639dd99e8a079f/.github/workflows/release.yml#L292-L299) and only writes a GitHub-side attestation ([example](https://github.com/PyO3/maturin/attestations/30873077)). This technically works, but is kind of a mismatch; this isn't where Python consumers see provenance -- PEP 740 is the PyPI-native version.

## Changes
- Adds [`astral-sh/attest-action`](https://github.com/astral-sh/attest-action) on non-dry-runs to generate PEP 740 attestations right before `uv publish`, which uploads them automatically.
- Removes the redundant `actions/attest` step (and its required permissions, which are no longer necessary)
  - Again, thise step isn't inherently wrong, just somewhat non-idiomatic for Python wheels: it writes GitHub-side provenance where PEP 740 is the PyPI-native equivalent. Removed here since it's redundant, but it's an isolated change, so happy to drop that commit if its preferred to keep it.

I used `astral-sh/attest-action` since it fits the current uv flow with the smallest diff, and best preserves existing dry-run semantics. An alternative would be to move the publish to [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish), which uses Trusted Publishing + PEP 740 by default, which is also used by[pyo3/pyo3](https://github.com/PyO3/pyo3/blob/4c8407df89463d130039643fb2c6dc22065011ba/.github/workflows/python-wheel.yml#L107)). Happy to change in that direction if maintainers prefer :^)

Note: `release-github`'s attestations are untouched; those will continue to be available via GitHub Releases as before.