### PR TITLE
Fix spurious cross-compilation metadata warnings

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -986,6 +986,12 @@ fn compile_target(
 ) -> Result<(HashMap<CrateType, BuildArtifact>, HashMap<String, PathBuf>)> {
     debug!("Running {:?}", build_command);
 
+    let root_package = context
+        .project
+        .cargo_metadata
+        .root_package()
+        .context("No root package found in cargo metadata")?;
+
     let using_cross = build_command
         .get_program()
         .to_string_lossy()
@@ -1007,32 +1013,10 @@ fn compile_target(
         trace!("cargo message: {:?}", message);
         match message {
             cargo_metadata::Message::CompilerArtifact(artifact) => {
-                let package_in_metadata = context
-                    .project
-                    .cargo_metadata
-                    .packages
-                    .iter()
-                    .find(|package| package.id == artifact.package_id);
-                let crate_name = match package_in_metadata {
-                    Some(package) => &package.name,
-                    None => {
-                        let package_id = &artifact.package_id;
-                        // Ignore the package if it's coming from Rust sysroot when compiling with `-Zbuild-std`
-                        let should_warn = !package_id.repr.contains("rustup")
-                            && !package_id.repr.contains("rustlib")
-                            && !artifact.features.contains(&"rustc-dep-of-std".to_string());
-                        if should_warn {
-                            // This is a spurious error I don't really understand
-                            eprintln!(
-                                "⚠️  Warning: The package {package_id} wasn't listed in `cargo metadata`"
-                            );
-                        }
-                        continue;
-                    }
-                };
-
-                // Extract the location of the .so/.dll/etc. from cargo's json output
-                if crate_name.as_ref() == context.project.crate_name {
+                // Only collect artifacts for the package being built. Target-filtered
+                // metadata may omit host-only dependencies used by build scripts or
+                // proc macros, so looking up every dependency can fail legitimately.
+                if artifact.package_id == root_package.id {
                     let num_crate_types = artifact.target.crate_types.len();
                     let mut filenames_iter = artifact.filenames.into_iter();
                     for crate_type in artifact.target.crate_types {

--- a/tests/run/integration.rs
+++ b/tests/run/integration.rs
@@ -177,6 +177,91 @@ fn integration_wasm_hello_world() {
 }
 
 #[test]
+fn integration_wasm_host_only_dependency() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let project_dir = temp_dir.path().join("hello-world");
+    other::copy_dir_recursive(Path::new("test-crates/hello-world"), &project_dir).unwrap();
+
+    let manifest_path = project_dir.join("Cargo.toml");
+    let mut manifest = fs_err::read_to_string(&manifest_path)
+        .unwrap()
+        .replace("../../README.md", "../README.md");
+    manifest.push_str("\n[build-dependencies]\nhost-helper = { path = \"../host-helper\" }\n");
+    fs_err::write(&manifest_path, manifest).unwrap();
+    fs_err::write(temp_dir.path().join("README.md"), "Cargo readme").unwrap();
+    fs_err::write(
+        project_dir.join("build.rs"),
+        "fn main() { host_helper::run(); }\n",
+    )
+    .unwrap();
+
+    // The build script runs on the host, so Cargo compiles host-only even though
+    // metadata filtered for the WASI target excludes it.
+    for (name, dependencies, source) in [
+        (
+            "host-helper",
+            indoc::indoc! {r#"
+                [target.'cfg(not(target_family = "wasm"))'.dependencies]
+                host-only = { path = "../host-only" }
+            "#},
+            "pub fn run() { host_only::run(); }\n",
+        ),
+        ("host-only", "", "pub fn run() {}\n"),
+    ] {
+        let dependency_dir = temp_dir.path().join(name);
+        fs_err::create_dir_all(dependency_dir.join("src")).unwrap();
+        fs_err::write(
+            dependency_dir.join("Cargo.toml"),
+            format!(
+                "[package]\nname = {name:?}\nversion = \"0.1.0\"\nedition = \"2021\"\n{dependencies}"
+            ),
+        )
+        .unwrap();
+        fs_err::write(dependency_dir.join("src/lib.rs"), source).unwrap();
+    }
+
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(&manifest_path)
+        .other_options(vec!["--filter-platform".into(), "wasm32-wasip1".into()])
+        .exec()
+        .unwrap();
+    assert!(metadata.packages.iter().all(|pkg| pkg.name != "host-only"));
+
+    let wheel_dir = temp_dir.path().join("wheels");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_maturin"))
+        .args(["build", "--target", "wasm32-wasip1", "--offline"])
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("--target-dir")
+        .arg(temp_dir.path().join("target"))
+        .arg("--out")
+        .arg(&wheel_dir)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        !stderr.contains("wasn't listed in `cargo metadata`"),
+        "{stderr}"
+    );
+
+    let wheels = fs_err::read_dir(&wheel_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+    assert_eq!(wheels.len(), 1);
+    let mut wheel = zip::ZipArchive::new(fs_err::File::open(&wheels[0]).unwrap()).unwrap();
+    for binary in ["hello-world", "foo"] {
+        assert!(
+            wheel
+                .by_name(&format!("hello_world-0.1.0.data/scripts/{binary}.wasm"))
+                .is_ok(),
+            "missing {binary} in wheel"
+        );
+    }
+}
+
+#[test]
 fn abi3_without_version() {
     handle_result(other::abi3_without_version())
 }


### PR DESCRIPTION
I hit this warning when doing some cross-compilation of wheels with maturin.

TL;DR: when cross-compiling (e.g. Windows-on-Linux), Cargo may compile host-only dependencies omitted from target-filtered cargo metadata. Maturin would spuriously warn about their artifacts. The fix is to collect artifacts only for the package being packaged, identified by its package ID.

I've added a wasm cross build to the tests that ensures that the warning no longer occurs.