### PR TITLE
Replace unguarded panics with explicit errors on fallible input

### DIFF
--- a/src/auditwheel/audit.rs
+++ b/src/auditwheel/audit.rs
@@ -86,7 +86,23 @@ pub fn get_sysroot_path(target: &Target) -> Result<PathBuf> {
     Ok(PathBuf::from("/"))
 }
 
-pub fn relpath(to: &Path, from: &Path) -> PathBuf {
+/// Compute the relative path from `from` to `to`.
+///
+/// Both inputs must be either absolute or relative — mixing them (e.g.
+/// one absolute and one relative) would otherwise produce nonsense `..`
+/// chains, since their components would never match and the entire `from`
+/// tail would be turned into `..` segments. That feeds the RPATH math with
+/// garbage, so reject it up front with a clear error.
+pub fn relpath(to: &Path, from: &Path) -> Result<PathBuf> {
+    let to_is_absolute = to.is_absolute();
+    let from_is_absolute = from.is_absolute();
+    if to_is_absolute != from_is_absolute {
+        bail!(
+            "cannot compute relative path between an absolute and a relative path: `{}` and `{}`",
+            from.display(),
+            to.display()
+        );
+    }
     let mut suffix_pos = 0;
     for (f, t) in from.components().zip(to.components()) {
         if f == t {
@@ -104,7 +120,7 @@ pub fn relpath(to: &Path, from: &Path) -> PathBuf {
         .skip(suffix_pos)
         .map(|x| result.push(x.as_os_str()))
         .last();
-    result
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -123,7 +139,7 @@ mod tests {
         for (from, to, expected) in cases {
             let from = Path::new(from);
             let to = Path::new(to);
-            let result = relpath(from, to);
+            let result = relpath(from, to).unwrap();
             assert_eq!(result, Path::new(expected));
         }
     }

--- a/src/auditwheel/linux.rs
+++ b/src/auditwheel/linux.rs
@@ -578,8 +578,11 @@ impl ElfRepairer {
                 continue;
             }
             let mut new_rpaths = patchelf::get_rpath(&aa.artifact.path)?;
-            let new_rpath = Path::new("$ORIGIN").join(relpath(libs_dir, artifact_dir));
-            new_rpaths.push(new_rpath.to_str().unwrap().to_string());
+            let new_rpath = Path::new("$ORIGIN").join(relpath(libs_dir, artifact_dir)?);
+            let new_rpath = new_rpath.to_str().with_context(|| {
+                format!("computed rpath is not valid UTF-8: {}", new_rpath.display())
+            })?;
+            new_rpaths.push(new_rpath.to_string());
             let new_rpath = new_rpaths.join(":");
             patchelf::set_rpath(&aa.artifact.path, &new_rpath)?;
         }

--- a/src/auditwheel/macos.rs
+++ b/src/auditwheel/macos.rs
@@ -175,7 +175,7 @@ impl WheelRepairer for MacOSRepairer {
         // searches `LC_LOAD_DYLIB` for the exact `old` string and
         // silently no-ops on `DylibNameMissing`); add a regression
         // fixture before bumping `lddtree` past 0.5.x if so.
-        let rel = relpath(libs_dir, artifact_dir);
+        let rel = relpath(libs_dir, artifact_dir)?;
         for audited in artifacts {
             let artifact_deps: HashSet<&str> = audited
                 .external_libs

--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -160,7 +160,10 @@ pub fn find_sysconfigdata(lib_dir: &Path, target: &Target) -> Result<PathBuf> {
 fn search_lib_dir(path: impl AsRef<Path>, target: &Target) -> Result<Vec<PathBuf>> {
     let mut sysconfig_paths = vec![];
     let (cpython_version_pat, pypy_version_pat) = if let Some(v) =
-        env::var_os("PYO3_CROSS_PYTHON_VERSION").map(|s| s.into_string().unwrap())
+        env::var_os("PYO3_CROSS_PYTHON_VERSION")
+            .map(|s| s.into_string())
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("PYO3_CROSS_PYTHON_VERSION is not valid UTF-8"))?
     {
         (format!("python{v}"), format!("pypy{v}"))
     } else {
@@ -250,18 +253,21 @@ struct BuildDetailsAbi {
 ///
 /// Starting from Python 3.14, the file is installed in the platform-independent
 /// standard library directory, e.g. `<prefix>/lib/python3.14/build-details.json`.
-pub fn find_build_details(path: &Path) -> Option<PathBuf> {
+pub fn find_build_details(path: &Path) -> Result<Option<PathBuf>> {
     let candidate = path.join("build-details.json");
     if candidate.is_file() {
-        return Some(candidate);
+        return Ok(Some(candidate));
     }
-    let cross_python_version =
-        env::var_os("PYO3_CROSS_PYTHON_VERSION").map(|s| s.into_string().unwrap());
+    let cross_python_version = env::var_os("PYO3_CROSS_PYTHON_VERSION")
+        .map(|s| s.into_string())
+        .transpose()
+        .map_err(|_| anyhow::anyhow!("PYO3_CROSS_PYTHON_VERSION is not valid UTF-8"))?;
     let version_pat = cross_python_version
         .as_deref()
         .map(|v| format!("python{v}"))
         .unwrap_or_else(|| "python3.".into());
-    let entries = fs::read_dir(path).ok()?;
+    let entries = fs::read_dir(path)
+        .with_context(|| format!("Failed to read directory {}", path.display()))?;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
@@ -273,12 +279,12 @@ pub fn find_build_details(path: &Path) -> Option<PathBuf> {
             || name_str.starts_with("3.");
         if dominated
             && entry.path().is_dir()
-            && let Some(found) = find_build_details(&entry.path())
+            && let Some(found) = find_build_details(&entry.path())?
         {
-            return Some(found);
+            return Ok(Some(found));
         }
     }
-    None
+    Ok(None)
 }
 
 /// Read and parse a PEP 739 `build-details.json` file into an `InterpreterConfig`.
@@ -455,7 +461,7 @@ mod tests {
         let path = dir.path().join("build-details.json");
         fs::write(&path, r#"{"schema_version":"1.0"}"#).unwrap();
 
-        let found = find_build_details(dir.path());
+        let found = find_build_details(dir.path()).unwrap();
         assert_eq!(found, Some(path));
     }
 
@@ -467,7 +473,7 @@ mod tests {
         let path = pydir.join("build-details.json");
         fs::write(&path, r#"{"schema_version":"1.0"}"#).unwrap();
 
-        let found = find_build_details(dir.path());
+        let found = find_build_details(dir.path()).unwrap();
         assert_eq!(found, Some(path));
     }
 
@@ -486,14 +492,14 @@ mod tests {
         let path = pydir.join("build-details.json");
         fs::write(&path, r#"{"schema_version":"1.0"}"#).unwrap();
 
-        let found = find_build_details(dir.path());
+        let found = find_build_details(dir.path()).unwrap();
         assert_eq!(found, Some(path));
     }
 
     #[test]
     fn test_find_build_details_not_present() {
         let dir = TempDir::new().unwrap();
-        let found = find_build_details(dir.path());
+        let found = find_build_details(dir.path()).unwrap();
         assert!(found.is_none());
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -410,9 +410,15 @@ impl Metadata24 {
             }
         }
 
+        let pyproject_dir_str = pyproject_dir.to_str().with_context(|| {
+            format!(
+                "project path is not valid UTF-8: {}",
+                pyproject_dir.display()
+            )
+        })?;
+
         if let Some(license_files) = &project.license_files {
-            let escaped_pyproject_dir =
-                PathBuf::from(glob::Pattern::escape(pyproject_dir.to_str().unwrap()));
+            let escaped_pyproject_dir = PathBuf::from(glob::Pattern::escape(pyproject_dir_str));
             for license_glob in license_files {
                 check_pep639_glob(license_glob)?;
                 for license_path in
@@ -436,7 +442,7 @@ impl Metadata24 {
         } else {
             // Auto-discovery of license files for backwards compatibility
             let license_include_targets = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"];
-            let escaped_manifest_string = glob::Pattern::escape(pyproject_dir.to_str().unwrap());
+            let escaped_manifest_string = glob::Pattern::escape(pyproject_dir_str);
             let escaped_manifest_path = Path::new(&escaped_manifest_string);
             for pattern in license_include_targets.iter() {
                 for license_path in

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -321,7 +321,7 @@ impl<'a> InterpreterResolver<'a> {
 
     /// Discover from `PYO3_CROSS_LIB_DIR` (build-details.json or sysconfigdata).
     fn discover_from_cross_lib_dir(&self, cross_lib_path: &Path) -> Result<DiscoveryResult> {
-        if let Some(build_details_path) = find_build_details(cross_lib_path) {
+        if let Some(build_details_path) = find_build_details(cross_lib_path)? {
             eprintln!("🐍 Using build-details.json for cross-compiling preparation");
             let config = parse_build_details_json_file(&build_details_path)?;
             let host_python = self.find_host_python()?;

--- a/src/source_distribution/mod.rs
+++ b/src/source_distribution/mod.rs
@@ -10,7 +10,6 @@ use anyhow::{Context, Result, bail};
 use cargo_metadata::camino::{self, Utf8Path};
 use ignore::overrides::Override;
 use normpath::PathExt as _;
-use path_slash::PathExt as _;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
@@ -451,8 +450,14 @@ fn compute_sdist_root(
     python_dir: &Path,
     known_path_deps: &HashMap<String, PathDependency>,
 ) -> Result<PathBuf> {
-    let mut sdist_root =
-        common_path_prefix(workspace_root.as_std_path(), pyproject_toml_path).unwrap();
+    let mut sdist_root = common_path_prefix(workspace_root.as_std_path(), pyproject_toml_path)
+        .with_context(|| {
+            format!(
+                "Failed to determine common path prefix of workspace root `{}` and pyproject.toml `{}`",
+                workspace_root,
+                pyproject_toml_path.display()
+            )
+        })?;
     for path_dep in known_path_deps.values() {
         if let Some(prefix) =
             common_path_prefix(&sdist_root, path_dep.manifest_path.parent().unwrap())
@@ -779,10 +784,15 @@ fn add_workspace_manifest(
     let mut deps_to_keep = ctx.known_path_deps.clone();
     let main_member_name = logical_manifest_dir
         .strip_prefix(ctx.workspace_root)
-        .unwrap()
-        .to_slash()
-        .unwrap()
-        .to_string();
+        .with_context(|| {
+            format!(
+                "Failed to strip workspace root `{}` from manifest dir `{}`",
+                ctx.workspace_root,
+                logical_manifest_dir.display()
+            )
+        })?
+        .to_string_lossy()
+        .into_owned();
     deps_to_keep.insert(
         main_member_name,
         PathDependency {

--- a/src/source_distribution/pyproject.rs
+++ b/src/source_distribution/pyproject.rs
@@ -241,8 +241,13 @@ pub(super) fn add_pyproject_metadata(
     if let Some(project) = pyproject.project.as_ref()
         && let Some(license_files) = &project.license_files
     {
-        let escaped_pyproject_dir =
-            PathBuf::from(glob::Pattern::escape(pyproject_dir.to_str().unwrap()));
+        let pyproject_dir_str = pyproject_dir.to_str().with_context(|| {
+            format!(
+                "project path is not valid UTF-8: {}",
+                pyproject_dir.display()
+            )
+        })?;
+        let escaped_pyproject_dir = PathBuf::from(glob::Pattern::escape(pyproject_dir_str));
         let mut seen = HashSet::new();
         for license_glob in license_files {
             check_pep639_glob(license_glob)?;


### PR DESCRIPTION
Several sites converted recoverable situations into process aborts via `unwrap()`/`expect()`/direct indexing on `OsStr`, env vars, and path arithmetic that can legitimately be non-UTF-8 or otherwise fallible. On Linux/macOS, paths and env vars may legally contain non-UTF-8 bytes, so a panic is the wrong response.

This sweep converts each site to explicit error handling via anyhow's `.context()`/`.with_context()` where the value flows into a `Result`, so a non-UTF-8 input surfaces a clear, contextual error rather than silently corrupting the output (lossy glob patterns match nothing; lossy rpath is a malformed DT_RUNPATH):

- `metadata.rs` + `source_distribution/pyproject.rs`: replace `pyproject_dir.to_str().unwrap()` with `.to_str().with_context(|| "...not valid UTF-8")?` for license glob escaping. Lossy conversion would silently produce a glob pattern that matches nothing for a non-UTF-8 project dir.
- `source_distribution/mod.rs`: replace `common_path_prefix(...).unwrap()` with `.with_context(...)` when the workspace root and pyproject.toml share no prefix (e.g. different Windows drives), and replace `strip_prefix().unwrap()` + `to_slash().unwrap()` with a context-bearing error and lossy conversion of the manifest member name.
- `cross_compile.rs`: replace `env::var_os(...).into_string().unwrap()` with an explicit "not valid UTF-8" error in `search_lib_dir`. Also change `find_build_details` from `Option<PathBuf>` to `Result<Option<PathBuf>>` so it can propagate the same non-UTF-8 env-var error and a `fs::read_dir` failure (previously silently swallowed via `.ok()?`) instead of falling back to lossy conversion. Updated its caller in `resolver.rs` (`find_build_details(...)?`) and the four unit tests.
- `auditwheel/linux.rs`: replace `new_rpath.to_str().unwrap()` with `.to_str().with_context(...)?` for the rpath join, so a non-UTF-8 rpath surfaces a clear error instead of silently corrupting the DT_RUNPATH.
- `auditwheel/audit.rs`: give `relpath` a precondition check and make it return `Result<PathBuf>`, rejecting mixed absolute/relative inputs that would otherwise produce nonsense `..` chains feeding the RPATH math. Updated both call sites (`macos.rs`, `linux.rs`) to propagate the error.