### PR TITLE
Fix group not cwd

### DIFF
--- a/src/develop/mod.rs
+++ b/src/develop/mod.rs
@@ -163,9 +163,22 @@ fn install_dependencies(
     };
     if !effective_groups.is_empty() {
         let mut args = vec!["install".to_string()];
+        // pip and uv resolve a bare `--group` against `pyproject.toml` in the current working
+        // directory, which breaks when `--manifest-path` points into a subdirectory. Pass the
+        // resolved pyproject.toml path explicitly using the `--group <path>:<group>` syntax
+        // supported by both backends.
+        let pyproject_path = dunce::simplified(&build_context.project.pyproject_toml_path)
+            .display()
+            .to_string();
         for group in &effective_groups {
             args.push("--group".to_string());
-            args.push(group.clone());
+            if group.contains(':') {
+                // The user already supplied a `<path>:<group>` form (e.g. for a pyproject.toml in
+                // another directory); pass it through unchanged instead of prepending our own path.
+                args.push(group.clone());
+            } else {
+                args.push(format!("{pyproject_path}:{group}"));
+            }
         }
         let status = install_backend
             .make_command(python)

--- a/src/pgo.rs
+++ b/src/pgo.rs
@@ -215,15 +215,13 @@ impl PgoContext {
                 .and_then(|p| p.dependency_groups.as_ref())
                 .is_some_and(|dg| dg.0.contains_key("dev"));
             if has_dev_group {
-                let project_dir = build_context
-                    .project
-                    .pyproject_toml_path
-                    .parent()
-                    .context("Failed to get project directory")?;
+                let pyproject_group = format!(
+                    "{}:dev",
+                    dunce::simplified(&build_context.project.pyproject_toml_path).display()
+                );
                 debug!("Installing dev dependency group");
                 let status = Command::new(&venv_python)
-                    .args(["-m", "pip", "install", "--group", "dev"])
-                    .current_dir(project_dir)
+                    .args(["-m", "pip", "install", "--group", &pyproject_group])
                     .status()
                     .context("Failed to install dev dependency group")?;
                 if !status.success() {

--- a/test-crates/pyo3-pure/pyproject.toml
+++ b/test-crates/pyo3-pure/pyproject.toml
@@ -34,6 +34,14 @@ test = [
     "boltons; sys_platform == 'win32'"
 ]
 
+[dependency-groups]
+dev = [
+    "attrs",
+]
+dev2 = [
+    "attrs",
+]
+
 [project.scripts]
 get_42 = "pyo3_pure:DummyClass.get_42"
 

--- a/tests/common/develop.rs
+++ b/tests/common/develop.rs
@@ -26,6 +26,9 @@ pub struct DevelopCase<'a> {
     pub backend: TestInstallBackend,
     /// Extra Python packages that must be installed into the test environment first.
     pub prereq_packages: &'a [&'a str],
+    /// Dependency groups passed to `maturin develop` as `--group` (e.g. `dev` or
+    /// `<path-to-pyproject.toml>:<group>`).
+    pub group: &'a [&'a str],
 }
 
 impl<'a> DevelopCase<'a> {
@@ -38,6 +41,7 @@ impl<'a> DevelopCase<'a> {
             env_kind: TestEnvKind::Venv,
             backend: TestInstallBackend::Pip,
             prereq_packages: &[],
+            group: &[],
         }
     }
 
@@ -56,6 +60,12 @@ impl<'a> DevelopCase<'a> {
 
     pub fn prereqs(mut self, packages: &'a [&'a str]) -> Self {
         self.prereq_packages = packages;
+        self
+    }
+
+    /// Pass explicit dependency groups to `maturin develop` as `--group` arguments.
+    pub fn with_groups(mut self, groups: &'a [&'a str]) -> Self {
+        self.group = groups;
         self
     }
 
@@ -110,7 +120,7 @@ pub fn test_develop(case: &DevelopCase<'_>) -> Result<()> {
         pgo: false,
         strip: false,
         extras: Vec::new(),
-        group: Vec::new(),
+        group: case.group.iter().map(|s| s.to_string()).collect(),
         skip_install: false,
         pip_path: None,
         cargo_options: CargoOptions {

--- a/tests/run/develop.rs
+++ b/tests/run/develop.rs
@@ -50,6 +50,14 @@ use std::time::Duration;
     "develop-bin-with-python-module",
     "test-crates/bin-with-python-module",
 ))]
+// Test that dependency groups are resolved from the project's pyproject.toml even when
+// `--manifest-path` points into a subdirectory, while being backward compatible
+// when the user explicitly provided the path already.
+// groups work (regression test for https://github.com/PyO3/maturin/issues/3283).
+#[case::pyo3_pure_with_dependency_group(DevelopCase::pip(
+    "develop-pyo3-pure-dependency-group",
+    "test-crates/pyo3-pure",
+).with_groups(&["dev", "test-crates/pyo3-pure/pyproject.toml:dev2"]))]
 #[test]
 fn develop_pip_cases(#[case] case: DevelopCase<'_>) {
     handle_result(develop::test_develop(&case));
@@ -99,6 +107,12 @@ fn develop_uniffi_cases(#[case] case: DevelopCase<'_>) {
 #[timeout(Duration::from_secs(600))]
 #[case::hello_world(DevelopCase::uv("develop-hello-world-uv", "test-crates/hello-world",))]
 #[case::pyo3_ffi_pure(DevelopCase::uv("develop-pyo3-ffi-pure-uv", "test-crates/pyo3-ffi-pure",))]
+// Test that dependency groups are resolved from the project's pyproject.toml even when
+// `--manifest-path` points into a subdirectory to it.
+#[case::pyo3_pure_with_dependency_group(DevelopCase::uv(
+    "develop-pyo3-pure-dependency-group-uv",
+    "test-crates/pyo3-pure",
+))]
 #[test]
 fn develop_uv_cases(#[case] case: DevelopCase<'_>) {
     // Only run uv tests on platforms that have wheels on PyPI or when a uv binary is found.


### PR DESCRIPTION
fix https://github.com/PyO3/maturin/issues/3283, by always adding the absolute path of the pyproject.toml to the group

The code was mainly authored by deepseek v4 flash, but reviewed personally.

And personally tested that the local implementation resulting from the fix, fix my issue, with and without the workaround used before (pre-pending the absolute path to the group), making the change BC compatible.