### PR TITLE
refactor build so that pgo is part of normal pathway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ test-crates/targets/
 test-crates/venvs/
 test-crates/wheels/
 test-crates/case-packages/
+test-targets/
 venv*/

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -63,13 +63,13 @@ impl<'a> BuildOrchestrator<'a> {
     }
 
     /// Wrapper around a single wheel build that runs a PGO cycle if needed
-    fn build_single_unit<F>(
+    fn build_single_wheel<F>(
         &self,
         instrumentation_python: Option<&PythonInterpreter>,
         build: F,
-    ) -> Result<Vec<BuiltWheel>>
+    ) -> Result<BuiltWheel>
     where
-        F: for<'ctx> Fn(&BuildOrchestrator<'ctx>) -> Result<Vec<BuiltWheel>>,
+        F: for<'ctx> Fn(&BuildOrchestrator<'ctx>) -> Result<BuiltWheel>,
     {
         let Some(pgo_command) = self.context.artifact.pgo_command.clone() else {
             return build(self);
@@ -82,14 +82,7 @@ impl<'a> BuildOrchestrator<'a> {
             pgo_command,
             instrumentation_python,
             "",
-            |instrumented| {
-                let wheels = build(instrumented)?;
-                Ok(wheels
-                    .first()
-                    .context("No instrumented wheel was built")?
-                    .path
-                    .clone())
-            },
+            |instrumented| Ok(build(instrumented)?.path),
             |optimized| build(optimized),
         )
     }
@@ -148,25 +141,28 @@ impl<'a> BuildOrchestrator<'a> {
         let sbom_data = SbomData::generate(self.context)?;
 
         let interpreters: Vec<_> = self.context.python.interpreter.iter().collect();
-        let wheels = match self.context.project.bridge() {
-            BridgeModel::Bin(None) => self
-                .build_single_unit(interpreters.first().copied(), |orchestrator| {
-                    orchestrator.build_bin_wheel(None, &sbom_data)
-                })?,
-            BridgeModel::Bin(Some(..)) => self.build_bin_wheels(&interpreters, &sbom_data)?,
-            BridgeModel::PyO3(crate::PyO3 { stable_abi, .. }) => match stable_abi {
-                Some(stable_abi) => self.build_stable_abi_wheels(stable_abi, &sbom_data)?,
-                None => self.build_pyo3_wheels(&interpreters, &sbom_data)?,
-            },
-            BridgeModel::Cffi => self
-                .build_single_unit(self.context.python.interpreter.first(), |orchestrator| {
-                    orchestrator.build_cffi_wheel(&sbom_data)
-                })?,
-            BridgeModel::UniFfi => self
-                .build_single_unit(interpreters.first().copied(), |orchestrator| {
-                    orchestrator.build_uniffi_wheel(&sbom_data)
-                })?,
-        };
+        let wheels =
+            match self.context.project.bridge() {
+                BridgeModel::Bin(None) => vec![
+                    self.build_single_wheel(interpreters.first().copied(), |orchestrator| {
+                        orchestrator.build_bin_wheel(None, &sbom_data)
+                    })?,
+                ],
+                BridgeModel::Bin(Some(..)) => self.build_bin_wheels(&interpreters, &sbom_data)?,
+                BridgeModel::PyO3(crate::PyO3 { stable_abi, .. }) => match stable_abi {
+                    Some(stable_abi) => self.build_stable_abi_wheels(stable_abi, &sbom_data)?,
+                    None => self.build_pyo3_wheels(&interpreters, &sbom_data)?,
+                },
+                BridgeModel::Cffi => vec![self.build_single_wheel(
+                    self.context.python.interpreter.first(),
+                    |orchestrator| orchestrator.build_cffi_wheel(&sbom_data),
+                )?],
+                BridgeModel::UniFfi => vec![
+                    self.build_single_wheel(interpreters.first().copied(), |orchestrator| {
+                        orchestrator.build_uniffi_wheel(&sbom_data)
+                    })?,
+                ],
+            };
 
         self.validate_wheels_for_pypi(&wheels)?;
 
@@ -400,7 +396,7 @@ impl<'a> BuildOrchestrator<'a> {
         let mut built_wheels = Vec::new();
         if let Some(first) = stable_abi_interps.first() {
             let (major, minor) = min_version.unwrap_or((first.major as u8, first.minor as u8));
-            built_wheels.extend(self.build_single_unit(Some(first), |orchestrator| {
+            built_wheels.push(self.build_single_wheel(Some(first), |orchestrator| {
                 orchestrator.build_pyo3_wheel_stable_abi(
                     &stable_abi_interps,
                     *stable_abi,
@@ -523,8 +519,7 @@ impl<'a> BuildOrchestrator<'a> {
         major: u8,
         min_minor: u8,
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheel>> {
-        let mut wheels = Vec::new();
+    ) -> Result<BuiltWheel> {
         let python_interpreter = interpreters.first().copied();
         let (audited_artifact, policy, out_dirs) = self.compile_and_audit(
             python_interpreter,
@@ -558,12 +553,10 @@ impl<'a> BuildOrchestrator<'a> {
             min_minor,
             wheel_path.display()
         );
-        wheels.push(BuiltWheel {
+        Ok(BuiltWheel {
             path: wheel_path,
             tag: BuiltArtifactTag::interpreter(tag.python()),
-        });
-
-        Ok(wheels)
+        })
     }
 
     /// Writes a PyO3 wheel for a specific Python interpreter.
@@ -627,23 +620,18 @@ impl<'a> BuildOrchestrator<'a> {
     ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
-            let mut unit_wheels =
-                self.build_single_unit(Some(python_interpreter), |orchestrator| {
-                    Ok(vec![
-                        orchestrator.build_single_pyo3_wheel(python_interpreter, sbom_data)?,
-                    ])
-                })?;
-            for wheel in &unit_wheels {
-                ui::status!(
-                    "📦 Built wheel for {} {}.{}{} to {}",
-                    python_interpreter.interpreter_kind,
-                    python_interpreter.major,
-                    python_interpreter.minor,
-                    python_interpreter.abiflags,
-                    wheel.path.display()
-                );
-            }
-            wheels.append(&mut unit_wheels);
+            let wheel = self.build_single_wheel(Some(python_interpreter), |orchestrator| {
+                orchestrator.build_single_pyo3_wheel(python_interpreter, sbom_data)
+            })?;
+            ui::status!(
+                "📦 Built wheel for {} {}.{}{} to {}",
+                python_interpreter.interpreter_kind,
+                python_interpreter.major,
+                python_interpreter.minor,
+                python_interpreter.abiflags,
+                wheel.path.display()
+            );
+            wheels.push(wheel);
         }
 
         Ok(wheels)
@@ -725,7 +713,7 @@ impl<'a> BuildOrchestrator<'a> {
 
     /// Builds a wheel with cffi bindings
     #[instrument(skip_all)]
-    fn build_cffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheel>> {
+    fn build_cffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<BuiltWheel> {
         let interpreter = self.context.python.interpreter.first().ok_or_else(|| {
             anyhow!("A python interpreter is required for cffi builds but one was not provided")
         })?;
@@ -752,23 +740,23 @@ impl<'a> BuildOrchestrator<'a> {
         }
 
         ui::status!("📦 Built wheel to {}", wheel_path.display());
-        Ok(vec![BuiltWheel {
+        Ok(BuiltWheel {
             path: wheel_path,
             tag: BuiltArtifactTag::Universal,
-        }])
+        })
     }
 
     /// Builds a wheel with uniffi bindings
     #[instrument(skip_all)]
-    fn build_uniffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<Vec<BuiltWheel>> {
+    fn build_uniffi_wheel(&self, sbom_data: &Option<SbomData>) -> Result<BuiltWheel> {
         let (wheel_path, _) =
             self.build_cdylib_wheel(|_temp_dir| Ok(UniFfiBindingGenerator::default()), sbom_data)?;
 
         ui::status!("📦 Built wheel to {}", wheel_path.display());
-        Ok(vec![BuiltWheel {
+        Ok(BuiltWheel {
             path: wheel_path,
             tag: BuiltArtifactTag::Universal,
-        }])
+        })
     }
 
     /// Internal implementation for writing a binary wheel.
@@ -837,8 +825,7 @@ impl<'a> BuildOrchestrator<'a> {
         &self,
         python_interpreter: Option<&PythonInterpreter>,
         sbom_data: &Option<SbomData>,
-    ) -> Result<Vec<BuiltWheel>> {
-        let mut wheels = Vec::new();
+    ) -> Result<BuiltWheel> {
         let result = compile(
             self.context,
             python_interpreter,
@@ -887,12 +874,10 @@ impl<'a> BuildOrchestrator<'a> {
         } else {
             BuiltArtifactTag::Universal
         };
-        wheels.push(BuiltWheel {
+        Ok(BuiltWheel {
             path: wheel_path,
             tag: artifact_tag,
-        });
-
-        Ok(wheels)
+        })
     }
 
     /// Builds wheels for a binary project for all given python versions.
@@ -904,8 +889,8 @@ impl<'a> BuildOrchestrator<'a> {
     ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
-            wheels.extend(
-                self.build_single_unit(Some(python_interpreter), |orchestrator| {
+            wheels.push(
+                self.build_single_wheel(Some(python_interpreter), |orchestrator| {
                     orchestrator.build_bin_wheel(Some(python_interpreter), sbom_data)
                 })?,
             );

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -51,120 +51,75 @@ impl<'a> BuildOrchestrator<'a> {
     /// correct builder.
     #[instrument(skip_all)]
     pub fn build_wheels(&self) -> Result<Vec<BuiltWheel>> {
-        if let Some(pgo_command) = &self.context.artifact.pgo_command {
-            let needs_per_interpreter_pgo = matches!(
-                self.context.project.bridge(),
-                BridgeModel::PyO3(crate::PyO3 {
-                    stable_abi: None,
-                    ..
-                })
-            );
-
+        if self.context.artifact.pgo_command.is_some() {
             ui::status!("🚀 Starting PGO build...");
             PgoContext::find_llvm_profdata()?;
-
-            return if needs_per_interpreter_pgo {
-                self.build_wheels_pgo_per_interpreter(pgo_command.clone())
-            } else {
-                self.build_wheels_pgo_single_pass(pgo_command.clone())
-            };
         }
-        self.build_wheels_inner()
+        let wheels = self.build_wheels_inner()?;
+        if self.context.artifact.pgo_command.is_some() {
+            ui::status!("🎉 PGO build complete!");
+        }
+        Ok(wheels)
     }
 
-    /// Single-pass PGO for abi3, cffi, uniffi, and bin builds.
-    fn build_wheels_pgo_single_pass(&self, pgo_command: String) -> Result<Vec<BuiltWheel>> {
-        let instrumentation_python = self.context.python.interpreter.first().context(
-            "PGO builds require a Python interpreter. \
-                 Please specify one with `--interpreter`.",
+    /// Wrapper around a single wheel build that runs a PGO cycle if needed
+    fn build_single_unit<F>(
+        &self,
+        instrumentation_python: Option<&PythonInterpreter>,
+        build: F,
+    ) -> Result<Vec<BuiltWheel>>
+    where
+        F: for<'ctx> Fn(&BuildOrchestrator<'ctx>) -> Result<Vec<BuiltWheel>>,
+    {
+        let Some(pgo_command) = self.context.artifact.pgo_command.clone() else {
+            return build(self);
+        };
+        let instrumentation_python = instrumentation_python.context(
+            "PGO builds require a Python interpreter. Please specify one with `--interpreter`.",
         )?;
 
-        let wheels = self.run_pgo_cycle(
+        self.run_pgo_cycle(
             pgo_command,
             instrumentation_python,
             "",
-            |instrumented_ctx| {
-                instrumented_ctx.python.interpreter = vec![instrumentation_python.clone()];
-            },
-            |instrumented_orchestrator| {
-                let instrumented_wheels = instrumented_orchestrator.build_wheels_inner()?;
-                Ok(instrumented_wheels
+            |instrumented| {
+                let wheels = build(instrumented)?;
+                Ok(wheels
                     .first()
                     .context("No instrumented wheel was built")?
                     .path
                     .clone())
             },
-            |optimized_orchestrator| optimized_orchestrator.build_wheels_inner(),
-        )?;
-
-        ui::status!("🎉 PGO build complete!");
-        Ok(wheels)
+            |optimized| build(optimized),
+        )
     }
 
-    /// Per-interpreter PGO for non-abi3 PyO3 builds.
-    fn build_wheels_pgo_per_interpreter(&self, pgo_command: String) -> Result<Vec<BuiltWheel>> {
-        fs::create_dir_all(&self.context.artifact.out)
-            .context("Failed to create the target directory for the wheels")?;
-
-        let sbom_data = SbomData::generate(self.context)?;
-        let mut wheels = Vec::new();
-
-        for (i, python_interpreter) in self.context.python.interpreter.iter().enumerate() {
-            ui::status!(
-                "📊 [{}/{}] PGO cycle for {} {}.{}...",
-                i + 1,
-                self.context.python.interpreter.len(),
-                python_interpreter.interpreter_kind,
-                python_interpreter.major,
-                python_interpreter.minor,
-            );
-
-            let wheel = self.run_pgo_cycle(
-                pgo_command.clone(),
-                python_interpreter,
-                "  ",
-                |_| {},
-                |instrumented_orchestrator| {
-                    let instrumented_wheel = instrumented_orchestrator
-                        .build_single_pyo3_wheel(python_interpreter, &sbom_data)?;
-                    Ok(instrumented_wheel.path)
-                },
-                |optimized_orchestrator| {
-                    optimized_orchestrator.build_single_pyo3_wheel(python_interpreter, &sbom_data)
-                },
-            )?;
-
-            ui::status!(
-                "  📦 Built PGO-optimized wheel for {} {}.{}{} to {}",
-                python_interpreter.interpreter_kind,
-                python_interpreter.major,
-                python_interpreter.minor,
-                python_interpreter.abiflags,
-                wheel.path.display()
-            );
-            wheels.push(wheel);
+    fn pgo_instrumentation_interpreter(&self) -> Result<Option<&PythonInterpreter>> {
+        if self.context.artifact.pgo_command.is_none() {
+            return Ok(None);
         }
-
-        self.validate_wheels_for_pypi(&wheels)?;
-
-        ui::status!("🎉 PGO build complete!");
-        Ok(wheels)
+        self.context
+            .python
+            .interpreter
+            .first()
+            .context(
+                "PGO builds require a Python interpreter. Please specify one with `--interpreter`.",
+            )
+            .map(Some)
     }
 
     /// Runs the shared PGO cycle: instrumented build, instrumentation, then optimized build.
     ///
     /// `message_prefix` preserves user-visible indentation for per-interpreter PGO output.
-    fn run_pgo_cycle<T, ConfigureInstrumented, BuildInstrumented, BuildOptimized>(
+    fn run_pgo_cycle<T, BuildInstrumented, BuildOptimized>(
         &self,
         pgo_command: String,
         instrumentation_python: &PythonInterpreter,
         message_prefix: &str,
-        configure_instrumented_context: ConfigureInstrumented,
         build_instrumented_wheel: BuildInstrumented,
         build_optimized_wheels: BuildOptimized,
     ) -> Result<T>
     where
-        ConfigureInstrumented: FnOnce(&mut BuildContext),
         BuildInstrumented: for<'ctx> FnOnce(&BuildOrchestrator<'ctx>) -> Result<PathBuf>,
         BuildOptimized: for<'ctx> FnOnce(&BuildOrchestrator<'ctx>) -> Result<T>,
     {
@@ -174,7 +129,6 @@ impl<'a> BuildOrchestrator<'a> {
         let mut instrumented_ctx = self.clone_context_for_pgo(PgoPhase::Generate(
             pgo_ctx.profdata_dir_path().to_path_buf(),
         ));
-        configure_instrumented_context(&mut instrumented_ctx);
         let instrumented_out =
             tempfile::TempDir::new().context("Failed to create temp dir for instrumented wheel")?;
         instrumented_ctx.artifact.out = instrumented_out.path().to_path_buf();
@@ -209,14 +163,23 @@ impl<'a> BuildOrchestrator<'a> {
 
         let interpreters: Vec<_> = self.context.python.interpreter.iter().collect();
         let wheels = match self.context.project.bridge() {
-            BridgeModel::Bin(None) => self.build_bin_wheel(None, &sbom_data)?,
+            BridgeModel::Bin(None) => self
+                .build_single_unit(self.pgo_instrumentation_interpreter()?, |orchestrator| {
+                    orchestrator.build_bin_wheel(None, &sbom_data)
+                })?,
             BridgeModel::Bin(Some(..)) => self.build_bin_wheels(&interpreters, &sbom_data)?,
             BridgeModel::PyO3(crate::PyO3 { stable_abi, .. }) => match stable_abi {
                 Some(stable_abi) => self.build_stable_abi_wheels(stable_abi, &sbom_data)?,
                 None => self.build_pyo3_wheels(&interpreters, &sbom_data)?,
             },
-            BridgeModel::Cffi => self.build_cffi_wheel(&sbom_data)?,
-            BridgeModel::UniFfi => self.build_uniffi_wheel(&sbom_data)?,
+            BridgeModel::Cffi => self
+                .build_single_unit(self.context.python.interpreter.first(), |orchestrator| {
+                    orchestrator.build_cffi_wheel(&sbom_data)
+                })?,
+            BridgeModel::UniFfi => self
+                .build_single_unit(self.pgo_instrumentation_interpreter()?, |orchestrator| {
+                    orchestrator.build_uniffi_wheel(&sbom_data)
+                })?,
         };
 
         self.validate_wheels_for_pypi(&wheels)?;
@@ -451,13 +414,15 @@ impl<'a> BuildOrchestrator<'a> {
         let mut built_wheels = Vec::new();
         if let Some(first) = stable_abi_interps.first() {
             let (major, minor) = min_version.unwrap_or((first.major as u8, first.minor as u8));
-            built_wheels.extend(self.build_pyo3_wheel_stable_abi(
-                &stable_abi_interps,
-                *stable_abi,
-                major,
-                minor,
-                sbom_data,
-            )?);
+            built_wheels.extend(self.build_single_unit(Some(first), |orchestrator| {
+                orchestrator.build_pyo3_wheel_stable_abi(
+                    &stable_abi_interps,
+                    *stable_abi,
+                    major,
+                    minor,
+                    sbom_data,
+                )
+            })?);
         }
         if !version_specific_abi_interps.is_empty() {
             let interp_names: HashSet<_> = version_specific_abi_interps
@@ -676,16 +641,23 @@ impl<'a> BuildOrchestrator<'a> {
     ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
-            let wheel = self.build_single_pyo3_wheel(python_interpreter, sbom_data)?;
-            ui::status!(
-                "📦 Built wheel for {} {}.{}{} to {}",
-                python_interpreter.interpreter_kind,
-                python_interpreter.major,
-                python_interpreter.minor,
-                python_interpreter.abiflags,
-                wheel.path.display()
-            );
-            wheels.push(wheel);
+            let mut unit_wheels =
+                self.build_single_unit(Some(python_interpreter), |orchestrator| {
+                    Ok(vec![
+                        orchestrator.build_single_pyo3_wheel(python_interpreter, sbom_data)?,
+                    ])
+                })?;
+            for wheel in &unit_wheels {
+                ui::status!(
+                    "📦 Built wheel for {} {}.{}{} to {}",
+                    python_interpreter.interpreter_kind,
+                    python_interpreter.major,
+                    python_interpreter.minor,
+                    python_interpreter.abiflags,
+                    wheel.path.display()
+                );
+            }
+            wheels.append(&mut unit_wheels);
         }
 
         Ok(wheels)
@@ -946,7 +918,11 @@ impl<'a> BuildOrchestrator<'a> {
     ) -> Result<Vec<BuiltWheel>> {
         let mut wheels = Vec::new();
         for &python_interpreter in interpreters {
-            wheels.extend(self.build_bin_wheel(Some(python_interpreter), sbom_data)?);
+            wheels.extend(
+                self.build_single_unit(Some(python_interpreter), |orchestrator| {
+                    orchestrator.build_bin_wheel(Some(python_interpreter), sbom_data)
+                })?,
+            );
         }
         Ok(wheels)
     }

--- a/src/build_orchestrator.rs
+++ b/src/build_orchestrator.rs
@@ -94,20 +94,6 @@ impl<'a> BuildOrchestrator<'a> {
         )
     }
 
-    fn pgo_instrumentation_interpreter(&self) -> Result<Option<&PythonInterpreter>> {
-        if self.context.artifact.pgo_command.is_none() {
-            return Ok(None);
-        }
-        self.context
-            .python
-            .interpreter
-            .first()
-            .context(
-                "PGO builds require a Python interpreter. Please specify one with `--interpreter`.",
-            )
-            .map(Some)
-    }
-
     /// Runs the shared PGO cycle: instrumented build, instrumentation, then optimized build.
     ///
     /// `message_prefix` preserves user-visible indentation for per-interpreter PGO output.
@@ -164,7 +150,7 @@ impl<'a> BuildOrchestrator<'a> {
         let interpreters: Vec<_> = self.context.python.interpreter.iter().collect();
         let wheels = match self.context.project.bridge() {
             BridgeModel::Bin(None) => self
-                .build_single_unit(self.pgo_instrumentation_interpreter()?, |orchestrator| {
+                .build_single_unit(interpreters.first().copied(), |orchestrator| {
                     orchestrator.build_bin_wheel(None, &sbom_data)
                 })?,
             BridgeModel::Bin(Some(..)) => self.build_bin_wheels(&interpreters, &sbom_data)?,
@@ -177,7 +163,7 @@ impl<'a> BuildOrchestrator<'a> {
                     orchestrator.build_cffi_wheel(&sbom_data)
                 })?,
             BridgeModel::UniFfi => self
-                .build_single_unit(self.pgo_instrumentation_interpreter()?, |orchestrator| {
+                .build_single_unit(interpreters.first().copied(), |orchestrator| {
                     orchestrator.build_uniffi_wheel(&sbom_data)
                 })?,
         };

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -224,7 +224,7 @@ impl<'a> InterpreterResolver<'a> {
         match self.bridge {
             BridgeModel::Cffi => self.resolve_single("cffi").map(|i| (vec![i], None)),
             BridgeModel::Bin(None) | BridgeModel::UniFfi => {
-                // A signle interpreter is required for PGO, if the user doesn't
+                // A single interpreter is required for PGO, if the user doesn't
                 // specify any, we don't care and can skip searching.
                 if self.user_interpreters.is_empty() {
                     Ok((vec![], None))

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -223,7 +223,20 @@ impl<'a> InterpreterResolver<'a> {
     pub fn resolve(&self) -> Result<(Vec<PythonInterpreter>, Option<PathBuf>)> {
         match self.bridge {
             BridgeModel::Cffi => self.resolve_single("cffi").map(|i| (vec![i], None)),
-            BridgeModel::Bin(None) | BridgeModel::UniFfi => Ok((vec![], None)),
+            BridgeModel::Bin(None) | BridgeModel::UniFfi => {
+                // A signle interpreter is required for PGO, if the user doesn't
+                // specify any, we don't care and can skip searching.
+                if self.user_interpreters.is_empty() {
+                    Ok((vec![], None))
+                } else {
+                    let bridge_name = match self.bridge {
+                        BridgeModel::Bin(None) => "bin",
+                        BridgeModel::UniFfi => "uniffi",
+                        _ => unreachable!(),
+                    };
+                    self.resolve_single(bridge_name).map(|i| (vec![i], None))
+                }
+            }
             BridgeModel::PyO3(pyo3) | BridgeModel::Bin(Some(pyo3)) => self.resolve_pyo3(pyo3),
         }
     }
@@ -873,7 +886,7 @@ impl<'a> InterpreterResolver<'a> {
             self.user_interpreters[0].clone()
         } else {
             bail!(
-                "You can only specify one python interpreter for {}",
+                "You can only specify one python interpreter for `{}` bindings",
                 bridge_name
             );
         };

--- a/test-crates/hello-world/pyproject.toml
+++ b/test-crates/hello-world/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "bin"
+pgo-command = "hello-world"
 exclude = [
   "benches/excluded_bench.rs",
   "examples/excluded_example.rs",

--- a/test-crates/pyo3-bin/check_installed/check_installed.py
+++ b/test-crates/pyo3-bin/check_installed/check_installed.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import sys
+import sysconfig
 from subprocess import check_output
 
 
@@ -11,6 +12,11 @@ def main():
         path = os.environ["PATH"]
         path = path + os.pathsep + sys.base_prefix
         os.environ["PATH"] = path
+    else:
+        # similar for non-windows platforms
+        library_path = sysconfig.get_config_var("LIBDIR")
+        os.environ["LD_LIBRARY_PATH"] = library_path
+        os.environ["DYLD_LIBRARY_PATH"] = library_path
 
     output = check_output(["pyo3-bin"]).decode("utf-8").strip()
     if not output == "Hello, world!":

--- a/test-crates/pyo3-bin/pyproject.toml
+++ b/test-crates/pyo3-bin/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "pyo3-bin"
+version = "0.1.0"
+
+[tool.maturin]
+pgo-command = "python check_installed/check_installed.py"

--- a/tests/common/errors.rs
+++ b/tests/common/errors.rs
@@ -203,8 +203,6 @@ pub fn pypi_compatibility_linux_tag() -> Result<()> {
         "test-crates/targets/pypi_compatibility_linux_tag",
         "--out",
         "test-crates/targets/pypi_compatibility_linux_tag",
-        "-i",
-        "python3.12", // Add interpreter to bypass interpreter detection
     ];
     let options: BuildOptions = BuildOptions::try_parse_from(cli)?;
     let build_context = options

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -377,20 +377,28 @@ pub fn test_integration_uv_multi_python(case: &IntegrationCase<'_>) -> Result<()
     let target = Target::from_target_triple(None)?;
     let mut interpreters = Vec::new();
 
-    for minor in [10, 11] {
+    for minor in [12, 13] {
         let env_dir = Path::new("test-crates")
             .join("venvs")
             .join(format!("{}-py3{minor}", case.id));
         if env_dir.is_dir() {
             fs_err::remove_dir_all(&env_dir)?;
         }
+        let python_request = if cfg!(all(windows, target_arch = "aarch64")) {
+            // see https://github.com/astral-sh/uv/issues/19015
+            // for now uv prefers x64 python on windows aarch64, need
+            // to directly request aarch64 python
+            format!("3.{minor}-aarch64")
+        } else {
+            format!("3.{minor}")
+        };
         let output = Command::new(&uv)
             .args([
                 "venv",
                 "--seed",
                 "--managed-python",
                 "--python",
-                &format!("3.{minor}"),
+                &python_request,
             ])
             .arg(&env_dir)
             .output()

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -238,7 +238,7 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
         file.lock_exclusive()?;
 
         let target_triple = Target::from_target_triple(None)?;
-        let python = target_triple.get_venv_python(&cffi_venv);
+        let mut python = target_triple.get_venv_python(&cffi_venv);
 
         // possible arch mismatch between the python interpreter and the cffi venv if e.g.
         // testing in containers that on the host, clean up conservatively if so
@@ -255,6 +255,9 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
         // ... and then create if needed
         if !cffi_venv.is_dir() {
             create_named_virtualenv(cffi_provider, python_interp.clone().map(PathBuf::from))?;
+            // re-resolve python because on windows `get_venv_python` depends on what's
+            // actually installed
+            python = target_triple.get_venv_python(&cffi_venv);
             assert!(python.is_file(), "cffi venv not created correctly");
             let pip_install_cffi = [
                 "-m",

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -356,6 +356,87 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
     Ok(())
 }
 
+pub fn test_integration_uv_multi_python(case: &IntegrationCase<'_>) -> Result<()> {
+    let package_path = prepare_case_package(case.id, case.package, case.package_copy)?;
+    let package = package_path.as_path();
+    let uv = which::which("uv").context("uv is required for this integration test")?;
+    let target = Target::from_target_triple(None)?;
+    let mut interpreters = Vec::new();
+
+    for minor in [10, 11] {
+        let env_dir = Path::new("test-crates")
+            .join("venvs")
+            .join(format!("{}-py3{minor}", case.id));
+        if env_dir.is_dir() {
+            fs_err::remove_dir_all(&env_dir)?;
+        }
+        let output = Command::new(&uv)
+            .args([
+                "venv",
+                "--seed",
+                "--managed-python",
+                "--python",
+                &format!("3.{minor}"),
+            ])
+            .arg(&env_dir)
+            .output()
+            .context("failed to create uv virtualenv")?;
+        if !output.status.success() {
+            bail!(
+                "uv failed to create a Python 3.{minor} environment: {}\n--- Stdout:\n{}\n--- Stderr:\n{}",
+                output.status,
+                str::from_utf8(&output.stdout)?.trim(),
+                str::from_utf8(&output.stderr)?.trim(),
+            );
+        }
+        interpreters.push((env_dir.clone(), target.get_venv_python(&env_dir)));
+    }
+
+    let mut cli: Vec<std::ffi::OsString> = vec![
+        "build".into(),
+        "--quiet".into(),
+        "--manifest-path".into(),
+        package.join("Cargo.toml").into_os_string(),
+        "--interpreter".into(),
+    ];
+    cli.extend(
+        interpreters
+            .iter()
+            .map(|(_, python)| python.as_os_str().to_owned()),
+    );
+    cli.push("--target-dir".into());
+    cli.push(case_target_dir(case.id).into_os_string());
+    cli.push("--out".into());
+    cli.push(case_wheel_dir(case.id).into_os_string());
+
+    let options = BuildOptions::try_parse_from(cli)?;
+    let build_context = options
+        .into_build_context()
+        .strip(Some(cfg!(feature = "faster-tests")))
+        .editable(false)
+        .pgo(case.pgo)
+        .build()?;
+    let wheels = BuildOrchestrator::new(&build_context).build_wheels()?;
+
+    let universal = wheels
+        .iter()
+        .all(|wheel| matches!(wheel.tag, BuiltArtifactTag::Universal));
+    if universal {
+        assert_eq!(wheels.len(), 1);
+        for (env_dir, python) in &interpreters {
+            install_and_check_wheel(package, &wheels[0].path, env_dir, python)?;
+        }
+    } else {
+        assert_eq!(wheels.len(), interpreters.len());
+        for (wheel, (env_dir, python)) in wheels.iter().zip(&interpreters) {
+            install_and_check_wheel(package, &wheel.path, env_dir, python)?;
+        }
+    }
+
+    cleanup_case(case.id);
+    Ok(())
+}
+
 pub fn test_integration_conda(
     package: impl AsRef<Path>,
     bindings: Option<&str>,

--- a/tests/common/integration.rs
+++ b/tests/common/integration.rs
@@ -236,10 +236,25 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
         // modifies it at a time and that during that time, no other test reads it.
         let file = File::create(venvs_dir.join("cffi-provider.lock"))?;
         file.lock_exclusive()?;
-        let python = if !cffi_venv.is_dir() {
+
+        let target_triple = Target::from_target_triple(None)?;
+        let python = target_triple.get_venv_python(&cffi_venv);
+
+        // possible arch mismatch between the python interpreter and the cffi venv if e.g.
+        // testing in containers that on the host, clean up conservatively if so
+        if python.exists() {
+            let output = Command::new(&python)
+                .args(["-c", "import cffi"])
+                .output()
+                .with_context(|| format!("cffi import check failed with {python:?}"))?;
+            if !output.status.success() {
+                fs_err::remove_dir_all(&cffi_venv)?;
+            }
+        }
+
+        // ... and then create if needed
+        if !cffi_venv.is_dir() {
             create_named_virtualenv(cffi_provider, python_interp.clone().map(PathBuf::from))?;
-            let target_triple = Target::from_target_triple(None)?;
-            let python = target_triple.get_venv_python(&cffi_venv);
             assert!(python.is_file(), "cffi venv not created correctly");
             let pip_install_cffi = [
                 "-m",
@@ -263,10 +278,6 @@ pub fn test_integration(case: &IntegrationCase<'_>) -> Result<()> {
                     stderr
                 );
             }
-            python
-        } else {
-            let target_triple = Target::from_target_triple(None)?;
-            target_triple.get_venv_python(&cffi_venv)
         };
         file.unlock()?;
         cli.push("--interpreter".into());

--- a/tests/run/integration.rs
+++ b/tests/run/integration.rs
@@ -3,7 +3,8 @@ use crate::common::other;
 use crate::common::{
     CFFI_MIXED_IMPLICIT_COPY, CFFI_MIXED_INCLUDE_EXCLUDE_COPY, CFFI_MIXED_PY_SUBDIR_COPY,
     CFFI_MIXED_SRC_COPY, CFFI_MIXED_SUBMODULE_COPY, CFFI_MIXED_WITH_PATH_DEP_COPY, handle_result,
-    has_conda, has_uniffi_bindgen, is_ci, test_python_implementation, test_python_supports_abi3t,
+    has_conda, has_uniffi_bindgen, has_uv, is_ci, test_python_implementation,
+    test_python_supports_abi3t,
 };
 use std::path::Path;
 
@@ -90,6 +91,18 @@ fn integration_pyo3_bin() {
 #[test]
 fn integration_cases(#[case] case: IntegrationCase<'_>) {
     handle_result(integration::test_integration(&case));
+}
+
+#[test]
+fn integration_pyo3_bin_uv_multi_python() {
+    if has_uv() {
+        handle_result(integration::test_integration_uv_multi_python(
+            &IntegrationCase::new(
+                "integration-pyo3-bin-uv-multi-python",
+                "test-crates/pyo3-bin",
+            ),
+        ));
+    }
 }
 
 #[test]

--- a/tests/run/pgo.rs
+++ b/tests/run/pgo.rs
@@ -1,5 +1,5 @@
-use crate::common::handle_result;
 use crate::common::integration::{self, IntegrationCase};
+use crate::common::{handle_result, has_uv};
 
 #[test]
 #[cfg_attr(
@@ -13,5 +13,25 @@ fn pgo_pyo3_mixed() {
     }
     handle_result(integration::test_integration(
         &IntegrationCase::new("pgo-pyo3-mixed", "test-crates/pyo3-mixed").pgo(),
+    ));
+}
+
+#[test]
+fn pgo_pyo3_bin_uv_multi_python() {
+    if std::env::var_os("MATURIN_TEST_SKIP_PGO").is_some() || !has_uv() {
+        return;
+    }
+    handle_result(integration::test_integration_uv_multi_python(
+        &IntegrationCase::new("pgo-pyo3-bin-uv-multi-python", "test-crates/pyo3-bin").pgo(),
+    ));
+}
+
+#[test]
+fn pgo_bin_uv_multi_python() {
+    if std::env::var_os("MATURIN_TEST_SKIP_PGO").is_some() || !has_uv() {
+        return;
+    }
+    handle_result(integration::test_integration_uv_multi_python(
+        &IntegrationCase::new("pgo-bin-uv-multi-python", "test-crates/hello-world").pgo(),
     ));
 }

--- a/tests/run/pgo.rs
+++ b/tests/run/pgo.rs
@@ -17,6 +17,24 @@ fn pgo_pyo3_mixed() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "possible windows aarch64 pgo issue, see https://github.com/rust-lang/rust/issues/156675"
+)]
+fn pgo_bin() {
+    if std::env::var_os("MATURIN_TEST_SKIP_PGO").is_some() || !has_uv() {
+        return;
+    }
+    handle_result(integration::test_integration(
+        &IntegrationCase::new("pgo-bin", "test-crates/hello-world").pgo(),
+    ));
+}
+
+#[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "possible windows aarch64 pgo issue, see https://github.com/rust-lang/rust/issues/156675"
+)]
 fn pgo_pyo3_bin_uv_multi_python() {
     if std::env::var_os("MATURIN_TEST_SKIP_PGO").is_some() || !has_uv() {
         return;
@@ -31,7 +49,12 @@ fn pgo_bin_uv_multi_python() {
     if std::env::var_os("MATURIN_TEST_SKIP_PGO").is_some() || !has_uv() {
         return;
     }
-    handle_result(integration::test_integration_uv_multi_python(
+    let err = integration::test_integration_uv_multi_python(
         &IntegrationCase::new("pgo-bin-uv-multi-python", "test-crates/hello-world").pgo(),
-    ));
+    )
+    .expect_err("multiple interpreters is not applicable with non-pyo3 binaries");
+    assert_eq!(
+        err.to_string(),
+        "You can only specify one python interpreter for `bin` bindings"
+    );
 }


### PR DESCRIPTION
I noticed that PGO can misalign with actual wheel builds. I tried to fix this by removing the dedicated PGO wheel-building functions and instead introducing a `build_single_unit` helper which either runs a PGO cycle or does a single build.

I also added some additional testing.

### AI Disclosure

I used AI to factor this out, in particular the additional test cases for multiple interpreters using uv.