### PR TITLE
Don’t specify generate-import-lib for PyO3 0.29

### DIFF
--- a/test-crates/pyo3-abi3-and-abi3t/Cargo.toml
+++ b/test-crates/pyo3-abi3-and-abi3t/Cargo.toml
@@ -13,12 +13,10 @@ default = ["abi3-and-abi3t-py315"]
 abi3-and-abi3t-py315 = [
     "pyo3/abi3-py38",
     "pyo3/abi3t-py315",
-    "pyo3/generate-import-lib",
 ]
 abi3-and-current-abi3t = [
     "pyo3/abi3-py38",
     "pyo3/abi3t",
-    "pyo3/generate-import-lib",
 ]
 
 [lib]

--- a/test-crates/pyo3-abi3t/Cargo.toml
+++ b/test-crates/pyo3-abi3t/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 [dependencies]
 pyo3 = { version = "0.29.0", features = [
     "abi3t-py315",
-    "generate-import-lib",
 ] }
 
 [lib]

--- a/test-crates/pyo3-mixed-include-exclude/Cargo.toml
+++ b/test-crates/pyo3-mixed-include-exclude/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implements a dummy function combining rust and python"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["generate-import-lib"] }
+pyo3 = { version = "0.29.0" }
 
 [lib]
 name = "pyo3_mixed_include_exclude"

--- a/test-crates/pyo3-mixed-src/rust/Cargo.toml
+++ b/test-crates/pyo3-mixed-src/rust/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implements a dummy function combining rust and python"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["generate-import-lib"] }
+pyo3 = { version = "0.29.0" }
 
 [lib]
 name = "pyo3_mixed_src"

--- a/test-crates/pyo3-mixed-workspace/rust/python/pyo3-mixed-workspace-py/Cargo.toml
+++ b/test-crates/pyo3-mixed-workspace/rust/python/pyo3-mixed-workspace-py/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 pyo3-mixed-workspace = { path = "../../pyo3-mixed-workspace" }
-pyo3 = { version = "0.29.0", features = ["generate-import-lib", ] }
+pyo3 = { version = "0.29.0" }
 
 [lib]
 name = "pyo3_mixed_workspace_py"

--- a/test-crates/pyo3-mixed/Cargo.toml
+++ b/test-crates/pyo3-mixed/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implements a dummy function combining rust and python"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["generate-import-lib"] }
+pyo3 = { version = "0.29.0" }
 
 [lib]
 name = "pyo3_mixed"

--- a/test-crates/pyo3-pure/Cargo.toml
+++ b/test-crates/pyo3-pure/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 [dependencies]
 pyo3 = { version = "0.29.0", features = [
     "abi3-py39",
-    "generate-import-lib",
 ] }
 
 [lib]

--- a/tests/run/sdist.rs
+++ b/tests/run/sdist.rs
@@ -488,7 +488,6 @@ fn workspace_members_non_local_dep_sdist() {
         [dependencies]
         pyo3 = { version = "0.29.0", features = [
             "abi3-py39",
-            "generate-import-lib",
         ] }
 
         [lib]


### PR DESCRIPTION
Since the `generate-import-lib` feature is deprecated in PyO3 0.29 and no longer has any effect, https://github.com/PyO3/pyo3/pull/5866, this commit stops asking for it in test crates.

It’s probably a good idea for someone who understands this deeply to update https://github.com/PyO3/maturin/blob/v1.14.1/guide/src/distribution.md#cross-compile-to-windows as well.