### PR TITLE
fix(generate-stubs): write stubs into the module's package directory

### DIFF
--- a/src/binding_generator/mod.rs
+++ b/src/binding_generator/mod.rs
@@ -390,23 +390,8 @@ where
         .context("Failed to add the python module to the package")?;
     }
 
-    let base_path = context
-        .project
-        .project_layout
-        .python_module
-        .as_ref()
-        .map(|python_module| python_module.parent().unwrap().to_path_buf());
-
-    let module = match &base_path {
-        Some(base_path) => context
-            .project
-            .project_layout
-            .rust_module
-            .strip_prefix(base_path)
-            .unwrap()
-            .to_path_buf(),
-        None => PathBuf::from(&context.project.project_layout.extension_name),
-    };
+    let base_path = context.project.project_layout.base_path();
+    let module = context.project.project_layout.module_dir();
 
     {
         let mut dest = InstallDest::new(writer, context.project.editable, base_path.as_deref());

--- a/src/commands/generate_stubs.rs
+++ b/src/commands/generate_stubs.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use fs_err as fs;
 use maturin::{BuildOptions, BuildOrchestrator, CargoOptions, OutputOptions, PythonOptions};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tracing::instrument;
@@ -26,32 +27,50 @@ pub fn generate_stubs(
     .build()?;
 
     let orchestrator = BuildOrchestrator::new(&build_context);
-    let stubs = orchestrator.generate_stubs()?;
-    let extension_name = &build_context.project.project_layout.extension_name;
-    if stubs.len() == 1
-        && let Some(stub) = stubs.get(Path::new("__init__.pyi"))
-    {
-        // Special case, we generate just a `extension_name.pyi` file instead of a __init__.pyi file
-        let output_path = output.join(format!("{}.pyi", extension_name));
-        if let Some(output_parent) = output_path.parent() {
-            fs::create_dir_all(output_parent)?;
+    let mut stubs = orchestrator.generate_stubs()?;
+    let project_layout = &build_context.project.project_layout;
+    let extension_name = &project_layout.extension_name;
+    // Lay the files out the way `--generate-stubs` lays them out inside a wheel, so that `--out`
+    // can be copied over the python source tree as-is. Without the module directory,
+    // `module-name = "a.b.c"` writes `c.pyi` to the root of `--out` instead of to `a/b/`, where
+    // neither a type checker nor the package build would find it.
+    let module_dir = output.join(project_layout.module_dir());
+
+    if project_layout.python_module.is_some() {
+        if stubs.len() == 1
+            && let Some(stub) = stubs.remove(Path::new("__init__.pyi"))
+        {
+            // Special case, we generate just a `extension_name.pyi` file instead of a __init__.pyi
+            // file: the extension is one module inside an existing package, not a package itself.
+            write_stub(&module_dir.join(format!("{extension_name}.pyi")), &stub)?;
+        } else {
+            // We copy the files into a `extension_name` directory
+            write_stub_dir(&module_dir.join(extension_name), &stubs)?;
         }
-        fs::write(&output_path, stub)?;
     } else {
-        // We copy the file into a `extension_name` directory
-        let output_dir = output.join(extension_name);
-        if output_dir.exists() {
-            // We want to replace the stubs so we remove the directory
-            fs::remove_dir_all(&output_dir)?;
-        }
-        fs::create_dir_all(&output_dir)?;
-        for (path, content) in &stubs {
-            let output_path = output_dir.join(path);
-            if let Some(output_parent) = output_path.parent() {
-                fs::create_dir_all(output_parent)?;
-            }
-            fs::write(&output_path, content)?;
-        }
+        // Pure Rust project: maturin generates the package around the extension, so these stubs are
+        // that package's own and keep their `__init__.pyi` name.
+        write_stub_dir(&module_dir, &stubs)?;
+    }
+    Ok(())
+}
+
+fn write_stub(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)?;
+    Ok(())
+}
+
+fn write_stub_dir(dir: &Path, stubs: &HashMap<PathBuf, String>) -> Result<()> {
+    if dir.exists() {
+        // We want to replace the stubs so we remove the directory
+        fs::remove_dir_all(dir)?;
+    }
+    fs::create_dir_all(dir)?;
+    for (path, content) in stubs {
+        write_stub(&dir.join(path), content)?;
     }
     Ok(())
 }

--- a/src/project_layout.rs
+++ b/src/project_layout.rs
@@ -398,6 +398,32 @@ impl ProjectResolver {
 }
 
 impl ProjectLayout {
+    /// Directory the wheel's contents are resolved against, for a mixed python/rust project.
+    ///
+    /// `None` for a pure Rust project, where there is no python source tree to be relative to.
+    pub fn base_path(&self) -> Option<PathBuf> {
+        self.python_module
+            .as_ref()
+            .map(|python_module| python_module.parent().unwrap().to_path_buf())
+    }
+
+    /// Directory holding the extension module, relative to the root of the wheel.
+    ///
+    /// For `module-name = "a.b.c"` in a mixed project this is `a/b`, so that anything placed
+    /// alongside the extension — the `.so`, its type stubs — lands in the same package the
+    /// extension is imported from. For a pure Rust project it is the extension name, which is the
+    /// package maturin generates around it.
+    pub fn module_dir(&self) -> PathBuf {
+        match self.base_path() {
+            Some(base_path) => self
+                .rust_module
+                .strip_prefix(base_path)
+                .unwrap()
+                .to_path_buf(),
+            None => PathBuf::from(&self.extension_name),
+        }
+    }
+
     /// Checks whether a python module exists besides Cargo.toml with the right name
     fn determine(
         project_root: &Path,

--- a/tests/run/integration.rs
+++ b/tests/run/integration.rs
@@ -239,3 +239,13 @@ fn abi3_generate_stubs() {
         ],
     ));
 }
+
+/// `module-name` places the extension inside a python package, and the stubs have to follow it
+/// there — writing `_pyo3_mixed.pyi` to the root of `--out` puts it where nothing will look for it.
+#[test]
+fn abi3_generate_stubs_mixed_py_subdir() {
+    handle_result(other::generate_stubs(
+        "test-crates/pyo3-stub-generation-mixed-py-subdir",
+        &["pyo3_stub_generation_mixed_py_subdir/_pyo3_mixed.pyi"],
+    ));
+}


### PR DESCRIPTION
## Problem

`maturin generate-stubs --out DIR` ignores the package path in `module-name`, so the stub is written somewhere no type checker will look.

With

```toml
[tool.maturin]
python-source = "python"
module-name = "disco.parquet._lib"
```

`maturin generate-stubs -o stubs` writes:

```
stubs/_lib.pyi
```

but the extension is imported as `disco.parquet._lib`, and `maturin build --generate-stubs` puts the very same file at `disco/parquet/_lib.pyi` inside the wheel. The `--out` tree therefore cannot be copied over the python source tree, which is the obvious thing to want from a command whose only job is to write stub files to a directory.

The cause is that `commands/generate_stubs.rs` builds its output path from `project_layout.extension_name` alone (`_lib`), while the wheel path derives a module directory from `rust_module` relative to the python source root (`disco/parquet`).

## Fix

Give `ProjectLayout` the `base_path()` / `module_dir()` accessors that `binding_generator` was computing inline, and use them from `generate-stubs` so the two cannot drift. The command now lays files out exactly as `--generate-stubs` lays them out inside a wheel:

| layout | before | after |
|---|---|---|
| mixed, single stub | `{ext}.pyi` | `{module_dir}/{ext}.pyi` |
| mixed, several stubs | `{ext}/…` | `{module_dir}/{ext}/…` |
| pure Rust, several stubs | `{ext}/…` | `{ext}/…` (unchanged) |
| pure Rust, single stub | `{ext}.pyi` | `{ext}/__init__.pyi` |

The last row is a second, smaller inconsistency the same code path had. For a pure Rust project maturin generates the package *around* the extension, so the wheel contains `{ext}/__init__.py`, `{ext}/{ext}.so` and `{ext}/__init__.pyi` — the stub is that package's own `__init__.pyi` and is not inlined. `generate-stubs` inlined it unconditionally, which only happened not to show up because the existing test crate emits two stub files and so never took that branch. Fixing only the missing directory would have made this case worse (`{ext}/{ext}.pyi`), so both are handled together.

`binding_generator` behaviour is unchanged; it just calls the extracted accessors now.

## Tests

`abi3_generate_stubs_mixed_py_subdir` covers a dotted `module-name` using the existing `pyo3-stub-generation-mixed-py-subdir` crate, which until now was only exercised through the wheel tests. It fails on `main`:

```
thread 'integration::abi3_generate_stubs_mixed_py_subdir' panicked at tests/common/other.rs:816:5:
assertion failed: `(left == right)`
```

and passes with this change. The existing `abi3_generate_stubs` case is unaffected — that crate is pure Rust with two stub files, which is the one row of the table that does not move.
