### PR TITLE
refactor: InstallDest, single BridgeModel, and ui output facade

### DIFF
--- a/src/binding_generator/mod.rs
+++ b/src/binding_generator/mod.rs
@@ -11,8 +11,6 @@ use fs_err as fs;
 use fs_err::File;
 #[cfg(unix)]
 use fs_err::os::unix::fs::OpenOptionsExt as _;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt as _;
 use tracing::{debug, warn};
 
 use crate::BuildArtifact;
@@ -23,6 +21,8 @@ use crate::WheelWriter;
 use crate::archive_source::ArchiveSource;
 #[cfg(unix)]
 use crate::module_writer::default_permission;
+use crate::module_writer::file_permission_mode;
+use crate::module_writer::permission_is_executable;
 use crate::module_writer::write_python_part;
 use walkdir::WalkDir;
 
@@ -93,6 +93,264 @@ pub(crate) struct GeneratorOutput {
     additional_files: HashMap<PathBuf, ArchiveSource>,
 }
 
+enum InstallDest<'writer, 'base> {
+    Editable {
+        writer: &'writer mut VirtualWriter<WheelWriter>,
+        base_path: &'base Path,
+    },
+    Archive {
+        writer: &'writer mut VirtualWriter<WheelWriter>,
+    },
+}
+
+impl<'writer, 'base> InstallDest<'writer, 'base> {
+    fn new(
+        writer: &'writer mut VirtualWriter<WheelWriter>,
+        editable: bool,
+        base_path: Option<&'base Path>,
+    ) -> Self {
+        match (editable, base_path) {
+            (true, Some(base_path)) => Self::Editable { writer, base_path },
+            _ => Self::Archive { writer },
+        }
+    }
+
+    fn add_artifact(&mut self, artifact_target: &ArtifactTarget, source: &Path) -> Result<()> {
+        match self {
+            Self::Editable { writer, base_path } => match artifact_target {
+                ArtifactTarget::Binary(path) => {
+                    // Use add_file_force to bypass exclusion checks for the compiled artifact
+                    writer.add_file_force(path, source, true)?;
+                }
+                ArtifactTarget::ExtensionModule(path) => {
+                    let target = base_path.join(path);
+                    debug!("Removing previously built module {}", target.display());
+                    fs::create_dir_all(target.parent().unwrap())?;
+                    // Remove existing so file to avoid triggering SIGSEV in running process
+                    // See https://github.com/PyO3/maturin/issues/758
+                    let _ = fs::remove_file(&target);
+
+                    debug!("Installing {} from {}", target.display(), source.display());
+                    fs::copy(source, &target).with_context(|| {
+                        format!(
+                            "Failed to copy {} to {}",
+                            source.display(),
+                            target.display(),
+                        )
+                    })?;
+                }
+            },
+            Self::Archive { writer } => {
+                debug!(
+                    "Adding to archive {} from {}",
+                    artifact_target.path().display(),
+                    source.display()
+                );
+                // Use add_file_force to bypass exclusion checks for the compiled artifact
+                writer.add_file_force(artifact_target.path(), source, true)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn add_generated_files(
+        &mut self,
+        additional_files: HashMap<PathBuf, ArchiveSource>,
+    ) -> Result<()> {
+        for (target, source) in additional_files {
+            self.add_generated_file(target, source)?;
+        }
+        Ok(())
+    }
+
+    fn add_generated_file(&mut self, target: PathBuf, source: ArchiveSource) -> Result<()> {
+        match self {
+            Self::Editable { base_path, .. } => {
+                let target = base_path.join(target);
+                fs::create_dir_all(target.parent().unwrap())?;
+                debug!("Generating file {}", target.display());
+                let mut options = File::options();
+                options.write(true).create(true).truncate(true);
+                #[cfg(unix)]
+                {
+                    options.mode(default_permission(source.executable()));
+                }
+
+                let mut file = options.open(&target)?;
+                match source {
+                    ArchiveSource::Generated(source) => file.write_all(&source.data)?,
+                    ArchiveSource::File(source) => {
+                        let mut source = File::options().read(true).open(source.path)?;
+                        io::copy(&mut source, &mut file)?;
+                    }
+                }
+            }
+            Self::Archive { writer } => {
+                debug!("Generating archive entry {}", target.display());
+                // Use add_entry_force to bypass exclusion checks for generated binding files
+                writer.add_entry_force(target, source)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn add_import_lib(&mut self, import_lib: &Path, module: &Path) -> Result<()> {
+        match self {
+            Self::Editable { base_path, .. } => {
+                let target = base_path.join(import_lib.file_name().unwrap());
+                fs::create_dir_all(target.parent().unwrap())?;
+                debug!("Installing import library {}", target.display());
+                fs::copy(import_lib, &target)?;
+            }
+            Self::Archive { writer } => {
+                let dest = module.join(import_lib.file_name().unwrap());
+                debug!("Adding import library to archive {}", dest.display());
+                writer.add_file_force(dest, import_lib, false)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn add_debuginfo(
+        &mut self,
+        debuginfo: &Path,
+        artifact_target: &ArtifactTarget,
+        module: &Path,
+    ) -> Result<()> {
+        match self {
+            Self::Editable { base_path, .. } => {
+                let debuginfo_base = match artifact_target {
+                    ArtifactTarget::Binary(_) => base_path.to_path_buf(),
+                    ArtifactTarget::ExtensionModule(path) => base_path
+                        .join(path)
+                        .parent()
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_else(|| base_path.to_path_buf()),
+                };
+                let debuginfo_name = debuginfo
+                    .file_name()
+                    .context("Failed to get debug info file name")?;
+                let target = debuginfo_base.join(debuginfo_name);
+
+                // Remove stale debuginfo to avoid mixed contents (mirrors the
+                // "remove existing .so" logic for the extension module itself)
+                if target.is_dir() {
+                    let _ = fs::remove_dir_all(&target);
+                } else if target.exists() {
+                    let _ = fs::remove_file(&target);
+                }
+
+                if debuginfo.is_dir() {
+                    // .dSYM is a directory bundle on macOS
+                    debug!(
+                        "Copying debug info directory {} to {}",
+                        debuginfo.display(),
+                        target.display()
+                    );
+                    copy_dir_all(debuginfo, &target)?;
+                } else if debuginfo.is_file() {
+                    debug!(
+                        "Installing debug info {} to {}",
+                        debuginfo.display(),
+                        target.display()
+                    );
+                    fs::create_dir_all(target.parent().unwrap())?;
+                    fs::copy(debuginfo, &target)?;
+                } else {
+                    warn!(
+                        "Debug info path {} is neither a file nor a directory, skipping",
+                        debuginfo.display()
+                    );
+                }
+            }
+            Self::Archive { writer } => {
+                // Binary artifacts go into the `.data/scripts/` directory.
+                // The wheel spec only permits regular files in `scripts/`, so
+                // a `.dSYM` directory bundle (macOS debug info) cannot be
+                // placed there.  Skip debug-info installation for binaries to
+                // avoid producing an invalid wheel that tools like uv reject.
+                if matches!(artifact_target, ArtifactTarget::Binary(_)) {
+                    warn!(
+                        "Skipping debug info for binary artifact in wheel: {} \
+                         (directory bundles such as .dSYM are not permitted in \
+                         the wheel `scripts` directory)",
+                        debuginfo.display()
+                    );
+                    return Ok(());
+                }
+
+                // Place debug info next to the artifact inside the wheel,
+                // not at the top-level module (the artifact may be nested
+                // in a subdirectory for CFFI/UniFFI mixed projects).
+                let debuginfo_dir = artifact_target
+                    .path()
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| module.to_path_buf());
+                let debuginfo_name = debuginfo
+                    .file_name()
+                    .context("Failed to get debug info file name")?;
+
+                if debuginfo.is_dir() {
+                    // .dSYM is a directory bundle on macOS - add all files recursively
+                    for entry in WalkDir::new(debuginfo).follow_links(true) {
+                        let entry = entry?;
+                        if entry.file_type().is_file() {
+                            let relative = entry
+                                .path()
+                                .strip_prefix(debuginfo)
+                                .context("Failed to compute relative path in debug info bundle")?;
+                            let dest = debuginfo_dir.join(debuginfo_name).join(relative);
+                            debug!(
+                                "Adding debug info {} to archive at {}",
+                                entry.path().display(),
+                                dest.display()
+                            );
+                            writer.add_file_force(dest, entry.path(), false)?;
+                        }
+                    }
+                } else if debuginfo.is_file() {
+                    let dest = debuginfo_dir.join(debuginfo_name);
+                    debug!(
+                        "Adding debug info {} to archive at {}",
+                        debuginfo.display(),
+                        dest.display()
+                    );
+                    writer.add_file_force(dest, debuginfo, false)?;
+                } else {
+                    warn!(
+                        "Debug info path {} is neither a file nor a directory, skipping",
+                        debuginfo.display()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn add_out_dir_include(&mut self, target: &Path, source: &Path) -> Result<()> {
+        match self {
+            Self::Editable { base_path, .. } => {
+                let target = base_path.join(target);
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                debug!(
+                    "Installing OUT_DIR file {} from {}",
+                    target.display(),
+                    source.display()
+                );
+                fs::copy(source, &target)?;
+            }
+            Self::Archive { writer } => {
+                let mode = file_permission_mode(source)?;
+                writer.add_file(target, source, permission_is_executable(mode))?;
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Every binding generator ultimately has to install the following:
 /// 1. The python files (if any)
 /// 2. The artifact
@@ -150,149 +408,28 @@ where
         None => PathBuf::from(&context.project.project_layout.extension_name),
     };
 
-    for artifact in artifacts {
-        let artifact = artifact.borrow();
-        let GeneratorOutput {
-            artifact_target,
-            artifact_source_override,
-            additional_files,
-        } = generator.generate_bindings(context, artifact, &module)?;
+    {
+        let mut dest = InstallDest::new(writer, context.project.editable, base_path.as_deref());
+        for artifact in artifacts {
+            let artifact = artifact.borrow();
+            let GeneratorOutput {
+                artifact_target,
+                artifact_source_override,
+                additional_files,
+            } = generator.generate_bindings(context, artifact, &module)?;
+            let source = artifact_source_override.unwrap_or_else(|| artifact.path.clone());
 
-        match (context.project.editable, &base_path) {
-            (true, Some(base_path)) => {
-                let source = artifact_source_override.unwrap_or_else(|| artifact.path.clone());
-                // Compute the directory where debug info files should be placed.
-                // For extension modules (e.g. CFFI mixed projects) the artifact
-                // may live in a subdirectory of base_path, so we derive the
-                // debug info directory from the artifact's installed location to
-                // keep the .dSYM / .pdb / .dwp next to the library it belongs to.
-                let debuginfo_base = match &artifact_target {
-                    ArtifactTarget::Binary(_) => base_path.clone(),
-                    ArtifactTarget::ExtensionModule(path) => base_path
-                        .join(path)
-                        .parent()
-                        .map(|p| p.to_path_buf())
-                        .unwrap_or_else(|| base_path.clone()),
-                };
-                match artifact_target {
-                    ArtifactTarget::Binary(path) => {
-                        // Use add_file_force to bypass exclusion checks for the compiled artifact
-                        writer.add_file_force(path, source, true)?;
-                    }
-                    ArtifactTarget::ExtensionModule(path) => {
-                        let target = base_path.join(path);
-                        debug!("Removing previously built module {}", target.display());
-                        fs::create_dir_all(target.parent().unwrap())?;
-                        // Remove existing so file to avoid triggering SIGSEV in running process
-                        // See https://github.com/PyO3/maturin/issues/758
-                        let _ = fs::remove_file(&target);
-
-                        // 2a. Install the artifact
-                        debug!("Installing {} from {}", target.display(), source.display());
-                        fs::copy(&source, &target).with_context(|| {
-                            format!(
-                                "Failed to copy {} to {}",
-                                source.display(),
-                                target.display(),
-                            )
-                        })?;
-                    }
-                }
-
-                // 3a. Install additional files
-                for (target, source) in additional_files {
-                    let target = base_path.join(target);
-                    fs::create_dir_all(target.parent().unwrap())?;
-                    debug!("Generating file {}", target.display());
-                    let mut options = File::options();
-                    options.write(true).create(true).truncate(true);
-                    #[cfg(unix)]
-                    {
-                        options.mode(default_permission(source.executable()));
-                    }
-
-                    let mut file = options.open(&target)?;
-                    match source {
-                        ArchiveSource::Generated(source) => file.write_all(&source.data)?,
-                        ArchiveSource::File(source) => {
-                            let mut source = File::options().read(true).open(source.path)?;
-                            io::copy(&mut source, &mut file)?;
-                        }
-                    }
-                }
-
-                // 4a. Install import library on Windows
-                if let Some(import_lib) = &artifact.import_lib_path
-                    && context.artifact.include_import_lib
-                {
-                    let target = base_path.join(import_lib.file_name().unwrap());
-                    fs::create_dir_all(target.parent().unwrap())?;
-                    debug!("Installing import library {}", target.display());
-                    fs::copy(import_lib, &target)?;
-                }
-
-                // 5a. Install debug info files
-                if let Some(debuginfo) = &artifact.debuginfo_path
-                    && context.artifact.include_debuginfo
-                {
-                    install_debuginfo_editable(debuginfo, &debuginfo_base)?;
-                }
+            dest.add_artifact(&artifact_target, &source)?;
+            dest.add_generated_files(additional_files)?;
+            if let Some(import_lib) = &artifact.import_lib_path
+                && context.artifact.include_import_lib
+            {
+                dest.add_import_lib(import_lib, &module)?;
             }
-            _ => {
-                // 2b. Install the artifact
-                let source = artifact_source_override.unwrap_or_else(|| artifact.path.clone());
-                debug!(
-                    "Adding to archive {} from {}",
-                    artifact_target.path().display(),
-                    source.display()
-                );
-                // Use add_file_force to bypass exclusion checks for the compiled artifact
-                writer.add_file_force(artifact_target.path(), source, true)?;
-
-                // 3b. Install additional files
-                for (target, source) in additional_files {
-                    debug!("Generating archive entry {}", target.display());
-                    // Use add_entry_force to bypass exclusion checks for generated binding files
-                    writer.add_entry_force(target, source)?;
-                }
-
-                // 4b. Install import library on Windows
-                if let Some(import_lib) = &artifact.import_lib_path
-                    && context.artifact.include_import_lib
-                {
-                    let dest = module.join(import_lib.file_name().unwrap());
-                    debug!("Adding import library to archive {}", dest.display());
-                    writer.add_file_force(dest, import_lib, false)?;
-                }
-
-                // 5b. Install debug info files
-                if let Some(debuginfo) = &artifact.debuginfo_path
-                    && context.artifact.include_debuginfo
-                {
-                    // Binary artifacts go into the `.data/scripts/` directory.
-                    // The wheel spec only permits regular files in `scripts/`, so
-                    // a `.dSYM` directory bundle (macOS debug info) cannot be
-                    // placed there.  Skip debug-info installation for binaries to
-                    // avoid producing an invalid wheel that tools like uv reject.
-                    if matches!(artifact_target, ArtifactTarget::Binary(_)) {
-                        warn!(
-                            "Skipping debug info for binary artifact in wheel: {} \
-                             (directory bundles such as .dSYM are not permitted in \
-                             the wheel `scripts` directory)",
-                            debuginfo.display()
-                        );
-                    } else {
-                        // Place debug info next to the artifact inside the wheel,
-                        // not at the top-level module (the artifact may be nested
-                        // in a subdirectory for CFFI/UniFFI mixed projects).
-                        let debuginfo_dir = artifact_target
-                            .path()
-                            .parent()
-                            .map(|p| p.to_path_buf())
-                            .unwrap_or_else(|| module.clone());
-                        install_debuginfo_wheel(writer, debuginfo, &debuginfo_dir)?;
-                    }
-                }
+            if let Some(debuginfo) = &artifact.debuginfo_path
+                && context.artifact.include_debuginfo
+            {
+                dest.add_debuginfo(debuginfo, &artifact_target, &module)?;
             }
         }
     }
@@ -322,6 +459,7 @@ where
     if let Some(pyproject) = context.project.pyproject_toml.as_ref()
         && let Some(glob_patterns) = pyproject.include()
     {
+        let mut dest = InstallDest::new(writer, context.project.editable, base_path.as_deref());
         for inc in glob_patterns.iter().filter_map(|p| p.as_out_dir_include()) {
             let pkg_name = inc.crate_name.unwrap_or(&context.project.crate_name);
             let out_dir = out_dirs.get(pkg_name).with_context(|| {
@@ -343,125 +481,12 @@ where
                     out_dir.display()
                 );
             }
-            match (context.project.editable, &base_path) {
-                (true, Some(base_path)) => {
-                    for m in matches {
-                        let target = base_path.join(&m.target);
-                        if let Some(parent) = target.parent() {
-                            fs::create_dir_all(parent)?;
-                        }
-                        debug!(
-                            "Installing OUT_DIR file {} from {}",
-                            target.display(),
-                            m.source.display()
-                        );
-                        fs::copy(&m.source, &target)?;
-                    }
-                }
-                _ => {
-                    for m in matches {
-                        #[cfg(unix)]
-                        let mode = m.source.metadata()?.permissions().mode();
-                        #[cfg(not(unix))]
-                        let mode = 0o644;
-                        writer.add_file(
-                            m.target,
-                            m.source,
-                            crate::module_writer::permission_is_executable(mode),
-                        )?;
-                    }
-                }
+            for m in matches {
+                dest.add_out_dir_include(&m.target, &m.source)?;
             }
         }
     }
 
-    Ok(())
-}
-
-/// Install debug info files for editable installs by copying to the target directory.
-/// Handles both single files (.pdb, .dwp) and directory bundles (.dSYM).
-fn install_debuginfo_editable(debuginfo: &Path, base_path: &Path) -> Result<()> {
-    let debuginfo_name = debuginfo
-        .file_name()
-        .context("Failed to get debug info file name")?;
-    let target = base_path.join(debuginfo_name);
-
-    // Remove stale debuginfo to avoid mixed contents (mirrors the
-    // "remove existing .so" logic for the extension module itself)
-    if target.is_dir() {
-        let _ = fs::remove_dir_all(&target);
-    } else if target.exists() {
-        let _ = fs::remove_file(&target);
-    }
-
-    if debuginfo.is_dir() {
-        // .dSYM is a directory bundle on macOS
-        debug!(
-            "Copying debug info directory {} to {}",
-            debuginfo.display(),
-            target.display()
-        );
-        copy_dir_all(debuginfo, &target)?;
-    } else if debuginfo.is_file() {
-        debug!(
-            "Installing debug info {} to {}",
-            debuginfo.display(),
-            target.display()
-        );
-        fs::create_dir_all(target.parent().unwrap())?;
-        fs::copy(debuginfo, &target)?;
-    } else {
-        warn!(
-            "Debug info path {} is neither a file nor a directory, skipping",
-            debuginfo.display()
-        );
-    }
-    Ok(())
-}
-
-/// Install debug info files into a wheel archive.
-/// Handles both single files (.pdb, .dwp) and directory bundles (.dSYM).
-fn install_debuginfo_wheel(
-    writer: &mut VirtualWriter<WheelWriter>,
-    debuginfo: &Path,
-    module: &Path,
-) -> Result<()> {
-    let debuginfo_name = debuginfo
-        .file_name()
-        .context("Failed to get debug info file name")?;
-
-    if debuginfo.is_dir() {
-        // .dSYM is a directory bundle on macOS — add all files recursively
-        for entry in WalkDir::new(debuginfo).follow_links(true) {
-            let entry = entry?;
-            if entry.file_type().is_file() {
-                let relative = entry
-                    .path()
-                    .strip_prefix(debuginfo)
-                    .context("Failed to compute relative path in debug info bundle")?;
-                let dest = module.join(debuginfo_name).join(relative);
-                debug!(
-                    "Adding debug info {} to archive at {}",
-                    entry.path().display(),
-                    dest.display()
-                );
-                writer.add_file_force(dest, entry.path(), false)?;
-            }
-        }
-    } else if debuginfo.is_file() {
-        let dest = module.join(debuginfo_name);
-        debug!(
-            "Adding debug info {} to archive at {}",
-            debuginfo.display(),
-            dest.display()
-        );
-        writer.add_file_force(dest, debuginfo, false)?;
-    } else {
-        warn!(
-            "Debug info path {} is neither a file nor a directory, skipping",
-            debuginfo.display()
-        );
-    }
     Ok(())
 }
 

--- a/src/build_context/builder.rs
+++ b/src/build_context/builder.rs
@@ -228,7 +228,7 @@ impl BuildContextBuilder {
             .unwrap_or_else(|| cargo_metadata.target_directory.clone().into_std_path_buf());
 
         let config_targets = pyproject.and_then(|x| x.targets());
-        let compile_targets = filter_cargo_targets(&cargo_metadata, bridge, config_targets)?;
+        let compile_targets = filter_cargo_targets(&cargo_metadata, &bridge, config_targets)?;
         if compile_targets.is_empty() {
             bail!(
                 "No Cargo targets to build, please check your bindings configuration in pyproject.toml."
@@ -267,6 +267,7 @@ impl BuildContextBuilder {
 
         Ok(BuildContext {
             project: ProjectContext {
+                bridge,
                 target,
                 project_layout,
                 pyproject_toml_path,

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 /// is generally independent of the target Python interpreter.
 #[derive(Clone, Debug)]
 pub struct ProjectContext {
+    /// The bridge model used by this project
+    pub bridge: BridgeModel,
     /// The platform, i.e. os and pointer width
     pub target: Target,
     /// Whether this project is pure rust or rust mixed with python
@@ -62,8 +64,7 @@ pub struct ProjectContext {
 impl ProjectContext {
     /// Bridge model
     pub fn bridge(&self) -> &BridgeModel {
-        // FIXME: currently we only allow multiple bin targets so bridges are all the same
-        &self.compile_targets[0].bridge_model
+        &self.bridge
     }
 
     /// Returns the platform part of the tag for the wheel name

--- a/src/build_context/mod.rs
+++ b/src/build_context/mod.rs
@@ -7,7 +7,6 @@ pub(crate) use repair::finalize_staged_artifacts;
 use crate::auditwheel::AuditWheelMode;
 use crate::auditwheel::PlatformTag;
 use crate::cargo_options::CargoOptions;
-use crate::compile::CompileTarget;
 use crate::compression::CompressionOptions;
 use crate::pgo::PgoPhase;
 use crate::project_layout::ProjectLayout;
@@ -58,7 +57,7 @@ pub struct ProjectContext {
     /// Cargo features conditionally enabled based on the target Python version/implementation
     pub conditional_features: Vec<ConditionalFeature>,
     /// List of Cargo targets to compile
-    pub compile_targets: Vec<CompileTarget>,
+    pub compile_targets: Vec<cargo_metadata::Target>,
 }
 
 impl ProjectContext {

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -10,6 +10,7 @@ use crate::pgo::{PgoContext, PgoPhase};
 use crate::sbom::SbomData;
 use crate::source_distribution::source_distribution;
 use crate::target::{WheelTag, validate_wheel_filename_for_pypi};
+use crate::ui;
 use crate::util::zip_mtime;
 use crate::{
     BridgeModel, BuildArtifact, BuildContext, BuiltArtifactTag, BuiltWheel, Metadata24,
@@ -59,7 +60,7 @@ impl<'a> BuildOrchestrator<'a> {
                 })
             );
 
-            eprintln!("🚀 Starting PGO build...");
+            ui::status!("🚀 Starting PGO build...");
             PgoContext::find_llvm_profdata()?;
 
             return if needs_per_interpreter_pgo {
@@ -96,7 +97,7 @@ impl<'a> BuildOrchestrator<'a> {
             |optimized_orchestrator| optimized_orchestrator.build_wheels_inner(),
         )?;
 
-        eprintln!("🎉 PGO build complete!");
+        ui::status!("🎉 PGO build complete!");
         Ok(wheels)
     }
 
@@ -109,7 +110,7 @@ impl<'a> BuildOrchestrator<'a> {
         let mut wheels = Vec::new();
 
         for (i, python_interpreter) in self.context.python.interpreter.iter().enumerate() {
-            eprintln!(
+            ui::status!(
                 "📊 [{}/{}] PGO cycle for {} {}.{}...",
                 i + 1,
                 self.context.python.interpreter.len(),
@@ -133,7 +134,7 @@ impl<'a> BuildOrchestrator<'a> {
                 },
             )?;
 
-            eprintln!(
+            ui::status!(
                 "  📦 Built PGO-optimized wheel for {} {}.{}{} to {}",
                 python_interpreter.interpreter_kind,
                 python_interpreter.major,
@@ -146,7 +147,7 @@ impl<'a> BuildOrchestrator<'a> {
 
         self.validate_wheels_for_pypi(&wheels)?;
 
-        eprintln!("🎉 PGO build complete!");
+        ui::status!("🎉 PGO build complete!");
         Ok(wheels)
     }
 
@@ -169,7 +170,7 @@ impl<'a> BuildOrchestrator<'a> {
     {
         let pgo_ctx = PgoContext::new(pgo_command)?;
 
-        eprintln!("{message_prefix}📊 Phase 1/3: Building instrumented wheel...");
+        ui::status!("{message_prefix}📊 Phase 1/3: Building instrumented wheel...");
         let mut instrumented_ctx = self.clone_context_for_pgo(PgoPhase::Generate(
             pgo_ctx.profdata_dir_path().to_path_buf(),
         ));
@@ -181,7 +182,7 @@ impl<'a> BuildOrchestrator<'a> {
         let instrumented_orchestrator = BuildOrchestrator::new(&instrumented_ctx);
         let instrumented_wheel_path = build_instrumented_wheel(&instrumented_orchestrator)?;
 
-        eprintln!("{message_prefix}🔬 Phase 2/3: Running PGO instrumentation...");
+        ui::status!("{message_prefix}🔬 Phase 2/3: Running PGO instrumentation...");
         pgo_ctx.run_instrumentation(
             instrumentation_python,
             &instrumented_wheel_path,
@@ -189,7 +190,7 @@ impl<'a> BuildOrchestrator<'a> {
         )?;
         pgo_ctx.merge_profiles()?;
 
-        eprintln!("{message_prefix}⚡ Phase 3/3: Building PGO-optimized wheel...");
+        ui::status!("{message_prefix}⚡ Phase 3/3: Building PGO-optimized wheel...");
         let optimized_ctx =
             self.clone_context_for_pgo(PgoPhase::Use(pgo_ctx.merged_profdata_path().to_path_buf()));
         let optimized_orchestrator = BuildOrchestrator::new(&optimized_ctx);
@@ -463,7 +464,7 @@ impl<'a> BuildOrchestrator<'a> {
                 .iter()
                 .map(|interp| interp.to_string())
                 .collect();
-            eprintln!(
+            ui::warning!(
                 "⚠️ Warning: {} does not yet support {} so the build artifacts will be version-specific.",
                 stable_abi.kind,
                 interp_names.iter().join(", ")
@@ -599,7 +600,7 @@ impl<'a> BuildOrchestrator<'a> {
             &out_dirs,
         )?;
 
-        eprintln!(
+        ui::status!(
             "📦 Built wheel for {} Python ≥ {}.{} to {}",
             stable_abi.kind,
             major,
@@ -676,7 +677,7 @@ impl<'a> BuildOrchestrator<'a> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
             let wheel = self.build_single_pyo3_wheel(python_interpreter, sbom_data)?;
-            eprintln!(
+            ui::status!(
                 "📦 Built wheel for {} {}.{}{} to {}",
                 python_interpreter.interpreter_kind,
                 python_interpreter.major,
@@ -786,13 +787,13 @@ impl<'a> BuildOrchestrator<'a> {
             .iter()
             .any(|requirement| requirement.name.as_ref() == "cffi")
         {
-            eprintln!(
+            ui::warning!(
                 "⚠️  Warning: missing cffi package dependency, please add it to pyproject.toml. \
                 e.g: `dependencies = [\"cffi\"]`. This will become an error."
             );
         }
 
-        eprintln!("📦 Built wheel to {}", wheel_path.display());
+        ui::status!("📦 Built wheel to {}", wheel_path.display());
         Ok(vec![BuiltWheel {
             path: wheel_path,
             tag: BuiltArtifactTag::Universal,
@@ -805,7 +806,7 @@ impl<'a> BuildOrchestrator<'a> {
         let (wheel_path, _) =
             self.build_cdylib_wheel(|_temp_dir| Ok(UniFfiBindingGenerator::default()), sbom_data)?;
 
-        eprintln!("📦 Built wheel to {}", wheel_path.display());
+        ui::status!("📦 Built wheel to {}", wheel_path.display());
         Ok(vec![BuiltWheel {
             path: wheel_path,
             tag: BuiltArtifactTag::Universal,
@@ -826,7 +827,7 @@ impl<'a> BuildOrchestrator<'a> {
         }
 
         if self.context.project.target.is_wasi() {
-            eprintln!("⚠️  Warning: wasi support is experimental");
+            ui::warning!("⚠️  Warning: wasi support is experimental");
             if !self.context.project.metadata24.entry_points.is_empty() {
                 bail!("You can't define entrypoints yourself for a binary project");
             }
@@ -920,7 +921,7 @@ impl<'a> BuildOrchestrator<'a> {
             sbom_data,
             &result.out_dirs,
         )?;
-        eprintln!("📦 Built wheel to {}", wheel_path.display());
+        ui::status!("📦 Built wheel to {}", wheel_path.display());
         // Interpreter-bound binary wheels (pyo3-bin) carry a real python tag; pure
         // standalone bins remain universal (`py3`).
         let artifact_tag = if python_interpreter.is_some() {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -48,13 +48,6 @@ pub(crate) fn missing_cdylib_error(arch: Option<&str>) -> anyhow::Error {
     anyhow!("{}", missing_cdylib_message(arch))
 }
 
-/// A cargo target to build
-#[derive(Debug, Clone)]
-pub struct CompileTarget {
-    /// The cargo target to build
-    pub target: cargo_metadata::Target,
-}
-
 /// A single-architecture thin binary artifact for universal2 builds.
 ///
 /// Used during macOS wheel repair to analyze dependencies per-architecture,
@@ -150,7 +143,7 @@ pub struct CompileResult {
 pub fn compile(
     context: &BuildContext,
     python_interpreter: Option<&PythonInterpreter>,
-    targets: &[CompileTarget],
+    targets: &[cargo_metadata::Target],
 ) -> Result<CompileResult> {
     if context.project.universal2 {
         compile_universal2(context, python_interpreter, targets)
@@ -164,7 +157,7 @@ pub(crate) fn filter_cargo_targets(
     cargo_metadata: &cargo_metadata::Metadata,
     bridge: &BridgeModel,
     config_targets: Option<&[crate::pyproject_toml::CargoTarget]>,
-) -> Result<Vec<CompileTarget>> {
+) -> Result<Vec<cargo_metadata::Target>> {
     let root_pkg = cargo_metadata
         .root_package()
         .ok_or_else(|| anyhow!("No root package found in cargo metadata"))?;
@@ -193,9 +186,7 @@ pub(crate) fn filter_cargo_targets(
             }
             _ => target.crate_types.contains(&CrateType::CDyLib),
         })
-        .map(|target| CompileTarget {
-            target: target.clone(),
-        })
+        .cloned()
         .collect();
     if targets.is_empty() && !bridge.is_bin() {
         // No `crate-type = ["cdylib"]` in `Cargo.toml`
@@ -207,15 +198,13 @@ pub(crate) fn filter_cargo_targets(
                 .any(|crate_type| LIB_CRATE_TYPES.contains(crate_type))
         });
         if let Some(target) = lib_target {
-            targets.push(CompileTarget {
-                target: target.clone(),
-            });
+            targets.push(target.clone());
         }
     }
 
     // Filter targets by config_targets
     if let Some(config_targets) = config_targets {
-        targets.retain(|CompileTarget { target }| {
+        targets.retain(|target| {
             config_targets.iter().any(|config_target| {
                 let name_eq = config_target.name == target.name;
                 match &config_target.kind {
@@ -231,7 +220,7 @@ pub(crate) fn filter_cargo_targets(
         } else {
             let target_names = targets
                 .iter()
-                .map(|CompileTarget { target }| target.name.as_str())
+                .map(|target| target.name.as_str())
                 .collect::<Vec<_>>();
             eprintln!(
                 "🎯 Found {} Cargo targets in `Cargo.toml`: {}",
@@ -248,7 +237,7 @@ pub(crate) fn filter_cargo_targets(
 fn compile_universal2(
     context: &BuildContext,
     python_interpreter: Option<&PythonInterpreter>,
-    targets: &[CompileTarget],
+    targets: &[cargo_metadata::Target],
 ) -> Result<CompileResult> {
     let mut aarch64_context = context.clone();
     aarch64_context.project.target = Target::from_resolved_target_triple("aarch64-apple-darwin")?;
@@ -359,12 +348,12 @@ fn compile_universal2(
 fn compile_targets(
     context: &BuildContext,
     python_interpreter: Option<&PythonInterpreter>,
-    targets: &[CompileTarget],
+    targets: &[cargo_metadata::Target],
 ) -> Result<CompileResult> {
     let mut artifacts = Vec::with_capacity(targets.len());
     let mut out_dirs = HashMap::new();
-    for target in targets {
-        let build_command = cargo_build_command(context, python_interpreter, target)?;
+    for cargo_target in targets {
+        let build_command = cargo_build_command(context, python_interpreter, cargo_target)?;
         let (target_artifacts, target_out_dirs) = compile_target(context, build_command)?;
         artifacts.push(target_artifacts);
         out_dirs.extend(target_out_dirs);
@@ -378,7 +367,7 @@ fn compile_targets(
 fn cargo_build_command(
     context: &BuildContext,
     python_interpreter: Option<&PythonInterpreter>,
-    compile_target: &CompileTarget,
+    cargo_target: &cargo_metadata::Target,
 ) -> Result<Command> {
     use crate::pyproject_toml::{FeatureConditionEnv, FeatureSpec};
 
@@ -419,8 +408,7 @@ fn cargo_build_command(
     cargo_rustc.message_format = vec!["json-render-diagnostics".to_string()];
 
     // Add `--crate-type cdylib` if available
-    if compile_target
-        .target
+    if cargo_target
         .crate_types
         .iter()
         .any(|crate_type| LIB_CRATE_TYPES.contains(crate_type))
@@ -461,7 +449,7 @@ fn cargo_build_command(
     configure_bin_lib_flags(
         &mut cargo_rustc,
         &mut rustflags,
-        compile_target,
+        cargo_target,
         bridge_model,
         target,
     );
@@ -510,13 +498,13 @@ fn cargo_build_command(
 fn configure_bin_lib_flags(
     cargo_rustc: &mut cargo_options::Rustc,
     rustflags: &mut cargo_config2::Flags,
-    compile_target: &CompileTarget,
+    cargo_target: &cargo_metadata::Target,
     bridge_model: &BridgeModel,
     target: &Target,
 ) {
     match bridge_model {
         BridgeModel::Bin(..) => {
-            cargo_rustc.bin.push(compile_target.target.name.clone());
+            cargo_rustc.bin.push(cargo_target.name.clone());
         }
         BridgeModel::Cffi | BridgeModel::UniFfi | BridgeModel::PyO3 { .. } => {
             cargo_rustc.lib = true;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -53,8 +53,6 @@ pub(crate) fn missing_cdylib_error(arch: Option<&str>) -> anyhow::Error {
 pub struct CompileTarget {
     /// The cargo target to build
     pub target: cargo_metadata::Target,
-    /// The bridge model to use
-    pub bridge_model: BridgeModel,
 }
 
 /// A single-architecture thin binary artifact for universal2 builds.
@@ -164,7 +162,7 @@ pub fn compile(
 /// Filter cargo targets based on bridge model and optional configuration.
 pub(crate) fn filter_cargo_targets(
     cargo_metadata: &cargo_metadata::Metadata,
-    bridge: BridgeModel,
+    bridge: &BridgeModel,
     config_targets: Option<&[crate::pyproject_toml::CargoTarget]>,
 ) -> Result<Vec<CompileTarget>> {
     let root_pkg = cargo_metadata
@@ -197,7 +195,6 @@ pub(crate) fn filter_cargo_targets(
         })
         .map(|target| CompileTarget {
             target: target.clone(),
-            bridge_model: bridge.clone(),
         })
         .collect();
     if targets.is_empty() && !bridge.is_bin() {
@@ -212,14 +209,13 @@ pub(crate) fn filter_cargo_targets(
         if let Some(target) = lib_target {
             targets.push(CompileTarget {
                 target: target.clone(),
-                bridge_model: bridge,
             });
         }
     }
 
     // Filter targets by config_targets
     if let Some(config_targets) = config_targets {
-        targets.retain(|CompileTarget { target, .. }| {
+        targets.retain(|CompileTarget { target }| {
             config_targets.iter().any(|config_target| {
                 let name_eq = config_target.name == target.name;
                 match &config_target.kind {
@@ -235,7 +231,7 @@ pub(crate) fn filter_cargo_targets(
         } else {
             let target_names = targets
                 .iter()
-                .map(|CompileTarget { target, .. }| target.name.as_str())
+                .map(|CompileTarget { target }| target.name.as_str())
                 .collect::<Vec<_>>();
             eprintln!(
                 "🎯 Found {} Cargo targets in `Cargo.toml`: {}",
@@ -266,19 +262,16 @@ fn compile_universal2(
         .context("Failed to build a x86_64 library through cargo")?;
 
     let mut universal_artifacts = Vec::with_capacity(targets.len());
-    for (bridge_model, (aarch64_artifact, x86_64_artifact)) in
-        targets.iter().map(|target| &target.bridge_model).zip(
-            aarch64_result
-                .artifacts
-                .iter()
-                .zip(&x86_64_result.artifacts),
-        )
+    let build_type = if context.project.bridge().is_bin() {
+        CrateType::Bin
+    } else {
+        CrateType::CDyLib
+    };
+    for (aarch64_artifact, x86_64_artifact) in aarch64_result
+        .artifacts
+        .iter()
+        .zip(&x86_64_result.artifacts)
     {
-        let build_type = if bridge_model.is_bin() {
-            CrateType::Bin
-        } else {
-            CrateType::CDyLib
-        };
         let aarch64_artifact = aarch64_artifact.get(&build_type).cloned().ok_or_else(|| {
             if build_type == CrateType::CDyLib {
                 missing_cdylib_error(Some("aarch64"))
@@ -350,7 +343,7 @@ fn compile_universal2(
             thin_artifacts,
             staging: CargoOutputState::NotStaged,
         };
-        result.insert(build_type, universal_artifact);
+        result.insert(build_type.clone(), universal_artifact);
         universal_artifacts.push(result);
     }
     // Note: we use x86_64 OUT_DIR paths for universal2 builds.
@@ -464,7 +457,7 @@ fn cargo_build_command(
         }
     }
 
-    let bridge_model = &compile_target.bridge_model;
+    let bridge_model = context.project.bridge();
     configure_bin_lib_flags(
         &mut cargo_rustc,
         &mut rustflags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod source_distribution;
 mod target;
 #[cfg(test)]
 mod test_utils;
+pub(crate) mod ui;
 #[cfg(feature = "upload")]
 mod upload;
 pub(crate) mod util;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,19 @@
+//! User-facing output facade.
+//!
+//! This is the single seam for later `--quiet` and JSON output support, introduced by
+//! the refactor plan item "Route user-facing output through a small facade".
+
+macro_rules! status {
+    ($($arg:tt)*) => {
+        eprintln!($($arg)*)
+    };
+}
+
+macro_rules! warning {
+    ($($arg:tt)*) => {
+        eprintln!($($arg)*)
+    };
+}
+
+pub(crate) use status;
+pub(crate) use warning;


### PR DESCRIPTION
- **InstallDest abstraction** — Consolidate editable vs archive install paths in `binding_generator` behind a private `InstallDest` enum (artifact placement, generated bindings, Windows import libs, debug info, `OUT_DIR` includes), so each concern is written once instead of twice.
- **Single `BridgeModel` on `ProjectContext`** — Stop cloning the bridge model onto every `CompileTarget`; `ProjectContext` owns it and `bridge()` is a plain accessor (removes `compile_targets[0]` indexing / FIXME).
- **`ui` output facade** — Add crate-internal `ui::status!` / `ui::warning!` macros (currently `eprintln!` passthroughs) as the seam for future `--quiet` / JSON output, and route `build_orchestrator` user messages through them. Output verified byte-identical.