### PR TITLE
ci: cut fixed setup overhead in test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,13 +90,10 @@ jobs:
           uv tool install uniffi-bindgen==0.28.0
       # The conda tests create their own conda environments independent of the
       # matrix python, so exercising them once per OS (on the non-dev cells) is
-      # enough; skipping the slow miniconda setup on the -dev cells saves time.
-      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
+      # enough. micromamba installs in seconds where miniconda took up to two
+      # minutes; the test harness falls back to micromamba when conda is absent.
+      - uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2
         if: ${{ matrix.os != 'windows-11-arm' && !contains(matrix.python-version, '-dev') }}
-        with:
-          auto-activate-base: "false"
-          activate-environment: ""
-          miniconda-version: "latest"
       - id: setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -154,11 +151,13 @@ jobs:
           rustup target add aarch64-unknown-linux-musl
           rustup target add aarch64-apple-darwin
 
+          # Use the maturin binary the `cargo test` step already built; `cargo run`
+          # would rebuild it with default features because the feature sets differ.
           # abi3
-          cargo run build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
-          cargo run build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-musl --zig
+          target/debug/maturin build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-gnu --zig
+          target/debug/maturin build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-unknown-linux-musl --zig
           if [[ "$PYTHON_VERSION" != "pypy"* ]]; then
-            cargo run build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-apple-darwin --zig
+            target/debug/maturin build -i $PYTHON_VERSION -m test-crates/pyo3-pure/Cargo.toml --target aarch64-apple-darwin --zig
           fi
 
           if [[ "$PYTHON_VERSION" == "3.1"* ]]; then
@@ -170,9 +169,9 @@ jobs:
           twine check --strict test-crates/pyo3-pure/target/wheels/*.whl
 
           # non-abi3
-          cargo run build -i $PYTHON_VERSION -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
+          target/debug/maturin build -i $PYTHON_VERSION -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-unknown-linux-gnu --zig
           if [[ "$PYTHON_VERSION" != "pypy"* ]]; then
-            cargo run build -i $PYTHON_VERSION -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-apple-darwin --zig
+            target/debug/maturin build -i $PYTHON_VERSION -m test-crates/pyo3-mixed/Cargo.toml --target aarch64-apple-darwin --zig
           fi
           # Check wheels with twine
           twine check --strict test-crates/pyo3-mixed/target/wheels/*.whl

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -189,7 +189,7 @@ pub fn is_ci() -> bool {
 }
 
 pub fn has_conda() -> bool {
-    which::which("conda").is_ok()
+    which::which("conda").is_ok() || which::which("micromamba").is_ok()
 }
 
 pub fn has_uv() -> bool {
@@ -396,7 +396,18 @@ pub fn create_conda_env(name: &str, major: usize, minor: usize) -> Result<(PathB
         success: bool,
     }
 
-    let mut cmd = if cfg!(windows) {
+    // conda and micromamba share the same `create` CLI and --json output fields we need
+    // (top-level `prefix` and `success`). micromamba is preferred because it is much faster;
+    // on Windows `conda` is a batch file and needs to go through cmd.exe.
+    let mut cmd = if let Ok(micromamba) = which::which("micromamba") {
+        let mut cmd = Command::new(micromamba);
+        if env::var_os("MAMBA_ROOT_PREFIX").is_none() {
+            // micromamba errors without a root prefix; keep envs under test-crates
+            cmd.arg("--root-prefix")
+                .arg(repo_test_crates_dir().join("venvs").join("mamba-root"));
+        }
+        cmd
+    } else if cfg!(windows) {
         let mut cmd = Command::new("cmd.exe");
         cmd.arg("/c").arg("conda");
         cmd


### PR DESCRIPTION
## Summary

Third round for #2189. After #3267 and #3268, warm-run step timings show the test phase is no longer the bottleneck in several cells — fixed setup steps are. Per matrix cell the remaining overhead concentrates in exactly two steps; this PR addresses both.

### zig cross-compile step: use the prebuilt maturin (was 1m39–3m54 per cell)

The step ran `cargo run build ...`, which **rebuilt maturin with default features** — the `cargo test` step builds it with `--features password-storage,faster-tests`, so the feature sets differ and cargo rebuilds the binary and its dependency tree. The `PYO3_CONFIG_FILE` and `maturin new` steps that follow already use `target/debug/maturin` directly; the zig step now does the same (`zig` is in the default feature set via `cross-compile`, so the nextest-built binary supports `--zig`). Most of the step's time was this rebuild, not the zig builds themselves.

### setup-miniconda → setup-micromamba (was up to 2m on Windows)

`setup-micromamba` in binary-only mode installs in seconds. The test harness now falls back to micromamba when `conda` is absent: conda and micromamba share the `create -n NAME python=X.Y -q -y --json` CLI, and micromamba's JSON output has the same top-level `prefix`/`success` fields the harness already parses. An explicit `--root-prefix` under `test-crates/venvs` keeps it working when `MAMBA_ROOT_PREFIX` isn't set.

Verified locally with conda removed from PATH: `develop_pyo3_pure_conda` passes through the micromamba path — and runs ~2.5× faster (36s vs ~90s), since micromamba also creates the conda envs much faster than conda does. Repeat `create` over an existing env is idempotent.

### Expected effect

Windows 3.9 (currently the long pole at ~17m53 warm with only 6m36 of actual tests): roughly −2m from the zig step rebuild and −1m40 from miniconda, plus faster conda env creation inside the conda tests. Similar cuts on the other cells running those steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNNLg7XZnxM8Aiqrzo6c5q