### PR TITLE
docs: fix cross compiling heading level

### DIFF
--- a/guide/src/distribution.md
+++ b/guide/src/distribution.md
@@ -235,19 +235,19 @@ To include arbitrary files in the sdist for use during compilation specify `incl
 include = [{ path = "path/**/*", format = "sdist" }]
 ```
 
-### Cross Compiling
+## Cross Compiling
 
 Maturin has decent cross compilation support for `pyo3` and `bin` bindings,
 other kind of bindings may work but aren't tested regularly.
 
-#### Cross-compile to Linux/macOS
+### Cross-compile to Linux/macOS
 
-##### Use Docker
+#### Use Docker
 
 For manylinux support the [manylinux-cross](https://github.com/rust-cross/manylinux-cross) docker images can be used.
 And [maturin-action](https://github.com/PyO3/maturin-action) makes it easy to do cross compilation on GitHub Actions.
 
-##### Use Zig
+#### Use Zig
 
 Since v0.12.7 maturin added support for linking with [`zig cc`](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html),
 compile for Linux works and is regularly tested on CI, other platforms may also work but aren't tested regularly.
@@ -259,7 +259,7 @@ Then pass `--zig` to maturin `build` or `publish` commands to use it, for exampl
 maturin build --release --target aarch64-unknown-linux-gnu --zig
 ```
 
-#### Cross-compile to Windows
+### Cross-compile to Windows
 
 Pyo3 0.16.5 added an experimental feature `generate-import-lib` enables the user to cross compile
 extension modules for Windows targets without setting the `PYO3_CROSS_LIB_DIR` environment variable


### PR DESCRIPTION
Right now the cross compiling section has a level 3 header, but it should be level 2 to match the other headers. This is what the mdbook sidebar looks like at <https://www.maturin.rs/distribution.html>:

<img width="280" height="163" alt="image" src="https://github.com/user-attachments/assets/64118f43-c485-4c38-9b28-71ffc89fe450" />

As you can see, "Cross Compiling" should not be a sub-section of "Source Distribution", as they are two different subjects. In this PR I made it a level 2 header and fixed all sub-headers to match.

Let me know if there's anything else you need me to do! :)