### PR TITLE
refactor: improve context and environment hygiene

### DIFF
--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -19,6 +19,7 @@ use anyhow::{Result, bail};
 use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::{debug, instrument};
 
 /// Builder for constructing a [`BuildContext`] from [`BuildOptions`].
@@ -179,15 +180,6 @@ impl BuildContextBuilder {
             eprintln!("🔗 Found {bridge} bindings");
         }
 
-        // Set PYO3_PYTHON for cross-compilation so pyo3's build script
-        // can find the host interpreter.
-        if let Some(ref host_python) = host_python {
-            unsafe {
-                env::set_var("PYO3_PYTHON", host_python);
-                env::set_var("PYTHON_SYS_EXECUTABLE", host_python);
-            }
-        }
-
         if cargo_options.args.is_empty() {
             // if not supplied on command line, try pyproject.toml
             let tool_maturin = pyproject.and_then(|p| p.maturin());
@@ -289,7 +281,7 @@ impl BuildContextBuilder {
                 module_name,
                 manifest_path: cargo_toml_path,
                 target_dir,
-                cargo_metadata,
+                cargo_metadata: Arc::new(cargo_metadata),
                 universal2,
                 editable,
                 cargo_options,
@@ -313,6 +305,7 @@ impl BuildContextBuilder {
                 zig: build_options.platform.zig,
                 platform_tag: platform_tags,
                 interpreter,
+                host_python,
                 pypi_validation,
             },
         })
@@ -332,14 +325,18 @@ impl BuildContextBuilder {
             return Ok((Vec::new(), None));
         }
 
-        let mut user_interpreters = build_options.python.interpreter.clone();
-        if cfg!(test)
-            && user_interpreters.is_empty()
-            && !build_options.python.find_interpreter
-            && let Some(python) = env::var_os("MATURIN_TEST_PYTHON")
-        {
-            user_interpreters = vec![python.into()];
-        }
+        let user_interpreters = build_options.python.interpreter.clone();
+        #[cfg(test)]
+        let user_interpreters = {
+            let mut user_interpreters = user_interpreters;
+            if user_interpreters.is_empty()
+                && !build_options.python.find_interpreter
+                && let Some(python) = env::var_os("MATURIN_TEST_PYTHON")
+            {
+                user_interpreters = vec![python.into()];
+            }
+            user_interpreters
+        };
 
         let resolver = InterpreterResolver::new(
             target,

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 use anyhow::Result;
 use cargo_metadata::Metadata;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// The input part of the build context.
 ///
@@ -45,7 +46,7 @@ pub struct ProjectContext {
     /// Directory for all generated artifacts
     pub target_dir: PathBuf,
     /// Cargo.toml as resolved by [cargo_metadata]
-    pub cargo_metadata: Metadata,
+    pub cargo_metadata: Arc<Metadata>,
     /// Whether to use universal2 or use the native macOS tag (off)
     pub universal2: bool,
     /// Build editable wheels
@@ -120,6 +121,8 @@ pub struct PythonContext {
     pub platform_tag: Vec<PlatformTag>,
     /// The available python interpreters
     pub interpreter: Vec<PythonInterpreter>,
+    /// Host Python to expose to PyO3 when target interpreters are not runnable.
+    pub host_python: Option<PathBuf>,
     /// Whether to validate wheels against PyPI platform tag rules
     pub pypi_validation: bool,
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -922,6 +922,15 @@ fn configure_pyo3_env(
 
             // and legacy pyo3 versions
             build_command.env("PYTHON_SYS_EXECUTABLE", &interpreter.executable);
+        } else if let Some(host_python) = context.python.host_python.as_ref() {
+            if bridge_model.is_pyo3() {
+                debug!(
+                    "Setting PYO3_PYTHON to host interpreter {}",
+                    host_python.display()
+                );
+                build_command.env("PYO3_PYTHON", host_python);
+            }
+            build_command.env("PYTHON_SYS_EXECUTABLE", host_python);
         }
 
         if bridge_model.is_pyo3()

--- a/src/sbom.rs
+++ b/src/sbom.rs
@@ -45,7 +45,7 @@ impl SbomData {
             // cargo_metadata 0.23. The Metadata structs are incompatible at the
             // type level but share the same JSON representation, so we bridge
             // them via a serde round-trip.
-            let json = serde_json::to_value(&context.project.cargo_metadata)?;
+            let json = serde_json::to_value(context.project.cargo_metadata.as_ref())?;
             let metadata = serde_json::from_value(json)
                 .context("Failed to convert cargo metadata for SBOM generation")?;
             let sboms = SbomGenerator::create_sboms(metadata, &config)


### PR DESCRIPTION
- Move host Python env setup out of BuildContextBuilder: host_python now lives on PythonContext and PYO3_PYTHON/PYTHON_SYS_EXECUTABLE are applied command-locally in configure_pyo3_env, only when the target interpreter is not runnable (cross-compilation); removes the unsafe process-global env::set_var
- Scope the MATURIN_TEST_PYTHON interpreter injection behind #[cfg(test)]; the sdist_only runtime escape hatch used by the integration harness is unchanged
- Wrap ProjectContext.cargo_metadata in Arc so BuildContext clones (PGO, universal2) no longer deep-copy cargo metadata (public API field type change); CompileOverrides threading deliberately skipped as the Arc delivers the payoff