### PR TITLE
Fix abi3t PyModExport entrypoint check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,9 +1830,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1147,83 +1147,17 @@ fn compile_target(
     Ok((artifacts, out_dirs))
 }
 
-/// Checks that the native library contains a function called `PyInit_<module name>` and warns
-/// if it's missing.
+/// Checks that the native library contains a Python extension entrypoint and warns if it's missing.
 ///
-/// That function is the python's entrypoint for loading native extensions, i.e. python will fail
-/// to import the module with error if it's missing or named incorrectly
+/// `PyInit_<module name>` is the traditional entrypoint. Free-threaded stable ABI builds can
+/// expose `PyModExport_<module name>` instead.
 ///
 /// Currently the check is only run on linux, macOS and Windows
 #[instrument(skip_all)]
 pub fn warn_missing_py_init(artifact: &Path, module_name: &str) -> Result<()> {
     let py_init = format!("PyInit_{module_name}");
     let py_modexport = format!("PyModExport_{module_name}");
-    let fd = File::open(artifact)?;
-    // SAFETY: The caller stages (moves or copies) the artifact into a
-    // private directory before invoking this function, so no concurrent
-    // process (e.g. cargo / rust-analyzer) can modify it while we have
-    // it mapped.
-    let mmap = unsafe { memmap2::Mmap::map(&fd).context("mmap failed")? };
-    let mut found = false;
-    match goblin::Object::parse(&mmap)? {
-        goblin::Object::Elf(elf) => {
-            for dyn_sym in elf.dynsyms.iter() {
-                if py_init == elf.dynstrtab[dyn_sym.st_name] {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        goblin::Object::Mach(mach) => {
-            match mach {
-                goblin::mach::Mach::Binary(macho) => {
-                    for sym in macho.exports()? {
-                        let sym_name = sym.name;
-                        if py_init == sym_name.strip_prefix('_').unwrap_or(&sym_name) {
-                            found = true;
-                            break;
-                        }
-                        if py_modexport == sym_name.strip_prefix('_').unwrap_or(&sym_name) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if !found {
-                        for sym in macho.symbols() {
-                            let (sym_name, _) = sym?;
-                            if py_init == sym_name.strip_prefix('_').unwrap_or(sym_name) {
-                                found = true;
-                                break;
-                            }
-                            if py_modexport == sym_name.strip_prefix('_').unwrap_or(sym_name) {
-                                found = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-                goblin::mach::Mach::Fat(_) => {
-                    // Ignore fat macho,
-                    // we only generate them by combining thin binaries which is handled above
-                    found = true
-                }
-            }
-        }
-        goblin::Object::PE(pe) => {
-            for sym in &pe.exports {
-                if let Some(sym_name) = sym.name
-                    && (py_init == sym_name || py_modexport == sym_name)
-                {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        _ => {
-            // Currently, only linux, macOS and Windows are implemented
-            found = true
-        }
-    }
+    let found = native_library_has_python_entrypoint(artifact, module_name)?;
 
     if !found {
         eprintln!(
@@ -1234,6 +1168,72 @@ pub fn warn_missing_py_init(artifact: &Path, module_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn native_library_has_python_entrypoint(artifact: &Path, module_name: &str) -> Result<bool> {
+    let py_init = format!("PyInit_{module_name}");
+    let py_modexport = format!("PyModExport_{module_name}");
+    let fd = File::open(artifact)?;
+    // SAFETY: The caller stages (moves or copies) the artifact into a
+    // private directory before invoking this function, so no concurrent
+    // process (e.g. cargo / rust-analyzer) can modify it while we have
+    // it mapped.
+    let mmap = unsafe { memmap2::Mmap::map(&fd).context("mmap failed")? };
+    let found = match goblin::Object::parse(&mmap)? {
+        goblin::Object::Elf(elf) => elf.dynsyms.iter().any(|dyn_sym| {
+            elf.dynstrtab
+                .get_at(dyn_sym.st_name)
+                .is_some_and(|sym_name| {
+                    is_python_entrypoint_symbol(sym_name, &py_init, &py_modexport)
+                })
+        }),
+        goblin::Object::Mach(mach) => {
+            match mach {
+                goblin::mach::Mach::Binary(macho) => {
+                    let mut found = false;
+                    for sym in macho.exports()? {
+                        let sym_name = sym.name;
+                        let sym_name = sym_name.strip_prefix('_').unwrap_or(&sym_name);
+                        if is_python_entrypoint_symbol(sym_name, &py_init, &py_modexport) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if !found {
+                        for sym in macho.symbols() {
+                            let (sym_name, _) = sym?;
+                            let sym_name = sym_name.strip_prefix('_').unwrap_or(sym_name);
+                            if is_python_entrypoint_symbol(sym_name, &py_init, &py_modexport) {
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+                    found
+                }
+                goblin::mach::Mach::Fat(_) => {
+                    // Ignore fat macho,
+                    // we only generate them by combining thin binaries which is handled above
+                    true
+                }
+            }
+        }
+        goblin::Object::PE(pe) => pe.exports.iter().any(|sym| {
+            sym.name.is_some_and(|sym_name| {
+                is_python_entrypoint_symbol(sym_name, &py_init, &py_modexport)
+            })
+        }),
+        _ => {
+            // Currently, only linux, macOS and Windows are implemented
+            true
+        }
+    };
+
+    Ok(found)
+}
+
+fn is_python_entrypoint_symbol(sym_name: &str, py_init: &str, py_modexport: &str) -> bool {
+    sym_name == py_init || sym_name == py_modexport
 }
 
 /// Ensures the `maturin` subdirectory inside the target directory exists
@@ -1261,4 +1261,18 @@ fn pyo3_version(cargo_metadata: &cargo_metadata::Metadata) -> Option<(u64, u64, 
         .get("pyo3")
         .or_else(|| packages.get("pyo3-ffi"))
         .map(|pkg| (pkg.version.major, pkg.version.minor, pkg.version.patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_python_entrypoint_symbol;
+
+    #[test]
+    fn python_entrypoint_symbol_accepts_pymodexport() {
+        assert!(is_python_entrypoint_symbol(
+            "PyModExport__core",
+            "PyInit__core",
+            "PyModExport__core"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3223.

ELF entrypoint validation only checked for `PyInit_<module>`, while free-threaded stable ABI builds can export `PyModExport_<module>` instead. This made valid abi3t extension modules warn that neither entrypoint was present even when `PyModExport_<module>` existed.

This PR makes the native-library entrypoint check accept both `PyInit_<module>` and `PyModExport_<module>` for ELF, matching the warning text and the existing Mach-O/PE behavior.

`Cargo.lock` is also updated from `memmap2` 0.9.10 to 0.9.11 because `cargo deny` now rejects 0.9.10 for RUSTSEC-2026-0186.

## Checks

- `cargo fmt --all`
- `cargo test --lib compile::tests`
- `cargo clippy --tests --all-features -- -D warnings`
- `pre-commit run --all-files`
