### PR TITLE
add uv cache keys to project template

### DIFF
--- a/src/templates/pyproject.toml.j2
+++ b/src/templates/pyproject.toml.j2
@@ -35,3 +35,13 @@ exclude = [
     "**/*.pyo"
 ]
 {% endif -%}
+
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "Cargo.toml" },
+    { file = "Cargo.lock" },
+    { file = "**/*.rs" },
+    { env = "MATURIN_PEP517_ARGS" },
+    { env = "RUSTFLAGS" }
+]


### PR DESCRIPTION
I find myself often using `uv run` to build / test projects these days.

Every time I forget that `uv` has its own caching layer that is by default not quite right for Rust projects. Adding `cache-keys` configuration to be derived from the Rust src helps a lot with this.

Might not be quite right for "python" project layout - we might want to tweak this before merge? Just wanted to kick off the discussion.