### PR TITLE
Don't force export of the PyInit_{module_name} in UniFfi mode

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -559,10 +559,7 @@ fn configure_platform_linker_args(
     if zig
         && target.is_windows()
         && !target.is_msvc()
-        && matches!(
-            bridge_model,
-            BridgeModel::PyO3 { .. } | BridgeModel::Cffi | BridgeModel::UniFfi
-        )
+        && matches!(bridge_model, BridgeModel::PyO3 { .. } | BridgeModel::Cffi)
     {
         let py_init = format!("PyInit_{module_name}");
         let maturin_dir = ensure_target_maturin_dir(target_dir);


### PR DESCRIPTION
Fixes #3274