### PR TITLE
feat: support --pgo for maturin develop

### DIFF
--- a/guide/src/local_development.md
+++ b/guide/src/local_development.md
@@ -20,6 +20,13 @@ Options:
 
           [possible values: pyo3, pyo3-ffi, cffi, uniffi, bin]
 
+      --pgo
+          Build with Profile-Guided Optimization (PGO).
+
+          Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml. This performs a three-phase build: instrumented build, profile training, and optimized rebuild.
+
+          Implies `--release` unless `--profile` is specified.
+
       --strip
           Strip the library for minimum file size
 

--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -39,6 +39,15 @@ pub struct DevelopOptions {
     /// Pass --release to cargo
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS, conflicts_with = "profile")]
     pub release: bool,
+    /// Build with Profile-Guided Optimization (PGO).
+    ///
+    /// Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml.
+    /// This performs a three-phase build: instrumented build, profile training,
+    /// and optimized rebuild.
+    ///
+    /// Implies `--release` unless `--profile` is specified.
+    #[arg(long)]
+    pub pgo: bool,
     /// Strip the library for minimum file size
     #[arg(long)]
     pub strip: bool,
@@ -324,6 +333,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
     let DevelopOptions {
         bindings,
         release,
+        pgo,
         strip,
         extras,
         group,
@@ -338,6 +348,11 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
 
     // set profile to release if specified; `--release` and `--profile` are mutually exclusive
     if release {
+        cargo_options.profile = Some("release".to_string());
+    }
+    // PGO-optimizing a debug build makes no sense, so `--pgo` implies the
+    // release profile unless another profile was requested explicitly
+    if pgo && cargo_options.profile.is_none() {
         cargo_options.profile = Some("release".to_string());
     }
 
@@ -385,6 +400,7 @@ pub fn develop(develop_options: DevelopOptions, venv_dir: &Path) -> Result<()> {
         .into_build_context()
         .strip(if strip { Some(true) } else { None })
         .editable(true)
+        .pgo(pgo)
         .build()?;
 
     // Ensure that version information is present, https://github.com/PyO3/maturin/issues/2416

--- a/tests/cmd/develop.stdout
+++ b/tests/cmd/develop.stdout
@@ -12,6 +12,14 @@ Options:
           
           [possible values: pyo3, pyo3-ffi, cffi, uniffi, bin]
 
+      --pgo
+          Build with Profile-Guided Optimization (PGO).
+          
+          Requires `pgo-command` to be set in `[tool.maturin]` in pyproject.toml. This performs a
+          three-phase build: instrumented build, profile training, and optimized rebuild.
+          
+          Implies `--release` unless `--profile` is specified.
+
       --strip
           Strip the library for minimum file size
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -105,6 +105,7 @@ pub fn test_develop(case: &DevelopCase<'_>) -> Result<()> {
     let develop_options = DevelopOptions {
         bindings: case.bindings.map(|binding| binding.to_owned()),
         release: false,
+        pgo: false,
         strip: false,
         extras: Vec::new(),
         group: Vec::new(),


### PR DESCRIPTION
Add a --pgo flag to `maturin develop` that runs the same three-phase PGO build as `maturin build --pgo`. Since PGO-optimizing a debug build makes no sense, --pgo implies the release profile unless another profile is explicitly requested with --profile.

Closes #3255