### PR TITLE
fix(ci): honor ~= and ==X.* in requires-python for generate-ci

### DIFF
--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -222,7 +222,11 @@ fn min_python3_minor(requires_python: &VersionSpecifiers) -> Option<u8> {
         .filter(|spec| {
             matches!(
                 spec.operator(),
-                Operator::GreaterThanEqual | Operator::GreaterThan | Operator::Equal
+                Operator::GreaterThanEqual
+                    | Operator::GreaterThan
+                    | Operator::Equal
+                    | Operator::TildeEqual
+                    | Operator::EqualStar
             )
         })
         .filter(|spec| spec.version().release().first() == Some(&3))
@@ -335,6 +339,9 @@ mod tests {
         assert_eq!(min_python3_minor(&parse(">=3.12,<4")), Some(12));
         assert_eq!(min_python3_minor(&parse(">3.12")), Some(13));
         assert_eq!(min_python3_minor(&parse(">=3.8")), Some(8));
+        assert_eq!(min_python3_minor(&parse("~=3.13")), Some(13));
+        assert_eq!(min_python3_minor(&parse("~=3.12.2")), Some(12));
+        assert_eq!(min_python3_minor(&parse("==3.11.*")), Some(11));
         assert_eq!(min_python3_minor(&parse("<4")), None);
         assert_eq!(min_python3_minor(&parse("!=3.5")), None);
     }


### PR DESCRIPTION
`min_python3_minor` (used by `maturin generate-ci`) only accepted the `>=`, `>`, and `==` operators when deriving the minimum Python version from `requires-python`. A `requires-python = "~=3.13"` (`Operator::TildeEqual`) or `"==3.11.*"` (`Operator::EqualStar`) was therefore dropped, and `generate-ci` fell back to a default Python floor instead of the project's actual minimum.

This adds `TildeEqual` and `EqualStar` to the accepted-operator set. The existing minor logic already yields the correct floor for both (`~=3.13` → 13, `==3.11.*` → 11), so no other change is needed.

Extends `test_min_python3_minor` with cases for `~=3.13`, `~=3.12.2`, and `==3.11.*`, which return `None` before this change and the correct minor after.

```
cargo test -p maturin min_python3_minor
```
