### PR TITLE
set `UV_PYTHON` when running `maturin develop` with uv

### DIFF
--- a/src/develop/install_backend.rs
+++ b/src/develop/install_backend.rs
@@ -107,7 +107,7 @@ impl InstallBackend {
             },
             InstallBackend::Uv { path, args } => {
                 let mut cmd = Command::new(path);
-                cmd.args(args).arg("pip");
+                cmd.args(args).arg("pip").env("UV_PYTHON", python_path);
                 cmd
             }
         }


### PR DESCRIPTION
If `UV_PYTHON` is set (e.g. as a default of 3.14 in my `.zshrc`) and it does not match the current `.venv` selected, then maturin develop will fail with a version mismatch:

```bash
$ uvx maturin develop
🐍 Found CPython 3.11 at /Users/david/Dev/pyo3-scratch/.venv/bin/python
🔗 Found pyo3 bindings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
📦 Built wheel for CPython 3.11 to /var/folders/nt/_zn9g40n6rj9ls6qj3l1g_840000gn/T/.tmpzuneLp/pyo3_scratch-0.1.0-cp311-cp311-macosx_11_0_arm64.whl
💥 maturin failed
  Caused by: uv pip install in /Users/david/Dev/pyo3-scratch/.venv failed running ["pip", "install", "--no-deps", "--force-reinstall", "/var/folders/nt/_zn9g40n6rj9ls6qj3l1g_840000gn/T/.tmpzuneLp/pyo3_scratch-0.1.0-cp311-cp311-macosx_11_0_arm64.whl"]: exit status: 1
--- Stdout:

--- Stderr:
× No solution found when resolving dependencies:
  ╰─▶ Because only pyo3-scratch==0.1.0 is available and pyo3-scratch==0.1.0
      has no wheels with a matching Python version tag (e.g., `cp314`), we can
      conclude that all versions of pyo3-scratch cannot be used.
      And because you require pyo3-scratch, we can conclude that your
      requirements are unsatisfiable.
---
```

By setting `UV_PYTHON` to the path of the maturin-resolved python interpreter as part of the `install_backend` command, this problem goes away.