### PR TITLE
Harden PEP 517 build-wheel and fix unreachable OIDC 404 fallback

### DIFF
--- a/src/commands/pep517.rs
+++ b/src/commands/pep517.rs
@@ -108,10 +108,30 @@ pub fn pep517(subcommand: Pep517Command) -> Result<()> {
             println!("{}", dist_info_dir.display());
         }
         Pep517Command::BuildWheel {
-            build_options,
+            mut build_options,
             strip_opt,
             editable,
         } => {
+            // PEP 517's `build_wheel` operates on a single interpreter (the
+            // one running pip). If duplicates of the same path were supplied
+            // (e.g. user-set `MATURIN_PEP517_ARGS=--interpreter ...` with
+            // multiple interpreters), collapse them first, then bail with a
+            // clear message instead of panicking. Mirrors the
+            // `write-dist-info` arm above.
+            {
+                let mut seen = std::collections::HashSet::new();
+                build_options
+                    .python
+                    .interpreter
+                    .retain(|p| seen.insert(p.clone()));
+            }
+            if build_options.python.interpreter.len() > 1 {
+                bail!(
+                    "`maturin pep517 build-wheel` expects exactly one --interpreter, got {}: {:?}",
+                    build_options.python.interpreter.len(),
+                    build_options.python.interpreter,
+                );
+            }
             let mut build_context = build_options
                 .into_build_context()
                 .strip(strip_opt.strip)
@@ -121,8 +141,20 @@ pub fn pep517(subcommand: Pep517Command) -> Result<()> {
 
             let orchestrator = BuildOrchestrator::new(&build_context);
             let wheels = orchestrator.build_wheels()?;
-            assert_eq!(wheels.len(), 1);
-            println!("{}", wheels[0].0.to_str().unwrap());
+            if wheels.len() != 1 {
+                bail!(
+                    "expected exactly one wheel to be built, got {}: {:?}",
+                    wheels.len(),
+                    wheels
+                        .iter()
+                        .map(|(path, _)| path.display().to_string())
+                        .collect::<Vec<_>>(),
+                );
+            }
+            let wheel_path = wheels[0].0.to_str().with_context(|| {
+                format!("wheel path is not valid UTF-8: {}", wheels[0].0.display())
+            })?;
+            println!("{wheel_path}");
         }
         Pep517Command::WriteSDist {
             sdist_directory,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -286,9 +286,17 @@ fn resolve_pypi_token_via_oidc(registry_url: &str) -> Result<Option<String>> {
         audience_url.set_path("_/oidc/audience");
         debug!("Requesting OIDC audience from {}", audience_url);
 
-        // Create agent with timeout configuration
+        // Create agent with timeout configuration.
+        //
+        // `http_status_as_error(false)` matches `http_agent()` so that a 404
+        // from the `_/oidc/audience` endpoint is returned as a normal
+        // response (instead of an `Err` that the `?` below would propagate),
+        // letting the graceful `Ok(None)` fallback below actually run for
+        // registries that don't support OIDC (GitLab, Artifactory, pypiserver,
+        // custom indexes).
         let agent: ureq::Agent = ureq::Agent::config_builder()
             .proxy(ureq::Proxy::try_from_env())
+            .http_status_as_error(false)
             .timeout_global(Some(Duration::from_secs(30)))
             .build()
             .into();


### PR DESCRIPTION
Two small, user-visible robustness fixes for the PEP 517 backend and the trusted-publisher (OIDC) token resolution path.

PEP 517 `build_wheel` panicked instead of returning an error:

The `BuildWheel` arm did `assert_eq!(wheels.len(), 1)` followed by `wheels[0].0.to_str().unwrap()`. The sibling `write-dist-info` arm had already been hardened to deduplicate interpreters and `bail!` with a clear message "instead of panicking", but the same hardening was never applied to `build-wheel`. A user setting
`MATURIN_PEP517_ARGS=--interpreter ...` with multiple interpreters (e.g. `--interpreter py3.11 py3.12`) tripped the assert, aborting the PEP 517 backend with an ugly traceback to pip. Asserts/panics are inappropriate in a PEP 517 backend invoked by pip.

Mirror the `write-dist-info` handling: deduplicate `build_options.python.interpreter`, `bail!` if more than one remains, replace the assert with a clear `bail!`, and convert the `to_str().unwrap()` to `to_str().with_context(...)?`.

OIDC audience 404 short-circuit was dead code:

`resolve_pypi_token_via_oidc` built its ureq agent without `.http_status_as_error(false)`, unlike `http_agent()` which sets it. ureq defaults `http_status_as_error` to `true`, so a 404 from the `_/oidc/audience` endpoint was returned as `Err(StatusCode(404))` and propagated by the `?` *before* the `if audience_res.status() == 404` check could run — making that graceful `Ok(None)` fallback unreachable. On GitHub Actions uploading to a registry without OIDC (GitLab, Artifactory, pypiserver, custom indexes), the intended fallback never fired; instead the error bubbled up and printed a warning on every such upload.

Add `.http_status_as_error(false)` to the OIDC agent config builder, matching `http_agent()`, so the 404 check actually runs.