### PR TITLE
Fix shell quoting in CI scripts

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -euxo pipefail
 
 sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,8 @@ jobs:
         run: |
           set -euo pipefail
           # set SDKROOT for C dependencies like ring and bzip2
-          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+          export SDKROOT
           rustup target add aarch64-apple-darwin
           cargo run -- build --release -b bin -o dist --target universal2-apple-darwin --features password-storage,static --compatibility pypi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,11 +129,12 @@ jobs:
 
       - name: Set MATURIN_TEST_PYTHON
         shell: bash
-        run: echo "MATURIN_TEST_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
+        run: echo "MATURIN_TEST_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> "${GITHUB_ENV}"
       # To save cache disk space
       - name: Disable debuginfo on Windows
         if: startsWith(matrix.os, 'windows')
-        run: echo "RUSTFLAGS="-C debuginfo=0"" >> $GITHUB_ENV
+        shell: bash
+        run: echo "RUSTFLAGS=-C debuginfo=0" >> "${GITHUB_ENV}"
       - name: cargo test
         run: cargo nextest run --features password-storage
       - name: test cross compiling with zig
@@ -173,7 +174,8 @@ jobs:
         run: |
           set -ex
           rustup target add x86_64-unknown-linux-gnu
-          export PYO3_CONFIG_FILE=$(pwd)/test-crates/pyo3-mixed/pyo3-config.txt
+          PYO3_CONFIG_FILE="$(pwd)/test-crates/pyo3-mixed/pyo3-config.txt"
+          export PYO3_CONFIG_FILE
           target/debug/maturin build -m test-crates/pyo3-mixed/Cargo.toml --target x86_64-unknown-linux-gnu --zig
       - name: test maturin new
         shell: bash


### PR DESCRIPTION
Fixes #3205.

This quotes GitHub environment file redirects in CI shell snippets and splits command-substitution exports so shellcheck can validate the scripts without changing the exported values. It also adds the missing Bash shebang to the devcontainer post-create script.

Validation:

- `PATH=/tmp/maturin-shellcheck/shellcheck-v0.10.0:$PATH; find . -name "*.sh" -print | sort | xargs shellcheck --severity=warning`
- `shellcheck --severity=warning` on the changed workflow shell snippets after substituting the GitHub expression that Actions expands before Bash runs
- `git diff --check origin/main...HEAD`
- `uvx pre-commit run --all-files`
