### PR TITLE
switch musllinux images to musllinux_1_2 as musllinux_1_1 is EOL

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
             manylinux: manylinux2014
           - name: musllinux
             tag-suffix: '-musllinux'
-            manylinux: musllinux_1_1
+            manylinux: musllinux_1_2
     environment:
       name: Docker Hub
       url: https://ghcr.io/pyo3/maturin


### PR DESCRIPTION
See: https://github.com/pypa/manylinux/issues/1629, https://quay.io/repository/pypa/musllinux_1_1_x86_64?tab=tags&tag=latest & https://github.com/pypa/manylinux#musllinux_1_1-alpine-linux-312-based---eol