### PR TITLE
refactor: type cleanup for options, tags, and wheel metadata

### DIFF
--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -332,85 +332,8 @@
       ]
     },
     "CompatibilityTag": {
-      "description": "Parsed `--compatibility` / `[tool.maturin] compatibility` value.\n\n`pypi` is not a real platform tag. It is normalized by `BuildContextBuilder`\ninto a PyPI-validation flag and never stored on `PythonContext.platform_tag`.",
-      "oneOf": [
-        {
-          "description": "Use the `manylinux_<major>_<minor>` tag",
-          "type": "object",
-          "properties": {
-            "Manylinux": {
-              "type": "object",
-              "properties": {
-                "major": {
-                  "description": "GLIBC version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                },
-                "minor": {
-                  "description": "GLIBC version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "major",
-                "minor"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "Manylinux"
-          ]
-        },
-        {
-          "description": "Use the `musllinux_<major>_<minor>` tag",
-          "type": "object",
-          "properties": {
-            "Musllinux": {
-              "type": "object",
-              "properties": {
-                "major": {
-                  "description": "musl libc version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                },
-                "minor": {
-                  "description": "musl libc version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "major",
-                "minor"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "Musllinux"
-          ]
-        },
-        {
-          "description": "Use the native linux tag",
-          "type": "string",
-          "const": "Linux"
-        },
-        {
-          "description": "Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.",
-          "type": "string",
-          "const": "Pypi"
-        }
-      ]
+      "description": "Parsed `--compatibility` / `[tool.maturin] compatibility` value.\n\nAccepts platform tags such as `linux`, `manylinux2014`, `manylinux_2_17`, `musllinux_1_2`, or the `pypi` pseudo-option (PyPI filename validation; not a real platform tag).",
+      "type": "string"
     },
     "FeatureSpec": {
       "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\", python-implementation = \"cpython\" },\n  { feature = \"pypy-compat\", python-implementation = \"pypy\" },\n]\n```",

--- a/maturin.schema.json
+++ b/maturin.schema.json
@@ -33,7 +33,7 @@
       "description": "Platform compatibility",
       "anyOf": [
         {
-          "$ref": "#/$defs/PlatformTag"
+          "$ref": "#/$defs/CompatibilityTag"
         },
         {
           "type": "null"
@@ -329,6 +329,87 @@
       },
       "required": [
         "name"
+      ]
+    },
+    "CompatibilityTag": {
+      "description": "Parsed `--compatibility` / `[tool.maturin] compatibility` value.\n\n`pypi` is not a real platform tag. It is normalized by `BuildContextBuilder`\ninto a PyPI-validation flag and never stored on `PythonContext.platform_tag`.",
+      "oneOf": [
+        {
+          "description": "Use the `manylinux_<major>_<minor>` tag",
+          "type": "object",
+          "properties": {
+            "Manylinux": {
+              "type": "object",
+              "properties": {
+                "major": {
+                  "description": "GLIBC version major",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                },
+                "minor": {
+                  "description": "GLIBC version minor",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Manylinux"
+          ]
+        },
+        {
+          "description": "Use the `musllinux_<major>_<minor>` tag",
+          "type": "object",
+          "properties": {
+            "Musllinux": {
+              "type": "object",
+              "properties": {
+                "major": {
+                  "description": "musl libc version major",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                },
+                "minor": {
+                  "description": "musl libc version minor",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Musllinux"
+          ]
+        },
+        {
+          "description": "Use the native linux tag",
+          "type": "string",
+          "const": "Linux"
+        },
+        {
+          "description": "Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.",
+          "type": "string",
+          "const": "Pypi"
+        }
       ]
     },
     "FeatureSpec": {
@@ -678,87 +759,6 @@
           }
         }
       }
-    },
-    "PlatformTag": {
-      "description": "Decides how to handle manylinux and musllinux compliance",
-      "oneOf": [
-        {
-          "description": "Use the `manylinux_<major>_<minor>` tag",
-          "type": "object",
-          "properties": {
-            "Manylinux": {
-              "type": "object",
-              "properties": {
-                "major": {
-                  "description": "GLIBC version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                },
-                "minor": {
-                  "description": "GLIBC version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "major",
-                "minor"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "Manylinux"
-          ]
-        },
-        {
-          "description": "Use the `musllinux_<major>_<minor>` tag",
-          "type": "object",
-          "properties": {
-            "Musllinux": {
-              "type": "object",
-              "properties": {
-                "major": {
-                  "description": "musl libc version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                },
-                "minor": {
-                  "description": "musl libc version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "maximum": 65535,
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "major",
-                "minor"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "Musllinux"
-          ]
-        },
-        {
-          "description": "Use the native linux tag",
-          "type": "string",
-          "const": "Linux"
-        },
-        {
-          "description": "Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.",
-          "type": "string",
-          "const": "Pypi"
-        }
-      ]
     },
     "SbomConfig": {
       "description": "SBOM configuration",

--- a/src/auditwheel/linux.rs
+++ b/src/auditwheel/linux.rs
@@ -338,9 +338,7 @@ fn auditwheel_rs(
                 policy
             })
             .collect(),
-        None | Some(PlatformTag::Pypi) => {
-            // Using the default for the `pypi` tag means we're correctly using manylinux where
-            // possible.
+        None => {
             let mut policies = get_default_platform_policies();
             for policy in &mut policies {
                 policy.fixup_musl_libc_so_name(target.target_arch());

--- a/src/auditwheel/mod.rs
+++ b/src/auditwheel/mod.rs
@@ -22,7 +22,7 @@ pub use audit::*;
 pub use linux::ElfRepairer;
 #[cfg(feature = "auditwheel")]
 pub use macos::MacOSRepairer;
-pub use platform_tag::PlatformTag;
+pub use platform_tag::{CompatibilityTag, PlatformTag};
 pub use policy::Policy;
 pub use repair::{
     AuditResult, AuditedArtifact, PatchKind, WheelRepairer, log_grafted_libs, prepare_grafted_libs,

--- a/src/auditwheel/platform_tag.rs
+++ b/src/auditwheel/platform_tag.rs
@@ -1,5 +1,5 @@
 use crate::auditwheel::Policy;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
@@ -145,25 +145,13 @@ impl<'de> Deserialize<'de> for PlatformTag {
 ///
 /// `pypi` is not a real platform tag. It is normalized by `BuildContextBuilder`
 /// into a PyPI-validation flag and never stored on `PythonContext.platform_tag`.
-#[derive(Serialize, Debug, Clone, Eq, PartialEq, Copy, Ord, PartialOrd)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+///
+/// Real platform tags are stored as [`CompatibilityTag::Platform`] so new
+/// [`PlatformTag`] variants only need to be added in one place.
+#[derive(Debug, Clone, Eq, PartialEq, Copy, Ord, PartialOrd)]
 pub enum CompatibilityTag {
-    /// Use the `manylinux_<major>_<minor>` tag
-    Manylinux {
-        /// GLIBC version major
-        major: u16,
-        /// GLIBC version minor
-        minor: u16,
-    },
-    /// Use the `musllinux_<major>_<minor>` tag
-    Musllinux {
-        /// musl libc version major
-        major: u16,
-        /// musl libc version minor
-        minor: u16,
-    },
-    /// Use the native linux tag
-    Linux,
+    /// A real platform tag (manylinux, musllinux, or linux).
+    Platform(PlatformTag),
     /// Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.
     Pypi,
 }
@@ -172,13 +160,7 @@ impl CompatibilityTag {
     /// Returns `None` for the `pypi` pseudo-option.
     pub fn into_platform_tag(self) -> Option<PlatformTag> {
         match self {
-            CompatibilityTag::Manylinux { major, minor } => {
-                Some(PlatformTag::Manylinux { major, minor })
-            }
-            CompatibilityTag::Musllinux { major, minor } => {
-                Some(PlatformTag::Musllinux { major, minor })
-            }
-            CompatibilityTag::Linux => Some(PlatformTag::Linux),
+            CompatibilityTag::Platform(tag) => Some(tag),
             CompatibilityTag::Pypi => None,
         }
     }
@@ -191,24 +173,14 @@ impl CompatibilityTag {
 
 impl From<PlatformTag> for CompatibilityTag {
     fn from(value: PlatformTag) -> Self {
-        match value {
-            PlatformTag::Manylinux { major, minor } => CompatibilityTag::Manylinux { major, minor },
-            PlatformTag::Musllinux { major, minor } => CompatibilityTag::Musllinux { major, minor },
-            PlatformTag::Linux => CompatibilityTag::Linux,
-        }
+        CompatibilityTag::Platform(value)
     }
 }
 
 impl fmt::Display for CompatibilityTag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            CompatibilityTag::Manylinux { major, minor } => {
-                write!(f, "manylinux_{major}_{minor}")
-            }
-            CompatibilityTag::Musllinux { major, minor } => {
-                write!(f, "musllinux_{major}_{minor}")
-            }
-            CompatibilityTag::Linux => write!(f, "linux"),
+            CompatibilityTag::Platform(tag) => write!(f, "{tag}"),
             CompatibilityTag::Pypi => write!(f, "pypi"),
         }
     }
@@ -221,8 +193,18 @@ impl FromStr for CompatibilityTag {
         if value.eq_ignore_ascii_case("pypi") {
             Ok(CompatibilityTag::Pypi)
         } else {
-            PlatformTag::from_str(value).map(CompatibilityTag::from)
+            PlatformTag::from_str(value).map(CompatibilityTag::Platform)
         }
+    }
+}
+
+/// Serialize as the same string form used by CLI / TOML parsing.
+impl Serialize for CompatibilityTag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 
@@ -233,5 +215,64 @@ impl<'de> Deserialize<'de> for CompatibilityTag {
     {
         let s = String::deserialize(deserializer)?;
         FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for CompatibilityTag {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "CompatibilityTag".into()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        "maturin::CompatibilityTag".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // TOML / CLI accept string values (e.g. "manylinux_2_17", "pypi"), not
+        // externally-tagged objects. Document the string form so the schema matches
+        // serde Deserialize and Serialize.
+        schemars::json_schema!({
+            "description": "Parsed `--compatibility` / `[tool.maturin] compatibility` value.\n\nAccepts platform tags such as `linux`, `manylinux2014`, `manylinux_2_17`, `musllinux_1_2`, or the `pypi` pseudo-option (PyPI filename validation; not a real platform tag).",
+            "type": "string"
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompatibilityTag, PlatformTag};
+    use std::str::FromStr;
+
+    #[test]
+    fn compatibility_tag_serde_round_trips_as_string() {
+        for value in [
+            CompatibilityTag::Pypi,
+            CompatibilityTag::from(PlatformTag::Linux),
+            CompatibilityTag::from(PlatformTag::manylinux2014()),
+            CompatibilityTag::from(PlatformTag::Musllinux { major: 1, minor: 2 }),
+        ] {
+            let json = serde_json::to_string(&value).unwrap();
+            // String form, not an externally-tagged object.
+            assert!(
+                json.starts_with('"') && json.ends_with('"'),
+                "expected string JSON, got {json}"
+            );
+            let parsed: CompatibilityTag = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, value);
+            assert_eq!(
+                CompatibilityTag::from_str(value.to_string().as_str()),
+                Ok(value)
+            );
+        }
+    }
+
+    #[test]
+    fn into_platform_tag_strips_pypi() {
+        assert_eq!(CompatibilityTag::Pypi.into_platform_tag(), None);
+        assert_eq!(
+            CompatibilityTag::from(PlatformTag::Linux).into_platform_tag(),
+            Some(PlatformTag::Linux)
+        );
     }
 }

--- a/src/auditwheel/platform_tag.rs
+++ b/src/auditwheel/platform_tag.rs
@@ -23,8 +23,6 @@ pub enum PlatformTag {
     },
     /// Use the native linux tag
     Linux,
-    /// Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.
-    Pypi,
 }
 
 impl PlatformTag {
@@ -73,18 +71,12 @@ impl PlatformTag {
         matches!(self, PlatformTag::Musllinux { .. })
     }
 
-    /// Is this the PyPI compatibility option
-    pub fn is_pypi(&self) -> bool {
-        matches!(self, PlatformTag::Pypi)
-    }
-
     /// Is it supported by Rust compiler and manylinux project
     pub fn is_supported(&self) -> bool {
         match self {
             PlatformTag::Manylinux { major, minor } => (*major, *minor) >= (2, 17),
             PlatformTag::Musllinux { .. } => true,
             PlatformTag::Linux => true,
-            PlatformTag::Pypi => true,
         }
     }
 }
@@ -95,7 +87,6 @@ impl fmt::Display for PlatformTag {
             PlatformTag::Manylinux { major, minor } => write!(f, "manylinux_{major}_{minor}"),
             PlatformTag::Musllinux { major, minor } => write!(f, "musllinux_{major}_{minor}"),
             PlatformTag::Linux => write!(f, "linux"),
-            PlatformTag::Pypi => write!(f, "pypi"),
         }
     }
 }
@@ -103,11 +94,10 @@ impl fmt::Display for PlatformTag {
 impl FromStr for PlatformTag {
     type Err = &'static str;
 
-    fn from_str(value: &str) -> anyhow::Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         let value = value.to_ascii_lowercase();
         match value.as_str() {
             "off" | "linux" => Ok(PlatformTag::Linux),
-            "pypi" => Ok(PlatformTag::Pypi),
             "1" | "manylinux1" => Ok(PlatformTag::manylinux1()),
             "2010" | "manylinux2010" => Ok(PlatformTag::manylinux2010()),
             "2014" | "manylinux2014" => Ok(PlatformTag::manylinux2014()),
@@ -142,6 +132,101 @@ impl FromStr for PlatformTag {
 }
 
 impl<'de> Deserialize<'de> for PlatformTag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Parsed `--compatibility` / `[tool.maturin] compatibility` value.
+///
+/// `pypi` is not a real platform tag. It is normalized by `BuildContextBuilder`
+/// into a PyPI-validation flag and never stored on `PythonContext.platform_tag`.
+#[derive(Serialize, Debug, Clone, Eq, PartialEq, Copy, Ord, PartialOrd)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum CompatibilityTag {
+    /// Use the `manylinux_<major>_<minor>` tag
+    Manylinux {
+        /// GLIBC version major
+        major: u16,
+        /// GLIBC version minor
+        minor: u16,
+    },
+    /// Use the `musllinux_<major>_<minor>` tag
+    Musllinux {
+        /// musl libc version major
+        major: u16,
+        /// musl libc version minor
+        minor: u16,
+    },
+    /// Use the native linux tag
+    Linux,
+    /// Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.
+    Pypi,
+}
+
+impl CompatibilityTag {
+    /// Returns `None` for the `pypi` pseudo-option.
+    pub fn into_platform_tag(self) -> Option<PlatformTag> {
+        match self {
+            CompatibilityTag::Manylinux { major, minor } => {
+                Some(PlatformTag::Manylinux { major, minor })
+            }
+            CompatibilityTag::Musllinux { major, minor } => {
+                Some(PlatformTag::Musllinux { major, minor })
+            }
+            CompatibilityTag::Linux => Some(PlatformTag::Linux),
+            CompatibilityTag::Pypi => None,
+        }
+    }
+
+    /// Is this the PyPI compatibility option
+    pub fn is_pypi(&self) -> bool {
+        matches!(self, CompatibilityTag::Pypi)
+    }
+}
+
+impl From<PlatformTag> for CompatibilityTag {
+    fn from(value: PlatformTag) -> Self {
+        match value {
+            PlatformTag::Manylinux { major, minor } => CompatibilityTag::Manylinux { major, minor },
+            PlatformTag::Musllinux { major, minor } => CompatibilityTag::Musllinux { major, minor },
+            PlatformTag::Linux => CompatibilityTag::Linux,
+        }
+    }
+}
+
+impl fmt::Display for CompatibilityTag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CompatibilityTag::Manylinux { major, minor } => {
+                write!(f, "manylinux_{major}_{minor}")
+            }
+            CompatibilityTag::Musllinux { major, minor } => {
+                write!(f, "musllinux_{major}_{minor}")
+            }
+            CompatibilityTag::Linux => write!(f, "linux"),
+            CompatibilityTag::Pypi => write!(f, "pypi"),
+        }
+    }
+}
+
+impl FromStr for CompatibilityTag {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("pypi") {
+            Ok(CompatibilityTag::Pypi)
+        } else {
+            PlatformTag::from_str(value).map(CompatibilityTag::from)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CompatibilityTag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/src/auditwheel/policy.rs
+++ b/src/auditwheel/policy.rs
@@ -94,7 +94,6 @@ impl Policy {
                 .iter()
                 .find(|p| p.name == "linux")
                 .cloned(),
-            PlatformTag::Pypi => unreachable!("pypi is not a policy"),
         }
     }
 

--- a/src/binding_generator/pyo3_binding.rs
+++ b/src/binding_generator/pyo3_binding.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 
 use anyhow::Context;
 use anyhow::Result;
-use anyhow::anyhow;
 use anyhow::bail;
 use pyo3_introspection::{introspect_cdylib, module_stub_files};
 use tempfile::TempDir;
@@ -42,29 +41,26 @@ enum BindingType<'a> {
 }
 
 impl<'a> Pyo3BindingGenerator<'a> {
-    pub fn new(
-        stable_abi: Option<StableAbiKind>,
+    pub fn new_stable_abi(
+        stable_abi: StableAbiKind,
         interpreter: Option<&'a PythonInterpreter>,
         tempdir: Rc<TempDir>,
-    ) -> Result<Self> {
+    ) -> Self {
         let binding_type = match stable_abi {
-            Some(kind) => match kind {
-                StableAbiKind::Abi3 => BindingType::Abi3(interpreter),
-                StableAbiKind::Abi3t => BindingType::Abi3t(interpreter),
-            },
-            None => {
-                let interpreter = interpreter.ok_or_else(|| {
-                    anyhow!(
-                    "A python interpreter is required for non-abi3 builds but one was not provided"
-                )
-                })?;
-                BindingType::VersionSpecific(interpreter)
-            }
+            StableAbiKind::Abi3 => BindingType::Abi3(interpreter),
+            StableAbiKind::Abi3t => BindingType::Abi3t(interpreter),
         };
-        Ok(Self {
+        Self {
             binding_type,
             tempdir,
-        })
+        }
+    }
+
+    pub fn new_version_specific(interpreter: &'a PythonInterpreter, tempdir: Rc<TempDir>) -> Self {
+        Self {
+            binding_type: BindingType::VersionSpecific(interpreter),
+            tempdir,
+        }
     }
 }
 

--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -1,4 +1,4 @@
-use crate::auditwheel::{AuditWheelMode, PlatformTag};
+use crate::auditwheel::{AuditWheelMode, CompatibilityTag, PlatformTag};
 use crate::bridge::{
     StableAbiVersion, find_bridge, has_windows_import_lib_support, upgrade_bridge_stable_abi,
 };
@@ -96,7 +96,7 @@ impl BuildContextBuilder {
             cargo_metadata,
             mut pyproject_toml_maturin_options,
         } = ProjectResolver::resolve(
-            build_options.manifest_path.clone(),
+            build_options.cargo.manifest_path.clone(),
             build_options.cargo.clone(),
             editable,
             explicit_pyproject_path,
@@ -133,7 +133,7 @@ impl BuildContextBuilder {
         }
 
         let (target, universal2) = resolve_target(
-            build_options.target.clone(),
+            build_options.cargo.target.clone(),
             build_options.python.interpreter.first(),
         )?;
 
@@ -194,15 +194,10 @@ impl BuildContextBuilder {
 
         let sbom = Self::resolve_sbom_config(&build_options, pyproject);
 
-        // Check if PyPI validation is needed from the original user input,
-        // since resolve_platform_tags filters out PlatformTag::Pypi
-        let pypi_validation = build_options
-            .platform
-            .platform_tag
-            .iter()
-            .any(|platform_tag| platform_tag == &PlatformTag::Pypi);
-
-        let platform_tags = resolve_platform_tags(
+        let ResolvedPlatformTags {
+            platform_tags,
+            pypi_validation,
+        } = resolve_platform_tags(
             build_options.platform.platform_tag,
             &target,
             &bridge,
@@ -454,15 +449,23 @@ fn resolve_target(
     Ok((target, universal2))
 }
 
+/// Real platform tags plus whether PyPI filename validation was requested via the pypi compatibility option.
+#[derive(Debug)]
+struct ResolvedPlatformTags {
+    platform_tags: Vec<PlatformTag>,
+    pypi_validation: bool,
+}
+
 /// Resolve platform tags from CLI flags, pyproject.toml, and target properties.
 fn resolve_platform_tags(
-    user_tags: Vec<PlatformTag>,
+    user_tags: Vec<CompatibilityTag>,
     target: &Target,
     bridge: &BridgeModel,
     pyproject: Option<&PyProjectToml>,
     pyproject_options: &mut Vec<&str>,
     #[cfg(feature = "zig")] use_zig: bool,
-) -> Result<Vec<PlatformTag>> {
+) -> Result<ResolvedPlatformTags> {
+    let pypi_validation;
     let platform_tags = if user_tags.is_empty() {
         #[cfg(feature = "zig")]
         let zig = use_zig;
@@ -477,27 +480,34 @@ fn resolve_platform_tags(
             })
             .or(if zig {
                 if target.is_musl_libc() {
-                    Some(PlatformTag::Musllinux { major: 1, minor: 2 })
+                    Some(PlatformTag::Musllinux { major: 1, minor: 2 }.into())
                 } else {
-                    Some(target.get_minimum_manylinux_tag())
+                    Some(target.get_minimum_manylinux_tag().into())
                 }
             } else if target.is_musl_libc() && !bridge.is_bin() {
-                Some(PlatformTag::Musllinux { major: 1, minor: 2 })
+                Some(PlatformTag::Musllinux { major: 1, minor: 2 }.into())
             } else {
                 None
             });
-        if let Some(platform_tag) = compatibility {
+        pypi_validation = compatibility
+            .as_ref()
+            .is_some_and(CompatibilityTag::is_pypi);
+        if pypi_validation && !is_arch_supported_by_pypi(target) {
+            bail!("Rust target {target} is not supported by PyPI");
+        }
+        if let Some(platform_tag) = compatibility.and_then(CompatibilityTag::into_platform_tag) {
             vec![platform_tag]
         } else {
             Vec::new()
         }
     } else {
-        if user_tags.iter().any(|tag| tag.is_pypi()) && !is_arch_supported_by_pypi(target) {
+        pypi_validation = user_tags.iter().any(CompatibilityTag::is_pypi);
+        if pypi_validation && !is_arch_supported_by_pypi(target) {
             bail!("Rust target {target} is not supported by PyPI");
         }
         user_tags
             .into_iter()
-            .filter(|platform_tag| platform_tag != &PlatformTag::Pypi)
+            .filter_map(CompatibilityTag::into_platform_tag)
             .collect()
     };
 
@@ -509,7 +519,10 @@ fn resolve_platform_tags(
         }
     }
 
-    Ok(platform_tags)
+    Ok(ResolvedPlatformTags {
+        platform_tags,
+        pypi_validation,
+    })
 }
 
 /// Checks for bridge/platform type edge cases
@@ -557,4 +570,107 @@ fn validate_bridge_type(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn pyproject_with_compatibility(compatibility: &str) -> PyProjectToml {
+        toml::from_str(&format!(
+            r#"
+            [build-system]
+            requires = ["maturin"]
+            build-backend = "maturin"
+
+            [tool.maturin]
+            compatibility = "{compatibility}"
+            "#
+        ))
+        .unwrap()
+    }
+
+    fn resolve_for_test(
+        user_tags: Vec<CompatibilityTag>,
+        target: &Target,
+        pyproject: Option<&PyProjectToml>,
+        pyproject_options: &mut Vec<&str>,
+    ) -> Result<ResolvedPlatformTags> {
+        resolve_platform_tags(
+            user_tags,
+            target,
+            &BridgeModel::Bin(None),
+            pyproject,
+            pyproject_options,
+            #[cfg(feature = "zig")]
+            false,
+        )
+    }
+
+    #[test]
+    fn resolve_platform_tags_filters_cli_pypi() {
+        let target = Target::from_target_triple(Some(&TargetTriple::Regular(
+            "x86_64-unknown-linux-gnu".to_string(),
+        )))
+        .unwrap();
+        let mut pyproject_options = Vec::new();
+
+        let resolved = resolve_for_test(
+            vec![CompatibilityTag::Pypi],
+            &target,
+            None,
+            &mut pyproject_options,
+        )
+        .unwrap();
+
+        assert!(resolved.platform_tags.is_empty());
+        assert!(resolved.pypi_validation);
+        assert!(pyproject_options.is_empty());
+    }
+
+    #[test]
+    fn resolve_platform_tags_filters_pyproject_pypi() {
+        let target = Target::from_target_triple(Some(&TargetTriple::Regular(
+            "x86_64-unknown-linux-gnu".to_string(),
+        )))
+        .unwrap();
+        let pyproject = pyproject_with_compatibility("pypi");
+        let mut pyproject_options = Vec::new();
+
+        let resolved = resolve_for_test(
+            Vec::new(),
+            &target,
+            Some(&pyproject),
+            &mut pyproject_options,
+        )
+        .unwrap();
+
+        assert!(resolved.platform_tags.is_empty());
+        assert!(resolved.pypi_validation);
+        assert_eq!(pyproject_options, vec!["compatibility"]);
+    }
+
+    #[test]
+    fn resolve_platform_tags_rejects_pyproject_pypi_for_unsupported_target() {
+        let target = Target::from_target_triple(Some(&TargetTriple::Regular(
+            "riscv32gc-unknown-linux-gnu".to_string(),
+        )))
+        .unwrap();
+        let pyproject = pyproject_with_compatibility("pypi");
+        let mut pyproject_options = Vec::new();
+
+        let err = resolve_for_test(
+            Vec::new(),
+            &target,
+            Some(&pyproject),
+            &mut pyproject_options,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Rust target riscv32gc-unknown-linux-gnu is not supported by PyPI"
+        );
+    }
 }

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -141,8 +141,38 @@ pub struct BuildContext {
     pub python: PythonContext,
 }
 
-/// The wheel file location and its Python version tag (e.g. `py3`).
-///
-/// For bindings the version tag contains the Python interpreter version
-/// they bind against (e.g. `cp37`).
-pub type BuiltWheelMetadata = (PathBuf, String);
+/// A built distribution artifact and the high-level tag maturin associates with it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BuiltWheel {
+    /// Path to the built wheel or source distribution.
+    pub path: PathBuf,
+    /// High-level tag describing the artifact kind or bound interpreter.
+    pub tag: BuiltArtifactTag,
+}
+
+/// High-level tag for a built artifact.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BuiltArtifactTag {
+    /// A Python interpreter tag such as `cp312`.
+    Interpreter(String),
+    /// Universal Python 3 artifact tag, rendered as `py3` at string boundaries.
+    Universal,
+    /// Source distribution artifact tag, rendered as `source` at string boundaries.
+    Source,
+}
+
+impl BuiltArtifactTag {
+    pub(crate) fn interpreter(tag: impl Into<String>) -> Self {
+        Self::Interpreter(tag.into())
+    }
+}
+
+impl std::fmt::Display for BuiltArtifactTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Interpreter(tag) => f.write_str(tag),
+            Self::Universal => f.write_str("py3"),
+            Self::Source => f.write_str("source"),
+        }
+    }
+}

--- a/src/build_options.rs
+++ b/src/build_options.rs
@@ -1,9 +1,8 @@
-use crate::auditwheel::{AuditWheelMode, PlatformTag};
+use crate::auditwheel::{AuditWheelMode, CompatibilityTag};
 use crate::build_context::BuildContextBuilder;
 pub use crate::cargo_options::{CargoOptions, TargetTriple};
 use crate::compression::CompressionOptions;
 use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use tracing::instrument;
 
@@ -55,7 +54,7 @@ pub struct PlatformOptions {
         num_args = 0..,
         action = clap::ArgAction::Append
     )]
-    pub platform_tag: Vec<PlatformTag>,
+    pub platform_tag: Vec<CompatibilityTag>,
 
     /// Audit wheel for manylinux compliance
     #[arg(long, conflicts_with = "skip_auditwheel")]
@@ -128,20 +127,6 @@ pub struct BuildOptions {
     /// Auto generate Python type stubs by introspecting the binary. Requires PyO3 and its "experimental-inspect" feature
     #[arg(long)]
     pub generate_stubs: bool,
-}
-
-impl Deref for BuildOptions {
-    type Target = CargoOptions;
-
-    fn deref(&self) -> &Self::Target {
-        &self.cargo
-    }
-}
-
-impl DerefMut for BuildOptions {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.cargo
-    }
 }
 
 impl BuildOptions {

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -9,11 +9,11 @@ use crate::module_writer::{WheelWriter, add_data, write_pth};
 use crate::pgo::{PgoContext, PgoPhase};
 use crate::sbom::SbomData;
 use crate::source_distribution::source_distribution;
-use crate::target::validate_wheel_filename_for_pypi;
+use crate::target::{WheelTag, validate_wheel_filename_for_pypi};
 use crate::util::zip_mtime;
 use crate::{
-    BridgeModel, BuildArtifact, BuildContext, BuiltWheelMetadata, Metadata24, PythonInterpreter,
-    StableAbi, VirtualWriter, compile, pyproject_toml::Format,
+    BridgeModel, BuildArtifact, BuildContext, BuiltArtifactTag, BuiltWheel, Metadata24,
+    PythonInterpreter, StableAbi, VirtualWriter, compile, pyproject_toml::Format,
 };
 use anyhow::{Context, Result, anyhow, bail};
 use cargo_metadata::CrateType;
@@ -49,7 +49,7 @@ impl<'a> BuildOrchestrator<'a> {
     /// Checks which kind of bindings we have (pyo3 or cffi or bin) and calls the
     /// correct builder.
     #[instrument(skip_all)]
-    pub fn build_wheels(&self) -> Result<Vec<BuiltWheelMetadata>> {
+    pub fn build_wheels(&self) -> Result<Vec<BuiltWheel>> {
         if let Some(pgo_command) = &self.context.artifact.pgo_command {
             let needs_per_interpreter_pgo = matches!(
                 self.context.project.bridge(),
@@ -72,7 +72,7 @@ impl<'a> BuildOrchestrator<'a> {
     }
 
     /// Single-pass PGO for abi3, cffi, uniffi, and bin builds.
-    fn build_wheels_pgo_single_pass(&self, pgo_command: String) -> Result<Vec<BuiltWheelMetadata>> {
+    fn build_wheels_pgo_single_pass(&self, pgo_command: String) -> Result<Vec<BuiltWheel>> {
         let instrumentation_python = self.context.python.interpreter.first().context(
             "PGO builds require a Python interpreter. \
                  Please specify one with `--interpreter`.",
@@ -90,7 +90,7 @@ impl<'a> BuildOrchestrator<'a> {
                 Ok(instrumented_wheels
                     .first()
                     .context("No instrumented wheel was built")?
-                    .0
+                    .path
                     .clone())
             },
             |optimized_orchestrator| optimized_orchestrator.build_wheels_inner(),
@@ -101,10 +101,7 @@ impl<'a> BuildOrchestrator<'a> {
     }
 
     /// Per-interpreter PGO for non-abi3 PyO3 builds.
-    fn build_wheels_pgo_per_interpreter(
-        &self,
-        pgo_command: String,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    fn build_wheels_pgo_per_interpreter(&self, pgo_command: String) -> Result<Vec<BuiltWheel>> {
         fs::create_dir_all(&self.context.artifact.out)
             .context("Failed to create the target directory for the wheels")?;
 
@@ -121,15 +118,15 @@ impl<'a> BuildOrchestrator<'a> {
                 python_interpreter.minor,
             );
 
-            let (wheel_path, tag) = self.run_pgo_cycle(
+            let wheel = self.run_pgo_cycle(
                 pgo_command.clone(),
                 python_interpreter,
                 "  ",
                 |_| {},
                 |instrumented_orchestrator| {
-                    let (instrumented_wheel_path, _) = instrumented_orchestrator
+                    let instrumented_wheel = instrumented_orchestrator
                         .build_single_pyo3_wheel(python_interpreter, &sbom_data)?;
-                    Ok(instrumented_wheel_path)
+                    Ok(instrumented_wheel.path)
                 },
                 |optimized_orchestrator| {
                     optimized_orchestrator.build_single_pyo3_wheel(python_interpreter, &sbom_data)
@@ -142,9 +139,9 @@ impl<'a> BuildOrchestrator<'a> {
                 python_interpreter.major,
                 python_interpreter.minor,
                 python_interpreter.abiflags,
-                wheel_path.display()
+                wheel.path.display()
             );
-            wheels.push((wheel_path, tag));
+            wheels.push(wheel);
         }
 
         self.validate_wheels_for_pypi(&wheels)?;
@@ -201,7 +198,7 @@ impl<'a> BuildOrchestrator<'a> {
 
     /// Standard wheel build pipeline (no PGO).
     #[instrument(skip_all)]
-    pub(crate) fn build_wheels_inner(&self) -> Result<Vec<BuiltWheelMetadata>> {
+    pub(crate) fn build_wheels_inner(&self) -> Result<Vec<BuiltWheel>> {
         fs::create_dir_all(&self.context.artifact.out)
             .context("Failed to create the target directory for the wheels")?;
 
@@ -228,14 +225,14 @@ impl<'a> BuildOrchestrator<'a> {
 
     /// Validates built wheel filenames against PyPI platform tag rules when
     /// `--compatibility pypi` validation was requested.
-    fn validate_wheels_for_pypi(&self, wheels: &[BuiltWheelMetadata]) -> Result<()> {
+    fn validate_wheels_for_pypi(&self, wheels: &[BuiltWheel]) -> Result<()> {
         if self.context.python.pypi_validation {
             for wheel in wheels {
                 let filename = wheel
-                    .0
+                    .path
                     .file_name()
                     .and_then(|name| name.to_str())
-                    .ok_or_else(|| anyhow!("Invalid wheel filename: {:?}", wheel.0))?;
+                    .ok_or_else(|| anyhow!("Invalid wheel filename: {:?}", wheel.path))?;
 
                 if let Err(error) = validate_wheel_filename_for_pypi(filename) {
                     bail!("PyPI validation failed: {}", error);
@@ -256,7 +253,7 @@ impl<'a> BuildOrchestrator<'a> {
 
     /// Builds a source distribution and returns the same metadata as [BuildOrchestrator::build_wheels]
     #[instrument(skip_all)]
-    pub fn build_source_distribution(&self) -> Result<Option<BuiltWheelMetadata>> {
+    pub fn build_source_distribution(&self) -> Result<Option<BuiltWheel>> {
         fs::create_dir_all(&self.context.artifact.out)
             .context("Failed to create the target directory for the source distribution")?;
 
@@ -269,7 +266,10 @@ impl<'a> BuildOrchestrator<'a> {
                     self.excludes(Format::Sdist)?,
                 )
                 .context("Failed to build source distribution")?;
-                Ok(Some((sdist_path, "source".to_string())))
+                Ok(Some(BuiltWheel {
+                    path: sdist_path,
+                    tag: BuiltArtifactTag::Source,
+                }))
             }
             None => Ok(None),
         }
@@ -303,14 +303,17 @@ impl<'a> BuildOrchestrator<'a> {
                         let stable_abi_tag = stable_abi_interps.first().map(|interp| {
                             let (major, minor) =
                                 min_version.unwrap_or((interp.major as u8, interp.minor as u8));
-                            format!("cp{major}{minor}-{abi_tag}-{platform}")
+                            WheelTag::new(format!("cp{major}{minor}"), abi_tag, platform.clone())
+                                .to_string()
                         });
                         // Some interpreters in this build may not support the selected stable ABI
                         // family, e.g. 3.14t when abi3t was selected for 3.15.
                         let version_specific_tags = version_specific_interps
                             .iter()
                             .map(|interpreter| {
-                                interpreter.get_tag(&self.context.project, &[PlatformTag::Linux])
+                                interpreter
+                                    .get_wheel_tag(&self.context.project, &[PlatformTag::Linux])
+                                    .map(|tag| tag.to_string())
                             })
                             .collect::<Result<Vec<_>>>()?;
                         let tags = stable_abi_tag
@@ -323,12 +326,16 @@ impl<'a> BuildOrchestrator<'a> {
                         tags
                     }
                     None => {
-                        vec![interp.get_tag(&self.context.project, &[PlatformTag::Linux])?]
+                        vec![
+                            interp
+                                .get_wheel_tag(&self.context.project, &[PlatformTag::Linux])?
+                                .to_string(),
+                        ]
                     }
                 }
             }
             BridgeModel::Bin(None) | BridgeModel::Cffi | BridgeModel::UniFfi => {
-                vec![self.get_universal_tag(&[PlatformTag::Linux])?]
+                vec![self.get_universal_tag(&[PlatformTag::Linux])?.to_string()]
             }
         };
         Ok(tags)
@@ -379,10 +386,10 @@ impl<'a> BuildOrchestrator<'a> {
         Ok(excludes.build()?)
     }
 
-    /// Returns the platform tag without python version (e.g. `py3-none-manylinux_2_17_x86_64`)
-    fn get_universal_tag(&self, platform_tags: &[PlatformTag]) -> Result<String> {
+    /// Returns the universal Python 3 wheel tag for the given platform tags.
+    fn get_universal_tag(&self, platform_tags: &[PlatformTag]) -> Result<WheelTag> {
         let platform = self.context.project.get_platform_tag(platform_tags)?;
-        Ok(format!("py3-none-{platform}"))
+        Ok(WheelTag::new("py3", "none", platform))
     }
 
     /// Returns user-specified platform tags, or falls back to the auditwheel
@@ -402,7 +409,7 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         stable_abi: &StableAbi,
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    ) -> Result<Vec<BuiltWheel>> {
         let min_version = stable_abi.version.min_version();
         // With mixed abi3 and abi3t features, selecting abi3t for a 3.15+
         // interpreter intentionally sends older interpreters to version-specific wheels.
@@ -478,7 +485,7 @@ impl<'a> BuildOrchestrator<'a> {
     #[allow(clippy::too_many_arguments)]
     fn write_wheel_inner<F, G>(
         &self,
-        tag: &str,
+        tag: &WheelTag,
         metadata24: &Metadata24,
         audited: &mut [AuditedArtifact],
         use_external_lib_shim: bool,
@@ -496,7 +503,13 @@ impl<'a> BuildOrchestrator<'a> {
             .compression
             .get_file_options()
             .last_modified_time(zip_mtime());
-        let writer = WheelWriter::new(tag, &self.context.artifact.out, metadata24, file_options)?;
+        let tag_string = tag.to_string();
+        let writer = WheelWriter::new(
+            &tag_string,
+            &self.context.artifact.out,
+            metadata24,
+            file_options,
+        )?;
         let mut writer = VirtualWriter::new(writer, self.excludes(Format::Wheel)?);
         self.context
             .add_external_libs(&mut writer, audited, use_external_lib_shim)?;
@@ -520,7 +533,7 @@ impl<'a> BuildOrchestrator<'a> {
             &metadata24.get_dist_info_dir(),
         )?;
 
-        let tags = [tag.to_string()];
+        let tags = [tag_string];
         let wheel_path = writer.finish(
             metadata24,
             &self.context.project.project_layout.project_root,
@@ -534,7 +547,7 @@ impl<'a> BuildOrchestrator<'a> {
     /// and writing the final .whl archive to the output directory.
     fn write_wheel<F, G>(
         &self,
-        tag: &str,
+        tag: &WheelTag,
         audited: &mut [AuditedArtifact],
         make_generator: F,
         sbom_data: &Option<SbomData>,
@@ -565,7 +578,7 @@ impl<'a> BuildOrchestrator<'a> {
         major: u8,
         min_minor: u8,
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         let python_interpreter = interpreters.first().copied();
         let (audited_artifact, policy, out_dirs) = self.compile_and_audit(
@@ -576,7 +589,7 @@ impl<'a> BuildOrchestrator<'a> {
 
         let platform = self.context.project.get_platform_tag(&platform_tags)?;
         let abi_tag = stable_abi.kind.wheel_tag();
-        let tag = format!("cp{major}{min_minor}-{abi_tag}-{platform}");
+        let tag = WheelTag::new(format!("cp{major}{min_minor}"), abi_tag, platform);
 
         let mut audited = [audited_artifact];
         let wheel_path = self.write_wheel(
@@ -600,7 +613,10 @@ impl<'a> BuildOrchestrator<'a> {
             min_minor,
             wheel_path.display()
         );
-        wheels.push((wheel_path, format!("cp{major}{min_minor}")));
+        wheels.push(BuiltWheel {
+            path: wheel_path,
+            tag: BuiltArtifactTag::interpreter(tag.python()),
+        });
 
         Ok(wheels)
     }
@@ -613,10 +629,10 @@ impl<'a> BuildOrchestrator<'a> {
         platform_tags: &[PlatformTag],
         sbom_data: &Option<SbomData>,
         out_dirs: &HashMap<String, PathBuf>,
-    ) -> Result<PathBuf> {
-        let tag = python_interpreter.get_tag(&self.context.project, platform_tags)?;
+    ) -> Result<(PathBuf, WheelTag)> {
+        let tag = python_interpreter.get_wheel_tag(&self.context.project, platform_tags)?;
 
-        self.write_wheel(
+        let path = self.write_wheel(
             &tag,
             audited,
             |temp_dir| {
@@ -627,7 +643,8 @@ impl<'a> BuildOrchestrator<'a> {
             },
             sbom_data,
             out_dirs,
-        )
+        )?;
+        Ok((path, tag))
     }
 
     /// Compile, audit, and write a single PyO3 wheel for one interpreter.
@@ -636,22 +653,24 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         python_interpreter: &PythonInterpreter,
         sbom_data: &Option<SbomData>,
-    ) -> Result<BuiltWheelMetadata> {
+    ) -> Result<BuiltWheel> {
         let (audited_artifact, policy, out_dirs) = self.compile_and_audit(
             Some(python_interpreter),
             Some(&self.context.project.project_layout.extension_name),
         )?;
         let platform_tags = self.resolve_platform_tags(&policy);
         let mut audited = [audited_artifact];
-        let wheel_path = self.write_pyo3_wheel(
+        let (wheel_path, tag) = self.write_pyo3_wheel(
             python_interpreter,
             &mut audited,
             &platform_tags,
             sbom_data,
             &out_dirs,
         )?;
-        let tag = format!("cp{}{}", python_interpreter.major, python_interpreter.minor);
-        Ok((wheel_path, tag))
+        Ok(BuiltWheel {
+            path: wheel_path,
+            tag: BuiltArtifactTag::interpreter(tag.python()),
+        })
     }
 
     /// Builds wheels for a pyo3 extension for all given python versions.
@@ -660,19 +679,19 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         interpreters: &[&PythonInterpreter],
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
-            let (wheel_path, tag) = self.build_single_pyo3_wheel(python_interpreter, sbom_data)?;
+            let wheel = self.build_single_pyo3_wheel(python_interpreter, sbom_data)?;
             eprintln!(
                 "📦 Built wheel for {} {}.{}{} to {}",
                 python_interpreter.interpreter_kind,
                 python_interpreter.major,
                 python_interpreter.minor,
                 python_interpreter.abiflags,
-                wheel_path.display()
+                wheel.path.display()
             );
-            wheels.push((wheel_path, tag));
+            wheels.push(wheel);
         }
 
         Ok(wheels)
@@ -754,7 +773,7 @@ impl<'a> BuildOrchestrator<'a> {
 
     /// Builds a wheel with cffi bindings
     #[instrument(skip_all)]
-    fn build_cffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheelMetadata>> {
+    fn build_cffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheel>> {
         let interpreter = self.context.python.interpreter.first().ok_or_else(|| {
             anyhow!("A python interpreter is required for cffi builds but one was not provided")
         })?;
@@ -781,17 +800,23 @@ impl<'a> BuildOrchestrator<'a> {
         }
 
         eprintln!("📦 Built wheel to {}", wheel_path.display());
-        Ok(vec![(wheel_path, "py3".to_string())])
+        Ok(vec![BuiltWheel {
+            path: wheel_path,
+            tag: BuiltArtifactTag::Universal,
+        }])
     }
 
     /// Builds a wheel with uniffi bindings
     #[instrument(skip_all)]
-    fn build_uniffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheelMetadata>> {
+    fn build_uniffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheel>> {
         let (wheel_path, _) =
             self.build_cdylib_wheel(|_temp_dir| Ok(UniFfiBindingGenerator::default()), sbom_data)?;
 
         eprintln!("📦 Built wheel to {}", wheel_path.display());
-        Ok(vec![(wheel_path, "py3".to_string())])
+        Ok(vec![BuiltWheel {
+            path: wheel_path,
+            tag: BuiltArtifactTag::Universal,
+        }])
     }
 
     /// Internal implementation for writing a binary wheel.
@@ -821,7 +846,7 @@ impl<'a> BuildOrchestrator<'a> {
         let tag = match (self.context.project.bridge(), python_interpreter) {
             (BridgeModel::Bin(None), _) => self.get_universal_tag(platform_tags)?,
             (BridgeModel::Bin(Some(..)), Some(python_interpreter)) => {
-                python_interpreter.get_tag(&self.context.project, platform_tags)?
+                python_interpreter.get_wheel_tag(&self.context.project, platform_tags)?
             }
             _ => unreachable!(),
         };
@@ -859,7 +884,7 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         python_interpreter: Option<&PythonInterpreter>,
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         let result = compile(
             self.context,
@@ -902,7 +927,10 @@ impl<'a> BuildOrchestrator<'a> {
             &result.out_dirs,
         )?;
         eprintln!("📦 Built wheel to {}", wheel_path.display());
-        wheels.push((wheel_path, "py3".to_string()));
+        wheels.push(BuiltWheel {
+            path: wheel_path,
+            tag: BuiltArtifactTag::Universal,
+        });
 
         Ok(wheels)
     }
@@ -913,7 +941,7 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         interpreters: &[&PythonInterpreter],
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheelMetadata>> {
+    ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
             wheels.extend(self.build_bin_wheel(Some(python_interpreter), sbom_data)?);

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -276,7 +276,7 @@ impl<'a> BuildOrchestrator<'a> {
     }
 
     /// Return the tags of the wheel that this build context builds.
-    pub fn tags_from_bridge(&self) -> Result<Vec<String>> {
+    pub fn tags_from_bridge(&self) -> Result<Vec<WheelTag>> {
         let bridge = self.context.project.bridge();
         let tags = match bridge {
             BridgeModel::PyO3(bindings) | BridgeModel::Bin(Some(bindings)) => {
@@ -304,7 +304,6 @@ impl<'a> BuildOrchestrator<'a> {
                             let (major, minor) =
                                 min_version.unwrap_or((interp.major as u8, interp.minor as u8));
                             WheelTag::new(format!("cp{major}{minor}"), abi_tag, platform.clone())
-                                .to_string()
                         });
                         // Some interpreters in this build may not support the selected stable ABI
                         // family, e.g. 3.14t when abi3t was selected for 3.15.
@@ -313,7 +312,6 @@ impl<'a> BuildOrchestrator<'a> {
                             .map(|interpreter| {
                                 interpreter
                                     .get_wheel_tag(&self.context.project, &[PlatformTag::Linux])
-                                    .map(|tag| tag.to_string())
                             })
                             .collect::<Result<Vec<_>>>()?;
                         let tags = stable_abi_tag
@@ -326,16 +324,12 @@ impl<'a> BuildOrchestrator<'a> {
                         tags
                     }
                     None => {
-                        vec![
-                            interp
-                                .get_wheel_tag(&self.context.project, &[PlatformTag::Linux])?
-                                .to_string(),
-                        ]
+                        vec![interp.get_wheel_tag(&self.context.project, &[PlatformTag::Linux])?]
                     }
                 }
             }
             BridgeModel::Bin(None) | BridgeModel::Cffi | BridgeModel::UniFfi => {
-                vec![self.get_universal_tag(&[PlatformTag::Linux])?.to_string()]
+                vec![self.get_universal_tag(&[PlatformTag::Linux])?]
             }
         };
         Ok(tags)
@@ -533,11 +527,10 @@ impl<'a> BuildOrchestrator<'a> {
             &metadata24.get_dist_info_dir(),
         )?;
 
-        let tags = [tag_string];
         let wheel_path = writer.finish(
             metadata24,
             &self.context.project.project_layout.project_root,
-            &tags,
+            std::slice::from_ref(tag),
         )?;
         finalize_staged_artifacts(audited);
         Ok(wheel_path)
@@ -827,7 +820,7 @@ impl<'a> BuildOrchestrator<'a> {
         platform_tags: &[PlatformTag],
         sbom_data: &Option<SbomData>,
         out_dirs: &HashMap<String, PathBuf>,
-    ) -> Result<PathBuf> {
+    ) -> Result<(PathBuf, WheelTag)> {
         if !self.context.project.metadata24.scripts.is_empty() {
             bail!("Defining scripts and working with a binary doesn't mix well");
         }
@@ -867,7 +860,7 @@ impl<'a> BuildOrchestrator<'a> {
         BinBindingGenerator::prepare_metadata(&mut metadata24, self.context, audited)
             .context("Failed to add the files to the wheel")?;
 
-        self.write_wheel_inner(
+        let path = self.write_wheel_inner(
             &tag,
             &metadata24,
             audited,
@@ -875,7 +868,8 @@ impl<'a> BuildOrchestrator<'a> {
             |_temp_dir| Ok(BinBindingGenerator::new(&metadata24, use_shim)),
             sbom_data,
             out_dirs,
-        )
+        )?;
+        Ok((path, tag))
     }
 
     /// Builds a wheel that contains a binary
@@ -919,7 +913,7 @@ impl<'a> BuildOrchestrator<'a> {
         let policy = policies.iter().min_by_key(|p| p.priority).unwrap();
         let platform_tags = self.resolve_platform_tags(policy);
 
-        let wheel_path = self.write_bin_wheel(
+        let (wheel_path, tag) = self.write_bin_wheel(
             python_interpreter,
             &mut audited_artifacts,
             &platform_tags,
@@ -927,9 +921,16 @@ impl<'a> BuildOrchestrator<'a> {
             &result.out_dirs,
         )?;
         eprintln!("📦 Built wheel to {}", wheel_path.display());
+        // Interpreter-bound binary wheels (pyo3-bin) carry a real python tag; pure
+        // standalone bins remain universal (`py3`).
+        let artifact_tag = if python_interpreter.is_some() {
+            BuiltArtifactTag::interpreter(tag.python())
+        } else {
+            BuiltArtifactTag::Universal
+        };
         wheels.push(BuiltWheel {
             path: wheel_path,
-            tag: BuiltArtifactTag::Universal,
+            tag: artifact_tag,
         });
 
         Ok(wheels)

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -583,8 +583,11 @@ impl<'a> BuildOrchestrator<'a> {
             &tag,
             &mut audited,
             |temp_dir| {
-                Pyo3BindingGenerator::new(Some(stable_abi.kind), python_interpreter, temp_dir)
-                    .context("Failed to initialize PyO3 binding generator")
+                Ok(Pyo3BindingGenerator::new_stable_abi(
+                    stable_abi.kind,
+                    python_interpreter,
+                    temp_dir,
+                ))
             },
             sbom_data,
             &out_dirs,
@@ -617,8 +620,10 @@ impl<'a> BuildOrchestrator<'a> {
             &tag,
             audited,
             |temp_dir| {
-                Pyo3BindingGenerator::new(None, Some(python_interpreter), temp_dir)
-                    .context("Failed to initialize PyO3 binding generator")
+                Ok(Pyo3BindingGenerator::new_version_specific(
+                    python_interpreter,
+                    temp_dir,
+                ))
             },
             sbom_data,
             out_dirs,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -15,7 +15,7 @@ pub fn build(
     let strip = strip_opt.strip;
     // set profile to release if specified; `--release` and `--profile` are mutually exclusive
     if release {
-        build.profile = Some("release".to_string());
+        build.cargo.profile = Some("release".to_string());
     }
     // Keep tempdir alive for the duration of the build
     let _sdist_tmp;

--- a/src/commands/pep517.rs
+++ b/src/commands/pep517.rs
@@ -129,12 +129,15 @@ pub fn pep517(subcommand: Pep517Command) -> Result<()> {
                     wheels.len(),
                     wheels
                         .iter()
-                        .map(|(path, _)| path.display().to_string())
+                        .map(|wheel| wheel.path.display().to_string())
                         .collect::<Vec<_>>(),
                 );
             }
-            let wheel_path = wheels[0].0.to_str().with_context(|| {
-                format!("wheel path is not valid UTF-8: {}", wheels[0].0.display())
+            let wheel_path = wheels[0].path.to_str().with_context(|| {
+                format!(
+                    "wheel path is not valid UTF-8: {}",
+                    wheels[0].path.display()
+                )
             })?;
             println!("{wheel_path}");
         }
@@ -164,10 +167,10 @@ pub fn pep517(subcommand: Pep517Command) -> Result<()> {
                 .build()?;
 
             let orchestrator = BuildOrchestrator::new(&build_context);
-            let (path, _) = orchestrator
+            let sdist = orchestrator
                 .build_source_distribution()?
                 .context("Failed to build source distribution, pyproject.toml not found")?;
-            println!("{}", path.file_name().unwrap().to_str().unwrap());
+            println!("{}", sdist.path.file_name().unwrap().to_str().unwrap());
         }
     };
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -16,7 +16,7 @@ pub fn publish(
     //
     // do it here to take precedence over pyproject.toml profile setting
     if debug {
-        build.profile = Some("dev".to_string());
+        build.cargo.profile = Some("dev".to_string());
     }
 
     // Keep tempdir alive for the duration of the build

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -1,6 +1,8 @@
 use crate::commands::utils::unpack_sdist_for_build;
 use anyhow::Result;
-use maturin::{BuildOptions, BuildOrchestrator, PublishOpt, upload_ui};
+use maturin::{
+    BuildOptions, BuildOrchestrator, BuiltArtifactTag, BuiltWheel, PublishOpt, upload_ui,
+};
 use tracing::instrument;
 
 #[instrument(skip_all)]
@@ -56,10 +58,16 @@ pub fn publish(
     let orchestrator = BuildOrchestrator::new(&build_context);
     let mut wheels = orchestrator.build_wheels()?;
     if let Some(sdist_path) = sdist_path {
-        wheels.push((sdist_path, "source".to_string()));
+        wheels.push(BuiltWheel {
+            path: sdist_path,
+            tag: BuiltArtifactTag::Source,
+        });
     }
 
-    let items = wheels.into_iter().map(|wheel| wheel.0).collect::<Vec<_>>();
+    let items = wheels
+        .into_iter()
+        .map(|wheel| wheel.path)
+        .collect::<Vec<_>>();
     publish.non_interactive_on_ci();
     upload_ui(&items, &publish)?;
     Ok(())

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -20,10 +20,10 @@ pub fn build_sdist(build: &BuildOptions, strip: Option<bool>) -> Result<PathBuf>
         .build()?;
 
     let orchestrator = BuildOrchestrator::new(&sdist_context);
-    let (sdist_path, _) = orchestrator
+    let sdist = orchestrator
         .build_source_distribution()?
         .context("Failed to build source distribution, pyproject.toml not found")?;
-    Ok(sdist_path)
+    Ok(sdist.path)
 }
 
 /// Build an sdist, unpack it, and point build options at the unpacked source.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -779,7 +779,7 @@ fn create_build_command(
                 };
 
                 let mut build = cargo_xwin::Rustc::from(cargo_rustc);
-                build.target = vec![target_triple.to_string()];
+                build.cargo.target = vec![target_triple.to_string()];
                 build.xwin = xwin_options;
                 build.build_command()?
             } else {
@@ -805,7 +805,7 @@ fn create_build_command(
             if !context.python.zig {
                 build.disable_zig_linker = true;
                 if target.user_specified {
-                    build.target = vec![target_triple.to_string()];
+                    build.cargo.target = vec![target_triple.to_string()];
                 }
             } else {
                 println!("🛠️ Using zig for cross-compiling to {target_triple}");
@@ -825,7 +825,7 @@ fn create_build_command(
                 } else {
                     target_triple.to_string()
                 };
-                build.target = vec![zig_triple];
+                build.cargo.target = vec![zig_triple];
             }
             build.build_command()?
         }

--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -450,12 +450,12 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
     let orchestrator = BuildOrchestrator::new(&build_context);
     let wheels = orchestrator.build_wheels()?;
     if !skip_install {
-        for (filename, _supported_version) in wheels.iter() {
+        for wheel in &wheels {
             install_wheel(
                 &build_context,
                 &python,
                 venv_dir,
-                filename,
+                &wheel.path,
                 &install_backend,
             )?;
             eprintln!(

--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -362,7 +362,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
             bindings,
         },
         platform: PlatformOptions {
-            platform_tag: vec![PlatformTag::Linux],
+            platform_tag: vec![PlatformTag::Linux.into()],
             auditwheel: Some(AuditWheelMode::Skip),
             skip_auditwheel: false,
             #[cfg(feature = "zig")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::python_interpreter::PythonInterpreter;
 pub use crate::source_distribution::{UnpackedSdist, find_path_deps, unpack_sdist};
 #[cfg(feature = "upload")]
 pub use crate::upload::{PublishOpt, Registry, UploadError, upload, upload_ui};
-pub use auditwheel::PlatformTag;
+pub use auditwheel::{CompatibilityTag, PlatformTag};
 pub use target::Target;
 
 mod archive_source;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::source_distribution::{UnpackedSdist, find_path_deps, unpack_sdist
 #[cfg(feature = "upload")]
 pub use crate::upload::{PublishOpt, Registry, UploadError, upload, upload_ui};
 pub use auditwheel::{CompatibilityTag, PlatformTag};
-pub use target::Target;
+pub use target::{Target, WheelTag};
 
 mod archive_source;
 mod auditwheel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 
 pub use crate::bridge::{BridgeModel, PyO3, PyO3Crate, StableAbi, StableAbiKind, StableAbiVersion};
 pub use crate::build_context::{
-    ArtifactContext, BuildContext, BuiltWheelMetadata, ProjectContext, PythonContext,
+    ArtifactContext, BuildContext, BuiltArtifactTag, BuiltWheel, ProjectContext, PythonContext,
 };
 pub use crate::build_options::{BuildOptions, OutputOptions, PlatformOptions, PythonOptions};
 pub use crate::build_orchestrator::BuildOrchestrator;

--- a/src/module_writer/mock_writer.rs
+++ b/src/module_writer/mock_writer.rs
@@ -15,6 +15,7 @@ use itertools::Itertools as _;
 use crate::BuildOptions;
 use crate::CargoOptions;
 use crate::Metadata24;
+use crate::WheelTag;
 use crate::archive_source::ArchiveSource;
 use crate::build_orchestrator::BuildOrchestrator;
 use crate::write_dist_info;
@@ -136,7 +137,7 @@ fn write_dist_info_uses_license_file_sources() -> Result<()> {
         &mut writer,
         &pyproject_dir,
         &metadata,
-        &["py3-none-any".to_string()],
+        &[WheelTag::new("py3", "none", "any")],
     )?;
 
     let files = writer.finish()?;
@@ -168,7 +169,7 @@ fn write_dist_info_rejects_absolute_license_paths() {
         &mut writer,
         pyproject_dir,
         &metadata,
-        &["py3-none-any".to_string()],
+        &[WheelTag::new("py3", "none", "any")],
     )
     .unwrap_err();
 
@@ -215,7 +216,7 @@ fn write_dist_info_respects_metadata_directory_env_var() -> Result<()> {
     // SAFETY: This test is serialized and the env var is removed before returning.
     unsafe { std::env::set_var("MATURIN_PEP517_METADATA_DIR", &pre_existing_dir) };
     let mut writer = VirtualWriter::new(MockWriter::default(), Override::empty());
-    let tags = &["cp310-cp310-manylinux_2_17_x86_64".to_string()];
+    let tags = &[WheelTag::new("cp310", "cp310", "manylinux_2_17_x86_64")];
     let result = write_dist_info(&mut writer, &pyproject_dir, &metadata, tags);
     unsafe { std::env::remove_var("MATURIN_PEP517_METADATA_DIR") };
     result?;
@@ -286,7 +287,7 @@ fn write_dist_info_metadata_dir_as_parent_directory() -> Result<()> {
     // SAFETY: This test is serialized and the env var is removed before returning.
     unsafe { std::env::set_var("MATURIN_PEP517_METADATA_DIR", &parent_dir) };
     let mut writer = VirtualWriter::new(MockWriter::default(), Override::empty());
-    let tags = &["cp310-cp310-manylinux_2_17_x86_64".to_string()];
+    let tags = &[WheelTag::new("cp310", "cp310", "manylinux_2_17_x86_64")];
     let result = write_dist_info(&mut writer, &pyproject_dir, &metadata, tags);
     unsafe { std::env::remove_var("MATURIN_PEP517_METADATA_DIR") };
     result?;

--- a/src/module_writer/mod.rs
+++ b/src/module_writer/mod.rs
@@ -300,7 +300,7 @@ pub fn write_dist_info(
     writer: &mut VirtualWriter<impl ModuleWriterInternal>,
     pyproject_dir: &Path,
     metadata24: &Metadata24,
-    tags: &[String],
+    tags: &[WheelTag],
 ) -> Result<PathBuf> {
     let dist_info_dir = metadata24.get_dist_info_dir();
 
@@ -406,7 +406,7 @@ fn write_dist_info_from_dir(
     writer: &mut VirtualWriter<impl ModuleWriterInternal>,
     dist_info_dir: &Path,
     source_dir: &Path,
-    tags: &[String],
+    tags: &[WheelTag],
 ) -> Result<PathBuf> {
     // Always regenerate WHEEL to ensure correct tags for the built wheel
     writer.add_bytes(
@@ -528,7 +528,7 @@ fn is_develop_build_artifact(relative_path: &Path, extension_name: &str) -> bool
     (is_native_ext || is_debuginfo) && name_matches
 }
 
-fn wheel_file(tags: &[String]) -> Result<String> {
+fn wheel_file(tags: &[WheelTag]) -> Result<String> {
     let mut wheel_file = format!(
         "Wheel-Version: 1.0
 Generator: {name} ({version})
@@ -539,7 +539,6 @@ Root-Is-Purelib: false
     );
 
     for tag in tags {
-        let tag = tag.parse::<WheelTag>()?;
         for expanded_tag in tag.expand() {
             writeln!(wheel_file, "Tag: {expanded_tag}")?;
         }
@@ -607,6 +606,7 @@ mod tests {
     use super::add_data;
     use super::wheel_file;
     use crate::Metadata24;
+    use crate::WheelTag;
 
     #[test]
     fn wheel_file_compressed_tags() -> Result<()> {
@@ -624,9 +624,9 @@ Tag: cp37-abi3-manylinux2014_x86_64
             version = env!("CARGO_PKG_VERSION"),
         );
         let actual = wheel_file(&[
-            "py2.py3-none-any".to_string(),
-            "pre-expanded-tag".to_string(),
-            "cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64".to_string(),
+            WheelTag::new("py2.py3", "none", "any"),
+            WheelTag::new("pre", "expanded", "tag"),
+            WheelTag::new("cp37", "abi3", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
         ])?;
         assert_eq!(expected, actual);
 
@@ -649,7 +649,11 @@ Tag: cp315-abi3t-manylinux_2_17_x86_64
             name = env!("CARGO_PKG_NAME"),
             version = env!("CARGO_PKG_VERSION"),
         );
-        let actual = wheel_file(&["cp315-abi3.abi3t-manylinux_2_17_x86_64".to_string()])?;
+        let actual = wheel_file(&[WheelTag::new(
+            "cp315",
+            "abi3.abi3t",
+            "manylinux_2_17_x86_64",
+        )])?;
         assert_eq!(expected, actual);
 
         Ok(())
@@ -682,7 +686,11 @@ Tag: cp315-abi3t-manylinux_2_17_x86_64
         let mut writer = VirtualWriter::new(wheel_writer, Override::empty());
         let wheel_path = {
             add_data(&mut writer, &metadata, Some(&data_dir))?;
-            writer.finish(&metadata, tmp_dir.path(), &["py3-none-any".to_string()])?
+            writer.finish(
+                &metadata,
+                tmp_dir.path(),
+                &[WheelTag::new("py3", "none", "any")],
+            )?
         };
 
         let mut wheel = ZipArchive::new(fs::File::open(&wheel_path)?)?;

--- a/src/module_writer/mod.rs
+++ b/src/module_writer/mod.rs
@@ -8,7 +8,6 @@ use anyhow::bail;
 use fs_err as fs;
 use ignore::WalkBuilder;
 use indexmap::IndexMap;
-use itertools::Itertools as _;
 use normpath::PathExt as _;
 use tracing::{debug, trace};
 
@@ -19,6 +18,7 @@ use crate::archive_source::FileSourceData;
 use crate::archive_source::GeneratedSourceData;
 use crate::project_layout::ProjectLayout;
 use crate::pyproject_toml::Format;
+use crate::target::WheelTag;
 
 pub(crate) mod glob;
 #[cfg(test)]
@@ -528,13 +528,6 @@ fn is_develop_build_artifact(relative_path: &Path, extension_name: &str) -> bool
     (is_native_ext || is_debuginfo) && name_matches
 }
 
-fn expand_compressed_tag(tag: &str) -> impl Iterator<Item = String> + '_ {
-    tag.split('-')
-        .map(|component| component.split('.'))
-        .multi_cartesian_product()
-        .map(|components| components.join("-"))
-}
-
 fn wheel_file(tags: &[String]) -> Result<String> {
     let mut wheel_file = format!(
         "Wheel-Version: 1.0
@@ -545,18 +538,9 @@ Root-Is-Purelib: false
         version = env!("CARGO_PKG_VERSION"),
     );
 
-    // N.B.: Tags should be in expanded form in this metadata (See:
-    // https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents
-    // items 7 and 11); so we do that expansion here if needed.
-    //
-    // It might make sense to reify a Tag struct in the code base and then, when a compressed tag
-    // set needs to be rendered, render a single string at that time. As things stand though, this
-    // is the only place in the codebase that needs reified tags (compressed tag sets expanded); so
-    // we do the expansion here.
-    //
-    // See: https://github.com/PyO3/maturin/issues/2761
     for tag in tags {
-        for expanded_tag in expand_compressed_tag(tag) {
+        let tag = tag.parse::<WheelTag>()?;
+        for expanded_tag in tag.expand() {
             writeln!(wheel_file, "Tag: {expanded_tag}")?;
         }
     }

--- a/src/module_writer/virtual_writer.rs
+++ b/src/module_writer/virtual_writer.rs
@@ -350,7 +350,7 @@ impl VirtualWriter<WheelWriter> {
         mut self,
         metadata24: &Metadata24,
         pyproject_dir: &Path,
-        tags: &[String],
+        tags: &[crate::WheelTag],
     ) -> Result<PathBuf> {
         let dist_info_dir = write_dist_info(&mut self, pyproject_dir, metadata24, tags)?;
         let mut comparator = self.inner.file_ordering(&dist_info_dir);

--- a/src/pyproject_toml.rs
+++ b/src/pyproject_toml.rs
@@ -1,6 +1,6 @@
 //! A pyproject.toml as specified in PEP 517
 
-use crate::PlatformTag;
+use crate::CompatibilityTag;
 use crate::auditwheel::AuditWheelMode;
 use anyhow::{Context, Result};
 use fs_err as fs;
@@ -369,7 +369,7 @@ pub struct ToolMaturin {
     pub bindings: Option<String>,
     /// Platform compatibility
     #[serde(alias = "manylinux")]
-    pub compatibility: Option<PlatformTag>,
+    pub compatibility: Option<CompatibilityTag>,
     /// Audit wheel mode
     pub auditwheel: Option<AuditWheelMode>,
     /// Skip audit wheel
@@ -600,7 +600,7 @@ impl PyProjectToml {
     }
 
     /// Returns the value of `[tool.maturin.compatibility]` in pyproject.toml
-    pub fn compatibility(&self) -> Option<PlatformTag> {
+    pub fn compatibility(&self) -> Option<CompatibilityTag> {
         self.maturin()?.compatibility
     }
 
@@ -778,12 +778,12 @@ impl PyProjectToml {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::test_crate_path;
     use crate::{
-        PyProjectToml,
+        CompatibilityTag, PyProjectToml,
         pyproject_toml::{
             FeatureConditionEnv, FeatureSpec, Format, Formats, GlobPattern, ToolMaturin,
         },
+        test_utils::test_crate_path,
     };
     use expect_test::expect;
     use fs_err as fs;
@@ -1157,6 +1157,15 @@ mod tests {
                 },
             ])
         );
+    }
+
+    #[test]
+    fn test_compatibility_pypi_deserializes() {
+        let toml_str = r#"
+            compatibility = "pypi"
+        "#;
+        let maturin: ToolMaturin = toml::from_str(toml_str).unwrap();
+        assert_eq!(maturin.compatibility, Some(CompatibilityTag::Pypi));
     }
 
     #[test]

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -2,6 +2,7 @@ pub use self::config::InterpreterConfig;
 use crate::Target;
 use crate::auditwheel::PlatformTag;
 use crate::bridge::{ABI3T_MINIMUM_PYTHON_MINOR, StableAbiKind};
+use crate::target::WheelTag;
 use anyhow::{Result, bail};
 use std::borrow::Cow;
 use std::ffi::OsStr;
@@ -192,6 +193,14 @@ impl PythonInterpreter {
         project: &crate::ProjectContext,
         platform_tags: &[PlatformTag],
     ) -> Result<String> {
+        Ok(self.get_wheel_tag(project, platform_tags)?.to_string())
+    }
+
+    pub(crate) fn get_wheel_tag(
+        &self,
+        project: &crate::ProjectContext,
+        platform_tags: &[PlatformTag],
+    ) -> Result<WheelTag> {
         // Restrict `sysconfig.get_platform()` usage to Windows and non-portable Linux only for now
         // so we don't need to deal with macOS deployment target
         let target = &project.target;
@@ -210,51 +219,53 @@ impl PythonInterpreter {
         let tag = if self.implementation_name.parse::<InterpreterKind>().is_err() {
             // Use generic tags when `sys.implementation.name` != `platform.python_implementation()`, for example Pyston
             // See also https://github.com/pypa/packaging/blob/0031046f7fad649580bc3127d1cef9157da0dd79/packaging/tags.py#L234-L261
-            format!(
-                "{interpreter}{major}{minor}-{soabi}-{platform}",
-                interpreter = self.implementation_name,
-                major = self.major,
-                minor = self.minor,
-                soabi = self
-                    .soabi
+            WheelTag::new(
+                format!(
+                    "{interpreter}{major}{minor}",
+                    interpreter = self.implementation_name,
+                    major = self.major,
+                    minor = self.minor,
+                ),
+                self.soabi
                     .as_deref()
                     .unwrap_or("none")
                     .replace(['-', '.'], "_"),
-                platform = platform
+                platform,
             )
         } else {
             match self.interpreter_kind {
-                InterpreterKind::CPython => {
+                InterpreterKind::CPython => WheelTag::new(
+                    format!("cp{major}{minor}", major = self.major, minor = self.minor),
                     format!(
-                        "cp{major}{minor}-cp{major}{minor}{abiflags}-{platform}",
+                        "cp{major}{minor}{abiflags}",
                         major = self.major,
                         minor = self.minor,
                         abiflags = self.abiflags,
-                        platform = platform
-                    )
-                }
+                    ),
+                    platform,
+                ),
                 InterpreterKind::PyPy => {
                     // pypy uses its version as part of the ABI, e.g.
                     // pypy 3.11 7.3 => numpy-1.20.1-pp311-pypy311_pp73-manylinux2014_x86_64.whl
-                    format!(
-                        "pp{major}{minor}-{abi_tag}-{platform}",
-                        major = self.major,
-                        minor = self.minor,
-                        abi_tag = abiflags::calculate_abi_tag(&self.ext_suffix)
+                    WheelTag::new(
+                        format!("pp{major}{minor}", major = self.major, minor = self.minor),
+                        abiflags::calculate_abi_tag(&self.ext_suffix)
                             .expect("PyPy's syconfig didn't define a valid `EXT_SUFFIX` ಠ_ಠ"),
-                        platform = platform,
+                        platform,
                     )
                 }
                 InterpreterKind::GraalPy => {
                     // GraalPy like PyPy uses its version as part of the ABI
                     // graalpy 3.10 23.1 => numpy-1.23.5-graalpy310-graalpy231_310_native-manylinux2014_x86_64.whl
-                    format!(
-                        "graalpy{major}{minor}-{abi_tag}-{platform}",
-                        major = self.major,
-                        minor = self.minor,
-                        abi_tag = abiflags::calculate_abi_tag(&self.ext_suffix)
+                    WheelTag::new(
+                        format!(
+                            "graalpy{major}{minor}",
+                            major = self.major,
+                            minor = self.minor
+                        ),
+                        abiflags::calculate_abi_tag(&self.ext_suffix)
                             .expect("GraalPy's syconfig didn't define a valid `EXT_SUFFIX` ಠ_ಠ"),
-                        platform = platform,
+                        platform,
                     )
                 }
             }

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -183,11 +183,13 @@ impl PythonInterpreter {
     }
 
     /// Returns the supported python environment in the PEP 425 format used for the wheel filename:
-    /// {python tag}-{abi tag}-{platform tag}
+    /// `{python tag}-{abi tag}-{platform tag}`.
     ///
-    /// Don't ask me why or how, this is just what setuptools uses so I'm also going to use
+    /// This is a **compatibility string helper** for external callers that need the tag as a
+    /// single string. New maturin code should prefer [`Self::get_wheel_tag`] and keep the
+    /// structured [`crate::WheelTag`] through to WHEEL metadata generation.
     ///
-    /// If abi3 is true, cpython wheels use the generic abi3 with the given version as minimum
+    /// If abi3 is true, cpython wheels use the generic abi3 with the given version as minimum.
     pub fn get_tag(
         &self,
         project: &crate::ProjectContext,
@@ -196,6 +198,9 @@ impl PythonInterpreter {
         Ok(self.get_wheel_tag(project, platform_tags)?.to_string())
     }
 
+    /// Structured PEP 425 wheel tag for this interpreter.
+    ///
+    /// Prefer this over [`Self::get_tag`] inside maturin so tags are not re-parsed from strings.
     pub(crate) fn get_wheel_tag(
         &self,
         project: &crate::ProjectContext,

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -25,7 +25,7 @@ mod wheel_tag;
 pub use platform_tag::get_platform_tag;
 pub(crate) use platform_tag::rustc_macosx_target_version;
 pub use pypi_tags::{is_arch_supported_by_pypi, validate_wheel_filename_for_pypi};
-pub(crate) use wheel_tag::WheelTag;
+pub use wheel_tag::WheelTag;
 
 pub(crate) const RUST_1_64_0: semver::Version = semver::Version::new(1, 64, 0);
 pub(crate) const RUST_1_93_0: semver::Version = semver::Version::new(1, 93, 0);

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -20,10 +20,12 @@ use tracing::error;
 mod legacy_py;
 mod platform_tag;
 mod pypi_tags;
+mod wheel_tag;
 
 pub use platform_tag::get_platform_tag;
 pub(crate) use platform_tag::rustc_macosx_target_version;
 pub use pypi_tags::{is_arch_supported_by_pypi, validate_wheel_filename_for_pypi};
+pub(crate) use wheel_tag::WheelTag;
 
 pub(crate) const RUST_1_64_0: semver::Version = semver::Version::new(1, 64, 0);
 pub(crate) const RUST_1_93_0: semver::Version = semver::Version::new(1, 93, 0);

--- a/src/target/wheel_tag.rs
+++ b/src/target/wheel_tag.rs
@@ -4,15 +4,23 @@ use std::str::FromStr;
 use anyhow::bail;
 use itertools::Itertools as _;
 
+/// A PEP 425 wheel tag with optional compressed (dot-separated) components.
+///
+/// Compressed tags such as `py2.py3-none-any` expand to one fully qualified tag
+/// per combination of components via [`WheelTag::expand`].
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct WheelTag {
+pub struct WheelTag {
     python: String,
     abi: String,
     platform: String,
 }
 
 impl WheelTag {
-    pub(crate) fn new(
+    /// Create a wheel tag from python, ABI, and platform components.
+    ///
+    /// Each component may itself be a compressed (dot-separated) list, e.g.
+    /// `py2.py3`, `abi3.abi3t`, or `manylinux_2_17_x86_64.manylinux2014_x86_64`.
+    pub fn new(
         python: impl Into<String>,
         abi: impl Into<String>,
         platform: impl Into<String>,
@@ -24,11 +32,23 @@ impl WheelTag {
         }
     }
 
-    pub(crate) fn python(&self) -> &str {
+    /// The python tag component (e.g. `cp312`, `pp311`, `py3`).
+    pub fn python(&self) -> &str {
         &self.python
     }
 
-    pub(crate) fn expand(&self) -> impl Iterator<Item = String> + '_ {
+    /// The ABI tag component (e.g. `cp312`, `abi3`, `none`).
+    pub fn abi(&self) -> &str {
+        &self.abi
+    }
+
+    /// The platform tag component (e.g. `manylinux_2_17_x86_64`, `any`).
+    pub fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    /// Expand compressed components into fully qualified PEP 425 tags.
+    pub fn expand(&self) -> impl Iterator<Item = String> + '_ {
         [&self.python, &self.abi, &self.platform]
             .into_iter()
             .map(|component| component.split('.'))
@@ -120,5 +140,30 @@ mod tests {
         let tag = "py3-none-any".parse::<WheelTag>().unwrap();
 
         assert_eq!(tag, WheelTag::new("py3", "none", "any"));
+    }
+
+    #[test]
+    fn display_round_trips_through_from_str() {
+        let original = WheelTag::new("cp37", "abi3", "manylinux_2_17_x86_64.manylinux2014_x86_64");
+        let parsed = original.to_string().parse::<WheelTag>().unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn from_str_rejects_too_few_components() {
+        let err = "cp37-abi3".parse::<WheelTag>().unwrap_err();
+        assert!(
+            err.to_string().contains("platform tag"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn from_str_rejects_too_many_components() {
+        let err = "a-b-c-d".parse::<WheelTag>().unwrap_err();
+        assert!(
+            err.to_string().contains("exactly three components"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/target/wheel_tag.rs
+++ b/src/target/wheel_tag.rs
@@ -1,0 +1,124 @@
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::bail;
+use itertools::Itertools as _;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WheelTag {
+    python: String,
+    abi: String,
+    platform: String,
+}
+
+impl WheelTag {
+    pub(crate) fn new(
+        python: impl Into<String>,
+        abi: impl Into<String>,
+        platform: impl Into<String>,
+    ) -> Self {
+        Self {
+            python: python.into(),
+            abi: abi.into(),
+            platform: platform.into(),
+        }
+    }
+
+    pub(crate) fn python(&self) -> &str {
+        &self.python
+    }
+
+    pub(crate) fn expand(&self) -> impl Iterator<Item = String> + '_ {
+        [&self.python, &self.abi, &self.platform]
+            .into_iter()
+            .map(|component| component.split('.'))
+            .multi_cartesian_product()
+            .map(|components| components.join("-"))
+    }
+}
+
+impl fmt::Display for WheelTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}-{}", self.python, self.abi, self.platform)
+    }
+}
+
+impl FromStr for WheelTag {
+    type Err = anyhow::Error;
+
+    fn from_str(tag: &str) -> std::result::Result<Self, Self::Err> {
+        let mut components = tag.split('-');
+        let Some(python) = components.next() else {
+            bail!("wheel tag must contain a python tag: {tag}");
+        };
+        let Some(abi) = components.next() else {
+            bail!("wheel tag must contain an ABI tag: {tag}");
+        };
+        let Some(platform) = components.next() else {
+            bail!("wheel tag must contain a platform tag: {tag}");
+        };
+        if components.next().is_some() {
+            bail!("wheel tag must have exactly three components: {tag}");
+        }
+
+        Ok(Self::new(python, abi, platform))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WheelTag;
+
+    #[test]
+    fn display_renders_pep425_tag() {
+        let tag = WheelTag::new("cp312", "cp312", "manylinux_2_17_x86_64");
+
+        assert_eq!(tag.to_string(), "cp312-cp312-manylinux_2_17_x86_64");
+    }
+
+    #[test]
+    fn expand_compressed_tags() {
+        let expanded = WheelTag::new("py2.py3", "none", "any")
+            .expand()
+            .collect::<Vec<_>>();
+
+        assert_eq!(expanded, ["py2-none-any", "py3-none-any"]);
+    }
+
+    #[test]
+    fn expand_compressed_platform_tags() {
+        let expanded = WheelTag::new("cp37", "abi3", "manylinux_2_17_x86_64.manylinux2014_x86_64")
+            .expand()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            expanded,
+            [
+                "cp37-abi3-manylinux_2_17_x86_64",
+                "cp37-abi3-manylinux2014_x86_64"
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_abi3t_to_abi3_and_abi3t() {
+        let expanded = WheelTag::new("cp315", "abi3.abi3t", "manylinux_2_17_x86_64")
+            .expand()
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            expanded,
+            [
+                "cp315-abi3-manylinux_2_17_x86_64",
+                "cp315-abi3t-manylinux_2_17_x86_64"
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_existing_string_boundary() {
+        let tag = "py3-none-any".parse::<WheelTag>().unwrap();
+
+        assert_eq!(tag, WheelTag::new("py3", "none", "any"));
+    }
+}

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -9,7 +9,7 @@ use cargo_zigbuild::Zig;
 use clap::Parser;
 use fs_err::File;
 use fs4::fs_err3::FileExt;
-use maturin::{BuildOptions, BuildOrchestrator, Target};
+use maturin::{BuildOptions, BuildOrchestrator, BuiltArtifactTag, Target};
 use normpath::PathExt;
 use std::collections::HashSet;
 use std::env;
@@ -325,9 +325,10 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
     };
     // We can do this since we know that wheels are built and returned in the
     // order they are in the build context
-    for ((filename, supported_version), python_interpreter) in wheels.iter().zip(interpreter) {
+    for (wheel, python_interpreter) in wheels.iter().zip(interpreter) {
+        let filename = &wheel.path;
         check_for_duplicates(filename)?;
-        let mut venv_name = if supported_version == "py3" {
+        let mut venv_name = if matches!(&wheel.tag, BuiltArtifactTag::Universal) {
             format!("{}-py3", case.id)
         } else {
             format!(
@@ -406,10 +407,10 @@ pub fn test_integration_conda(
     let wheels = BuildOrchestrator::new(&build_context).build_wheels()?;
 
     let mut conda_wheels: Vec<(PathBuf, PathBuf)> = vec![];
-    for ((filename, _), python_interpreter) in wheels.iter().zip(build_context.python.interpreter) {
+    for (wheel, python_interpreter) in wheels.iter().zip(build_context.python.interpreter) {
         let executable = python_interpreter.executable;
         if executable.to_string_lossy().contains(case_id) {
-            conda_wheels.push((filename.clone(), executable))
+            conda_wheels.push((wheel.path.clone(), executable))
         }
     }
 

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -289,7 +289,7 @@ fn build_wheel_files(package: impl AsRef<Path>, unique_name: &str) -> Result<Zip
             ..Default::default()
         },
         platform: PlatformOptions {
-            platform_tag: vec![PlatformTag::Linux],
+            platform_tag: vec![PlatformTag::Linux.into()],
             ..Default::default()
         },
         ..Default::default()

--- a/tests/common/other.rs
+++ b/tests/common/other.rs
@@ -199,11 +199,11 @@ pub fn build_source_distribution(
     pyproject_toml.tool = Some(tool);
     build_context.project.pyproject_toml = Some(pyproject_toml);
 
-    let (path, _) = BuildOrchestrator::new(&build_context)
+    let sdist = BuildOrchestrator::new(&build_context)
         .build_source_distribution()?
         .context("Failed to build source distribution")?;
 
-    let tar_gz = fs_err::File::open(path)?;
+    let tar_gz = fs_err::File::open(sdist.path)?;
     let tar = GzDecoder::new(tar_gz);
     let archive = Archive::new(tar);
     Ok(archive)
@@ -304,7 +304,7 @@ fn build_wheel_files(package: impl AsRef<Path>, unique_name: &str) -> Result<Zip
         .build_wheels()
         .context("Failed to build wheels")?;
     assert!(!wheels.is_empty());
-    let (wheel_path, _) = &wheels[0];
+    let wheel_path = &wheels[0].path;
 
     let wheel = ZipArchive::new(File::open(wheel_path)?)?;
     Ok(wheel)
@@ -617,7 +617,8 @@ pub fn combined_stable_abi_wheel_selection(unique_name: &str, features: &[&str])
 
     let actual = wheels
         .iter()
-        .map(|(wheel_path, _)| {
+        .map(|wheel| {
+            let wheel_path = &wheel.path;
             let filename = wheel_path.file_name().unwrap().to_str().unwrap();
             let mut fields = filename.strip_suffix(".whl").unwrap().rsplit('-');
             let _platform = fields.next().unwrap();
@@ -734,7 +735,7 @@ pub fn test_build_wheels_from_sdist(package: impl AsRef<Path>, unique_name: &str
         .editable(false)
         .sdist_only(true)
         .build()?;
-    let (sdist_path, _) = BuildOrchestrator::new(&sdist_context)
+    let sdist = BuildOrchestrator::new(&sdist_context)
         .build_source_distribution()?
         .context("Failed to build source distribution")?;
 
@@ -743,7 +744,7 @@ pub fn test_build_wheels_from_sdist(package: impl AsRef<Path>, unique_name: &str
         tmpdir: _tmp,
         cargo_toml,
         pyproject_toml,
-    } = unpack_sdist(&sdist_path)?;
+    } = unpack_sdist(&sdist.path)?;
     let wheel_options = BuildOptions {
         output: OutputOptions {
             out: Some(wheel_dir),

--- a/tests/run/sdist.rs
+++ b/tests/run/sdist.rs
@@ -238,7 +238,7 @@ fn sdist_excludes_explicit_build_script() {
         .sdist_only(true)
         .build()
         .unwrap();
-    let (sdist_path, _) = BuildOrchestrator::new(&build_context)
+    let sdist = BuildOrchestrator::new(&build_context)
         .build_source_distribution()
         .unwrap()
         .expect("failed to build sdist");
@@ -247,7 +247,7 @@ fn sdist_excludes_explicit_build_script() {
         tmpdir: _tmp,
         cargo_toml,
         pyproject_toml: _pyproject_toml,
-    } = unpack_sdist(&sdist_path).unwrap();
+    } = unpack_sdist(&sdist.path).unwrap();
     let sdist_root = cargo_toml.parent().unwrap();
     assert!(
         !sdist_root.join("build.rs").exists(),
@@ -821,7 +821,7 @@ fn lib_with_parent_workspace_git_dep_sdist() {
         .sdist_only(true)
         .build()
         .unwrap();
-    let (sdist_path, _) = BuildOrchestrator::new(&build_context)
+    let sdist = BuildOrchestrator::new(&build_context)
         .build_source_distribution()
         .unwrap()
         .expect("failed to build sdist");
@@ -830,7 +830,7 @@ fn lib_with_parent_workspace_git_dep_sdist() {
         tmpdir: _tmp,
         cargo_toml,
         pyproject_toml: _pyproject_toml,
-    } = unpack_sdist(&sdist_path).unwrap();
+    } = unpack_sdist(&sdist.path).unwrap();
     let sdist_root = cargo_toml.parent().unwrap().parent().unwrap();
     let shared_manifest = sdist_root.join("shared_crate/Cargo.toml");
     let rewritten_shared_manifest = fs_err::read_to_string(&shared_manifest).unwrap();
@@ -964,7 +964,7 @@ fn lib_with_parent_workspace_lints_sdist() {
         .sdist_only(true)
         .build()
         .unwrap();
-    let (sdist_path, _) = BuildOrchestrator::new(&build_context)
+    let sdist = BuildOrchestrator::new(&build_context)
         .build_source_distribution()
         .unwrap()
         .expect("failed to build sdist");
@@ -973,7 +973,7 @@ fn lib_with_parent_workspace_lints_sdist() {
         tmpdir: _tmp,
         cargo_toml,
         pyproject_toml: _pyproject_toml,
-    } = unpack_sdist(&sdist_path).unwrap();
+    } = unpack_sdist(&sdist.path).unwrap();
     let sdist_root = cargo_toml.parent().unwrap().parent().unwrap();
     let shared_manifest = sdist_root.join("shared_crate/Cargo.toml");
     let rewritten_shared_manifest = fs_err::read_to_string(&shared_manifest).unwrap();


### PR DESCRIPTION
- Remove `BuildOptions` `Deref`/`DerefMut` to `CargoOptions` and use explicit `.cargo` access; split `Pyo3BindingGenerator` into state-specific constructors so impossible runtime states go away.
- Peel the `pypi` pseudo-tag out of `PlatformTag` into a thin `CompatibilityTag` wrapper (`Platform(PlatformTag) | Pypi`), normalize it in the builder to real platform tags plus a validation flag, and serialize as the same string form used by CLI/TOML. This also makes pyproject `compatibility = "pypi"` behave like `--compatibility pypi`.
- Replace the stringly `BuiltWheelMetadata = (PathBuf, String)` alias with `BuiltWheel { path, tag: BuiltArtifactTag }`, introduce a public `WheelTag` type that owns compressed-tag expansion, and thread it through WHEEL metadata generation without re-parsing strings. Interpreter-bound pyo3-bin wheels now report real python tags instead of always `Universal`.