### PR TITLE
properly normalize / validate abiflags and include in environment signature

### DIFF
--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -69,6 +69,7 @@ KEYS = [
     "EXT_SUFFIX",
     "SOABI",
     "Py_GIL_DISABLED",
+    "Py_DEBUG",
 ]
 for key in KEYS:
     print(key, build_time_vars.get(key, ""))

--- a/src/cross_compile.rs
+++ b/src/cross_compile.rs
@@ -327,12 +327,7 @@ pub fn parse_build_details(content: &str) -> Result<InterpreterConfig> {
     )?;
 
     let abiflags = abi.flags.as_deref().unwrap_or_default().join("");
-    let gil_disabled = abi
-        .flags
-        .as_deref()
-        .unwrap_or_default()
-        .iter()
-        .any(|f| f == "t");
+    let gil_disabled = abiflags.contains('t');
     let ext_suffix = abi.extension_suffix.clone();
 
     debug!(

--- a/src/python_interpreter/abiflags.rs
+++ b/src/python_interpreter/abiflags.rs
@@ -8,12 +8,39 @@ use anyhow::{Result, bail, ensure};
 
 use super::discovery::InterpreterMetadataMessage;
 
+pub(super) fn normalize_abiflags(
+    abiflags: &mut String,
+    debug: bool,
+    gil_disabled: bool,
+) -> Result<()> {
+    if debug && !abiflags.contains('d') {
+        abiflags.insert(0, 'd');
+    }
+    if gil_disabled && !abiflags.contains('t') {
+        abiflags.push('t');
+    }
+    validate_abiflags(abiflags, debug, gil_disabled)
+}
+
+pub(super) fn validate_abiflags(abiflags: &str, debug: bool, gil_disabled: bool) -> Result<()> {
+    for (flag, enabled, name) in [
+        ('d', debug, "Py_DEBUG"),
+        ('t', gil_disabled, "Py_GIL_DISABLED"),
+    ] {
+        ensure!(
+            abiflags.contains(flag) == enabled,
+            "ABI flags are inconsistent with {name}={enabled}"
+        );
+    }
+    Ok(())
+}
+
 /// Returns the abiflags that are assembled through the message, with some
 /// additional sanity checks.
 ///
 /// The rules are as follows:
 ///  - python 3 + Unix: Use ABIFLAGS
-///  - python 3 + Windows: No ABIFLAGS, return an empty string
+///  - python 3 + Windows: Use ABIFLAGS when available, otherwise infer them
 pub(super) fn fun_with_abiflags(
     message: &InterpreterMetadataMessage,
     target: &Target,
@@ -136,6 +163,39 @@ pub(super) fn calculate_abi_tag(ext_suffix: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_infer_abiflags() {
+        for (flags, debug, gil_disabled, expected) in [
+            ("", false, false, ""),
+            ("", true, false, "d"),
+            ("", false, true, "t"),
+            ("", true, true, "dt"),
+            ("t", true, true, "dt"),
+            ("d", true, true, "dt"),
+            ("dt", true, true, "dt"),
+            ("m", true, false, "dm"),
+            ("dt", false, false, "dt"),
+        ] {
+            let mut flags = flags.to_string();
+            normalize_abiflags(&mut flags, debug, gil_disabled).unwrap();
+            assert_eq!(flags, expected);
+        }
+    }
+
+    #[test]
+    fn test_validate_abiflags() {
+        for (flags, debug, gil_disabled) in [
+            ("", false, false),
+            ("d", true, false),
+            ("t", false, true),
+            ("dt", true, true),
+        ] {
+            assert!(validate_abiflags(flags, debug, gil_disabled).is_ok());
+            assert!(validate_abiflags(flags, !debug, gil_disabled).is_err());
+            assert!(validate_abiflags(flags, debug, !gil_disabled).is_err());
+        }
+    }
 
     #[test]
     fn test_calculate_abi_tag() {

--- a/src/python_interpreter/abiflags.rs
+++ b/src/python_interpreter/abiflags.rs
@@ -8,24 +8,31 @@ use anyhow::{Result, bail, ensure};
 
 use super::discovery::InterpreterMetadataMessage;
 
-pub(super) fn normalize_abiflags(
-    abiflags: &mut String,
-    debug: bool,
-    gil_disabled: bool,
-) -> Result<()> {
-    if debug && !abiflags.contains('d') {
-        abiflags.insert(0, 'd');
-    }
-    if gil_disabled && !abiflags.contains('t') {
+pub(super) fn default_abiflags(minor_version: usize, gil_disabled: bool, debug: bool) -> String {
+    let mut abiflags = String::new();
+
+    // order is [t][d][m], to match order used in `packaging`
+    // https://github.com/pypa/packaging/blob/10590c194edb33c82f84a127883d6097c56b7840/src/packaging/tags.py#L376-L390
+    if gil_disabled {
         abiflags.push('t');
     }
-    validate_abiflags(abiflags, debug, gil_disabled)
+
+    if debug {
+        abiflags.push('d');
+    }
+
+    // pymalloc abi was the default until 3.8
+    if minor_version < 8 {
+        abiflags.push('m');
+    }
+
+    abiflags
 }
 
-pub(super) fn validate_abiflags(abiflags: &str, debug: bool, gil_disabled: bool) -> Result<()> {
+pub(super) fn validate_abiflags(abiflags: &str, gil_disabled: bool, debug: bool) -> Result<()> {
     for (flag, enabled, name) in [
-        ('d', debug, "Py_DEBUG"),
         ('t', gil_disabled, "Py_GIL_DISABLED"),
+        ('d', debug, "Py_DEBUG"),
     ] {
         ensure!(
             abiflags.contains(flag) == enabled,
@@ -86,46 +93,19 @@ pub(super) fn fun_with_abiflags(
         // - Python 3.13t: abiflags is empty/None but we need "t" (gil_disabled)
         // - Python >= 3.14: abiflags is now defined in sysconfig (upstream change)
         match message.abiflags.as_deref() {
-            Some("") | None => {
-                if message.minor <= 7 {
-                    Ok("m".to_string())
-                } else if message.gil_disabled {
-                    ensure!(
-                        message.minor >= 13,
-                        "gil_disabled is only available in python 3.13+ ಠ_ಠ"
-                    );
-                    Ok("t".to_string())
-                } else {
-                    Ok("".to_string())
-                }
-            }
+            Some("") | None => Ok(default_abiflags(
+                message.minor,
+                message.gil_disabled,
+                message.debug,
+            )),
             Some(abiflags) => {
-                // Python 3.14+ on Windows now defines ABIFLAGS in sysconfig.
-                // Accept it (fixes #2740).
-                if message.minor >= 14 {
-                    Ok(abiflags.to_string())
-                } else if message.gil_disabled && abiflags == "t" {
-                    // Python 3.13t may also report "t"
-                    Ok(abiflags.to_string())
-                } else {
-                    bail!(
-                        "Unexpected abiflags '{}' for Python {}.{} on Windows ಠ_ಠ",
-                        abiflags,
-                        message.major,
-                        message.minor
-                    )
-                }
+                validate_abiflags(abiflags, message.gil_disabled, message.debug)?;
+                Ok(abiflags.to_string())
             }
         }
-    } else if let Some(ref abiflags) = message.abiflags {
-        if message.minor >= 8 {
-            // for 3.8, "builds with and without pymalloc are ABI compatible" and the flag dropped
-            Ok(abiflags.to_string())
-        } else if (abiflags != "m") && (abiflags != "dm") {
-            bail!("A python 3 interpreter on Linux or macOS must have 'm' or 'dm' as abiflags ಠ_ಠ")
-        } else {
-            Ok(abiflags.to_string())
-        }
+    } else if let Some(abiflags) = &message.abiflags {
+        validate_abiflags(&abiflags, message.gil_disabled, message.debug)?;
+        Ok(abiflags.to_string())
     } else {
         bail!("A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig ಠ_ಠ")
     }
@@ -165,20 +145,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_infer_abiflags() {
-        for (flags, debug, gil_disabled, expected) in [
-            ("", false, false, ""),
-            ("", true, false, "d"),
-            ("", false, true, "t"),
-            ("", true, true, "dt"),
-            ("t", true, true, "dt"),
-            ("d", true, true, "dt"),
-            ("dt", true, true, "dt"),
-            ("m", true, false, "dm"),
-            ("dt", true, true, "dt"),
+    fn test_default_abiflags() {
+        for (minor_version, gil_disabled, debug, expected) in [
+            (7, false, false, "m"),
+            (7, false, true, "dm"),
+            (8, false, false, ""),
+            (8, false, true, "d"),
+            (13, false, false, ""),
+            (13, true, false, "t"),
+            (13, true, true, "td"),
         ] {
-            let mut flags = flags.to_string();
-            normalize_abiflags(&mut flags, debug, gil_disabled).unwrap();
+            let flags = default_abiflags(minor_version, gil_disabled, debug);
             assert_eq!(flags, expected);
         }
     }
@@ -189,11 +166,11 @@ mod tests {
             ("", false, false),
             ("d", true, false),
             ("t", false, true),
-            ("dt", true, true),
+            ("td", true, true),
         ] {
-            assert!(validate_abiflags(flags, debug, gil_disabled).is_ok());
-            assert!(validate_abiflags(flags, !debug, gil_disabled).is_err());
-            assert!(validate_abiflags(flags, debug, !gil_disabled).is_err());
+            assert!(validate_abiflags(flags, gil_disabled, debug,).is_ok());
+            assert!(validate_abiflags(flags, !gil_disabled, debug,).is_err());
+            assert!(validate_abiflags(flags, gil_disabled, !debug).is_err());
         }
     }
 

--- a/src/python_interpreter/abiflags.rs
+++ b/src/python_interpreter/abiflags.rs
@@ -175,7 +175,7 @@ mod tests {
             ("d", true, true, "dt"),
             ("dt", true, true, "dt"),
             ("m", true, false, "dm"),
-            ("dt", false, false, "dt"),
+            ("dt", true, true, "dt"),
         ] {
             let mut flags = flags.to_string();
             normalize_abiflags(&mut flags, debug, gil_disabled).unwrap();

--- a/src/python_interpreter/abiflags.rs
+++ b/src/python_interpreter/abiflags.rs
@@ -104,7 +104,7 @@ pub(super) fn fun_with_abiflags(
             }
         }
     } else if let Some(abiflags) = &message.abiflags {
-        validate_abiflags(&abiflags, message.gil_disabled, message.debug)?;
+        validate_abiflags(abiflags, message.gil_disabled, message.debug)?;
         Ok(abiflags.to_string())
     } else {
         bail!("A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig ಠ_ಠ")

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -375,22 +375,24 @@ impl InterpreterConfig {
         })?;
         let implementation = implementation.unwrap_or_else(|| "cpython".to_string());
         let interpreter_kind = implementation.parse().map_err(|e| format_err!("{}", e))?;
-        let gil_disabled = build_flags
-            .as_deref()
-            .unwrap_or_default()
-            .split(',')
-            .any(|flag| flag.trim() == "Py_GIL_DISABLED");
-        let debug = build_flags
-            .as_deref()
-            .unwrap_or_default()
-            .split(',')
-            .any(|flag| flag.trim() == "Py_DEBUG");
+        let known_flags = build_flags.map(|flags| {
+            let debug = flags.split(',').any(|flag| flag.trim() == "Py_DEBUG");
+            let gil_disabled = flags
+                .split(',')
+                .any(|flag| flag.trim() == "Py_GIL_DISABLED");
+            (debug, gil_disabled)
+        });
         let abiflags = if let Some(abiflags) = abiflags {
-            validate_abiflags(&abiflags, debug, gil_disabled)?;
+            if let Some((debug, gil_disabled)) = known_flags {
+                // `gil_disabled` and `debug` are derived from
+                validate_abiflags(&abiflags, debug, gil_disabled)?;
+            }
             abiflags
         } else {
             let mut abiflags = String::new();
-            normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
+            if let Some((debug, gil_disabled)) = known_flags {
+                normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
+            }
             if interpreter_kind == InterpreterKind::CPython && (major, minor) < (3, 8) {
                 // default of "m" (pymalloc) for Python 3.7 and earlier
                 abiflags.push('m');
@@ -412,6 +414,7 @@ impl InterpreterConfig {
                 "ABI flags are unsupported for {interpreter_kind}"
             );
         }
+        let gil_disabled = abiflags.contains('t');
         let abi_tag = match interpreter_kind {
             InterpreterKind::CPython => {
                 abi_tag.unwrap_or_else(|| format!("{major}{minor}{abiflags}"))
@@ -588,6 +591,7 @@ mod tests {
         ] {
             let file = tempfile::NamedTempFile::new().unwrap();
             fs::write(file.path(), format!("version=3.14\n{settings}")).unwrap();
+            dbg!(settings, flags);
             let config = InterpreterConfig::from_pyo3_config(file.path(), &target).unwrap();
             assert_eq!(config.abiflags, flags, "{settings}");
             assert_eq!(config.gil_disabled, flags.contains('t'));

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -1,10 +1,12 @@
 use super::{
     FREE_THREADED_MINIMUM_PYTHON_MINOR, InterpreterKind, MAXIMUM_PYPY_MINOR, MAXIMUM_PYTHON_MINOR,
-    MINIMUM_PYPY_MINOR, MINIMUM_PYTHON_MINOR,
-    abiflags::{normalize_abiflags, validate_abiflags},
+    MINIMUM_PYPY_MINOR, MINIMUM_PYTHON_MINOR, abiflags::validate_abiflags,
 };
-use crate::target::{Arch, Os};
 use crate::{StableAbi, StableAbiKind, Target};
+use crate::{
+    python_interpreter::abiflags::default_abiflags,
+    target::{Arch, Os},
+};
 use anyhow::{Context, Result, ensure, format_err};
 use fs_err as fs;
 use serde::Deserialize;
@@ -376,28 +378,21 @@ impl InterpreterConfig {
         let implementation = implementation.unwrap_or_else(|| "cpython".to_string());
         let interpreter_kind = implementation.parse().map_err(|e| format_err!("{}", e))?;
         let known_flags = build_flags.map(|flags| {
-            let debug = flags.split(',').any(|flag| flag.trim() == "Py_DEBUG");
             let gil_disabled = flags
                 .split(',')
                 .any(|flag| flag.trim() == "Py_GIL_DISABLED");
-            (debug, gil_disabled)
+            let debug = flags.split(',').any(|flag| flag.trim() == "Py_DEBUG");
+            (gil_disabled, debug)
         });
         let abiflags = if let Some(abiflags) = abiflags {
-            if let Some((debug, gil_disabled)) = known_flags {
+            if let Some((gil_disabled, debug)) = known_flags {
                 // `gil_disabled` and `debug` are derived from
-                validate_abiflags(&abiflags, debug, gil_disabled)?;
+                validate_abiflags(&abiflags, gil_disabled, debug)?;
             }
             abiflags
         } else {
-            let mut abiflags = String::new();
-            if let Some((debug, gil_disabled)) = known_flags {
-                normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
-            }
-            if interpreter_kind == InterpreterKind::CPython && (major, minor) < (3, 8) {
-                // default of "m" (pymalloc) for Python 3.7 and earlier
-                abiflags.push('m');
-            }
-            abiflags
+            let (gil_disabled, debug) = known_flags.unwrap_or((false, false));
+            default_abiflags(minor, gil_disabled, debug)
         };
         if interpreter_kind == InterpreterKind::CPython {
             ensure!(
@@ -582,11 +577,11 @@ mod tests {
             ("", ""),
             ("abiflags=\n", ""),
             ("abiflags=d\n", "d"),
-            ("abiflags=dt\n", "dt"),
+            ("abiflags=td\n", "td"),
             ("build_flags=Py_GIL_DISABLED\n", "t"),
             ("abiflags=t\n", "t"),
-            ("abiflags=dt\nbuild_flags=Py_DEBUG,Py_GIL_DISABLED\n", "dt"),
-            ("build_flags=Py_DEBUG,Py_GIL_DISABLED\n", "dt"),
+            ("abiflags=td\nbuild_flags=Py_DEBUG,Py_GIL_DISABLED\n", "td"),
+            ("build_flags=Py_DEBUG,Py_GIL_DISABLED\n", "td"),
             ("build_flags=Py_DEBUG\n", "d"),
         ] {
             let file = tempfile::NamedTempFile::new().unwrap();
@@ -644,7 +639,7 @@ mod tests {
             "wasm32-unknown-emscripten",
         ] {
             let target = Target::from_resolved_target_triple(triple).unwrap();
-            for flags in ["", "d", "t", "dt"] {
+            for flags in ["", "d", "t", "td"] {
                 let config = InterpreterConfig::lookup_one(
                     &target,
                     InterpreterKind::CPython,

--- a/src/python_interpreter/config.rs
+++ b/src/python_interpreter/config.rs
@@ -1,10 +1,11 @@
 use super::{
     FREE_THREADED_MINIMUM_PYTHON_MINOR, InterpreterKind, MAXIMUM_PYPY_MINOR, MAXIMUM_PYTHON_MINOR,
     MINIMUM_PYPY_MINOR, MINIMUM_PYTHON_MINOR,
+    abiflags::{normalize_abiflags, validate_abiflags},
 };
 use crate::target::{Arch, Os};
 use crate::{StableAbi, StableAbiKind, Target};
-use anyhow::{Context, Result, format_err};
+use anyhow::{Context, Result, ensure, format_err};
 use fs_err as fs;
 use serde::Deserialize;
 use std::fmt::Write as _;
@@ -38,14 +39,8 @@ pub struct InterpreterConfig {
     /// cpython, pypy, or graalpy
     #[serde(rename = "interpreter")]
     pub interpreter_kind: InterpreterKind,
-    /// For linux and mac, this contains the value of the abiflags, e.g. "m"
-    /// for python3.7m or "dm" for python3.6dm.
-    ///
-    /// * Since python3.8, the value is empty
-    /// * Since python3.13, the value is "t" for free-threaded builds.
-    /// * On Windows, the value was always None.
-    ///
-    /// See PEP 261 and PEP 393 for details
+    /// Normalized Python ABI flags, e.g. "m" for Python 3.7, "d" for debug builds,
+    /// and "t" for free-threaded builds. Empty for PyPy and GraalPy.
     pub abiflags: String,
     /// Suffix to use for extension modules as given by sysconfig.
     pub ext_suffix: String,
@@ -89,11 +84,14 @@ impl InterpreterConfig {
         }
         let python_ext_arch = target.get_python_ext_arch(python_impl);
         let target_env = target.get_python_target_env(python_impl, python_version);
-        let gil_disabled = abiflags == "t";
+        let gil_disabled = abiflags.contains('t');
+        if gil_disabled && (python_impl != CPython || python_version < (3, 13)) {
+            return None;
+        }
         match (target.target_os(), python_impl) {
             (Os::Linux, CPython) => {
                 let abiflags = if python_version < (3, 8) {
-                    "m".to_string()
+                    format!("{}m", abiflags.trim_end_matches('m'))
                 } else {
                     abiflags.to_string()
                 };
@@ -141,7 +139,7 @@ impl InterpreterConfig {
             }
             (Os::Macos, CPython) => {
                 let abiflags = if python_version < (3, 8) {
-                    "m".to_string()
+                    format!("{}m", abiflags.trim_end_matches('m'))
                 } else {
                     abiflags.to_string()
                 };
@@ -187,7 +185,7 @@ impl InterpreterConfig {
             }
             (Os::Windows, CPython) => {
                 let abiflags = if python_version < (3, 8) {
-                    "m".to_string()
+                    format!("{}m", abiflags.trim_end_matches('m'))
                 } else {
                     abiflags.to_string()
                 };
@@ -230,7 +228,10 @@ impl InterpreterConfig {
             }
             (Os::FreeBsd, CPython) => {
                 let (abiflags, ext_suffix) = if python_version < (3, 8) {
-                    ("m".to_string(), ".so".to_string())
+                    (
+                        format!("{}m", abiflags.trim_end_matches('m')),
+                        ".so".to_string(),
+                    )
                 } else {
                     (
                         abiflags.to_string(),
@@ -253,7 +254,7 @@ impl InterpreterConfig {
                     major,
                     minor,
                     interpreter_kind: CPython,
-                    abiflags: String::new(),
+                    abiflags: abiflags.to_string(),
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),
                     gil_disabled,
@@ -266,7 +267,7 @@ impl InterpreterConfig {
                     major,
                     minor,
                     interpreter_kind: CPython,
-                    abiflags: String::new(),
+                    abiflags: abiflags.to_string(),
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),
                     gil_disabled,
@@ -274,12 +275,13 @@ impl InterpreterConfig {
             }
             (Os::Emscripten, CPython) => {
                 let ldversion = format!("{major}{minor}");
-                let ext_suffix = format!(".cpython-{ldversion}-{python_ext_arch}-emscripten.so");
+                let ext_suffix =
+                    format!(".cpython-{ldversion}{abiflags}-{python_ext_arch}-emscripten.so");
                 Some(Self {
                     major,
                     minor,
                     interpreter_kind: CPython,
-                    abiflags: String::new(),
+                    abiflags: abiflags.to_string(),
                     ext_suffix,
                     pointer_width: Some(target.pointer_width()),
                     gil_disabled,
@@ -339,7 +341,7 @@ impl InterpreterConfig {
 
         let mut implementation = None;
         let mut version = None;
-        let mut abiflags = None;
+        let mut abiflags: Option<String> = None;
         let mut ext_suffix = None;
         let mut abi_tag = None;
         let mut pointer_width = None;
@@ -373,13 +375,46 @@ impl InterpreterConfig {
         })?;
         let implementation = implementation.unwrap_or_else(|| "cpython".to_string());
         let interpreter_kind = implementation.parse().map_err(|e| format_err!("{}", e))?;
+        let gil_disabled = build_flags
+            .as_deref()
+            .unwrap_or_default()
+            .split(',')
+            .any(|flag| flag.trim() == "Py_GIL_DISABLED");
+        let debug = build_flags
+            .as_deref()
+            .unwrap_or_default()
+            .split(',')
+            .any(|flag| flag.trim() == "Py_DEBUG");
+        let abiflags = if let Some(abiflags) = abiflags {
+            validate_abiflags(&abiflags, debug, gil_disabled)?;
+            abiflags
+        } else {
+            let mut abiflags = String::new();
+            normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
+            if interpreter_kind == InterpreterKind::CPython && (major, minor) < (3, 8) {
+                // default of "m" (pymalloc) for Python 3.7 and earlier
+                abiflags.push('m');
+            }
+            abiflags
+        };
+        if interpreter_kind == InterpreterKind::CPython {
+            ensure!(
+                !abiflags.contains('t') || (major, minor) >= (3, 13),
+                "Free-threaded ABI flags require Python 3.13 or later"
+            );
+            ensure!(
+                abiflags.contains('m') == ((major, minor) < (3, 8)),
+                "ABI flag 'm' is required before Python 3.8 and unsupported thereafter"
+            );
+        } else {
+            ensure!(
+                abiflags.is_empty(),
+                "ABI flags are unsupported for {interpreter_kind}"
+            );
+        }
         let abi_tag = match interpreter_kind {
             InterpreterKind::CPython => {
-                if (major, minor) >= (3, 8) {
-                    abi_tag.unwrap_or_else(|| format!("{major}{minor}"))
-                } else {
-                    abi_tag.unwrap_or_else(|| format!("{major}{minor}m"))
-                }
+                abi_tag.unwrap_or_else(|| format!("{major}{minor}{abiflags}"))
             }
             InterpreterKind::PyPy => abi_tag.unwrap_or_else(|| PYPY_ABI_TAG.to_string()),
             InterpreterKind::GraalPy => abi_tag.unwrap_or_else(|| {
@@ -442,14 +477,11 @@ impl InterpreterConfig {
             } else {
                 ext_suffix.context("missing value for ext_suffix")?
             };
-        let gil_disabled = build_flags
-            .map(|flags| flags.contains("Py_GIL_DISABLED"))
-            .unwrap_or(false);
         Ok(Self {
             major,
             minor,
             interpreter_kind,
-            abiflags: abiflags.unwrap_or_default(),
+            abiflags,
             ext_suffix,
             pointer_width,
             gil_disabled,
@@ -539,6 +571,111 @@ mod tests {
     use super::*;
     use expect_test::expect;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_from_pyo3_config_abiflags() {
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
+        for (settings, flags) in [
+            ("", ""),
+            ("abiflags=\n", ""),
+            ("abiflags=d\n", "d"),
+            ("abiflags=dt\n", "dt"),
+            ("build_flags=Py_GIL_DISABLED\n", "t"),
+            ("abiflags=t\n", "t"),
+            ("abiflags=dt\nbuild_flags=Py_DEBUG,Py_GIL_DISABLED\n", "dt"),
+            ("build_flags=Py_DEBUG,Py_GIL_DISABLED\n", "dt"),
+            ("build_flags=Py_DEBUG\n", "d"),
+        ] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            fs::write(file.path(), format!("version=3.14\n{settings}")).unwrap();
+            let config = InterpreterConfig::from_pyo3_config(file.path(), &target).unwrap();
+            assert_eq!(config.abiflags, flags, "{settings}");
+            assert_eq!(config.gil_disabled, flags.contains('t'));
+            assert_eq!(
+                config.ext_suffix,
+                format!(".cpython-314{flags}-x86_64-linux-gnu.so")
+            );
+        }
+        for settings in ["", "abiflags=dm\n"] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            fs::write(
+                file.path(),
+                format!("version=3.7\nbuild_flags=Py_DEBUG\n{settings}"),
+            )
+            .unwrap();
+            let config = InterpreterConfig::from_pyo3_config(file.path(), &target).unwrap();
+            assert_eq!(config.abiflags, "dm");
+            assert_eq!(config.ext_suffix, ".cpython-37dm-x86_64-linux-gnu.so");
+        }
+        for settings in [
+            "version=3.14\nabiflags=t\nbuild_flags=\n",
+            "version=3.14\nabiflags=\nbuild_flags=Py_GIL_DISABLED\n",
+            "version=3.14\nabiflags=d\nbuild_flags=Py_DEBUG,Py_GIL_DISABLED\n",
+            "version=3.14\nabiflags=t\nbuild_flags=Py_DEBUG,Py_GIL_DISABLED\n",
+            "version=3.14\nabiflags=d\nbuild_flags=\n",
+            "version=3.14\nabiflags=m\n",
+            "version=3.12\nabiflags=t\n",
+            "version=3.7\nabiflags=\n",
+            "version=3.7\nabiflags=d\n",
+            "version=3.14\nimplementation=PyPy\nabiflags=t\n",
+        ] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            fs::write(file.path(), settings).unwrap();
+            assert!(
+                InterpreterConfig::from_pyo3_config(file.path(), &target).is_err(),
+                "{settings}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_well_known_sysconfigs_abiflags() {
+        for triple in [
+            "x86_64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "x86_64-unknown-freebsd",
+            "x86_64-unknown-netbsd",
+            "x86_64-unknown-openbsd",
+            "wasm32-unknown-emscripten",
+        ] {
+            let target = Target::from_resolved_target_triple(triple).unwrap();
+            for flags in ["", "d", "t", "dt"] {
+                let config = InterpreterConfig::lookup_one(
+                    &target,
+                    InterpreterKind::CPython,
+                    (3, 14),
+                    flags,
+                )
+                .unwrap();
+                assert_eq!(config.abiflags, flags, "{triple}");
+                assert_eq!(config.gil_disabled, flags.contains('t'), "{triple}");
+            }
+            assert!(
+                InterpreterConfig::lookup_one(&target, InterpreterKind::PyPy, (3, 14), "t",)
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn test_well_known_sysconfigs_python_3_7_debug() {
+        for triple in [
+            "x86_64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "x86_64-unknown-freebsd",
+        ] {
+            let target = Target::from_resolved_target_triple(triple).unwrap();
+            for flags in ["d", "dm"] {
+                let config =
+                    InterpreterConfig::lookup_one(&target, InterpreterKind::CPython, (3, 7), flags)
+                        .unwrap();
+                assert_eq!(config.abiflags, "dm", "{triple}");
+                assert!(!config.gil_disabled);
+            }
+        }
+    }
 
     #[test]
     fn test_well_known_sysconfigs_linux() {

--- a/src/python_interpreter/discovery.rs
+++ b/src/python_interpreter/discovery.rs
@@ -9,7 +9,6 @@ use super::{
     FREE_THREADED_MINIMUM_PYTHON_MINOR, InterpreterConfig, InterpreterKind, MINIMUM_PYPY_MINOR,
     MINIMUM_PYTHON_MINOR, PythonInterpreter,
 };
-use crate::python_interpreter::abiflags::normalize_abiflags;
 use crate::target::Arch;
 use crate::{BridgeModel, Target};
 use anyhow::{Context, Result, bail, format_err};
@@ -43,8 +42,8 @@ pub(super) struct InterpreterMetadataMessage {
     // comes from `platform.system()`
     pub system: String,
     pub soabi: Option<String>,
-    pub debug: bool,
     pub gil_disabled: bool,
+    pub debug: bool,
 }
 
 /// Manages interpreter discovery on Windows.
@@ -616,15 +615,10 @@ fn from_metadata_message(
         }
     };
 
-    let abiflags = fun_with_abiflags(&message, target, bridge)
-        .and_then(|mut flags| {
-            normalize_abiflags(&mut flags, message.debug, message.gil_disabled)?;
-            Ok(flags)
-        })
-        .context(format_err!(
-            "Failed to get information from the python interpreter at {}",
-            executable.as_ref().display()
-        ))?;
+    let abiflags = fun_with_abiflags(&message, target, bridge).context(format_err!(
+        "Failed to get information from the python interpreter at {}",
+        executable.as_ref().display()
+    ))?;
 
     let executable = message
         .executable
@@ -1055,9 +1049,14 @@ mod tests {
     }
 
     #[test]
-    fn test_discovery_infers_windows_debug_abiflags() {
+    fn test_discovery_infers_windows_abiflags() {
         let target = Target::from_resolved_target_triple("x86_64-pc-windows-msvc").unwrap();
-        for (gil_disabled, expected) in [(false, "d"), (true, "dt")] {
+        for (gil_disabled, debug, expected) in [
+            (false, false, ""),
+            (true, false, "t"),
+            (false, true, "d"),
+            (true, true, "td"),
+        ] {
             let message = InterpreterMetadataMessage {
                 major: 3,
                 minor: 13,
@@ -1068,8 +1067,8 @@ mod tests {
                 platform: "win-amd64".to_string(),
                 executable: None,
                 soabi: None,
-                debug: true,
                 gil_disabled,
+                debug,
                 system: "windows".to_string(),
             };
             let interpreter =
@@ -1081,7 +1080,7 @@ mod tests {
     }
 
     #[test]
-    fn test_discovery_normalizes_abiflags() {
+    fn test_discovery_abiflags() {
         for (triple, system, platform, minor, flags, expected) in [
             (
                 "x86_64-pc-windows-msvc",
@@ -1097,15 +1096,15 @@ mod tests {
                 "linux-x86_64",
                 14,
                 Some("d"),
-                "dt",
+                "d",
             ),
             (
                 "x86_64-unknown-linux-gnu",
                 "linux",
                 "linux-x86_64",
                 14,
-                Some("dt"),
-                "dt",
+                Some("td"),
+                "td",
             ),
         ] {
             let target = Target::from_resolved_target_triple(triple).unwrap();
@@ -1120,7 +1119,7 @@ mod tests {
                 executable: None,
                 soabi: None,
                 debug: expected.contains('d'),
-                gil_disabled: true,
+                gil_disabled: expected.contains('t'),
                 system: system.to_string(),
             };
             let interpreter =
@@ -1128,7 +1127,6 @@ mod tests {
                     .unwrap()
                     .unwrap();
             assert_eq!(interpreter.abiflags, expected);
-            assert!(interpreter.gil_disabled);
         }
     }
 

--- a/src/python_interpreter/discovery.rs
+++ b/src/python_interpreter/discovery.rs
@@ -9,6 +9,7 @@ use super::{
     FREE_THREADED_MINIMUM_PYTHON_MINOR, InterpreterConfig, InterpreterKind, MINIMUM_PYPY_MINOR,
     MINIMUM_PYTHON_MINOR, PythonInterpreter,
 };
+use crate::python_interpreter::abiflags::normalize_abiflags;
 use crate::target::Arch;
 use crate::{BridgeModel, Target};
 use anyhow::{Context, Result, bail, format_err};
@@ -42,6 +43,7 @@ pub(super) struct InterpreterMetadataMessage {
     // comes from `platform.system()`
     pub system: String,
     pub soabi: Option<String>,
+    pub debug: bool,
     pub gil_disabled: bool,
 }
 
@@ -614,10 +616,15 @@ fn from_metadata_message(
         }
     };
 
-    let abiflags = fun_with_abiflags(&message, target, bridge).context(format_err!(
-        "Failed to get information from the python interpreter at {}",
-        executable.as_ref().display()
-    ))?;
+    let abiflags = fun_with_abiflags(&message, target, bridge)
+        .and_then(|mut flags| {
+            normalize_abiflags(&mut flags, message.debug, message.gil_disabled)?;
+            Ok(flags)
+        })
+        .context(format_err!(
+            "Failed to get information from the python interpreter at {}",
+            executable.as_ref().display()
+        ))?;
 
     let executable = message
         .executable
@@ -881,6 +888,7 @@ mod tests {
             implementation_name: "CPython".to_string(),
             abiflags: None,
             ext_suffix: Some(".pyd".to_string()),
+            debug: false,
             platform: platform.to_string(),
             executable: None,
             soabi: None,
@@ -1008,6 +1016,7 @@ mod tests {
             implementation_name: "CPython".to_string(),
             abiflags: Some("".to_string()),
             ext_suffix: Some(".cp314-win_amd64.pyd".to_string()),
+            debug: false,
             platform: "win-amd64".to_string(),
             executable: None,
             soabi: None,
@@ -1029,6 +1038,7 @@ mod tests {
             implementation_name: "CPython".to_string(),
             abiflags: Some("t".to_string()),
             ext_suffix: Some(".cp314t-win_amd64.pyd".to_string()),
+            debug: false,
             platform: "win-amd64".to_string(),
             executable: None,
             soabi: None,
@@ -1042,6 +1052,84 @@ mod tests {
         assert_eq!(interp.minor, 14);
         assert_eq!(interp.abiflags, "t");
         assert!(interp.gil_disabled);
+    }
+
+    #[test]
+    fn test_discovery_infers_windows_debug_abiflags() {
+        let target = Target::from_resolved_target_triple("x86_64-pc-windows-msvc").unwrap();
+        for (gil_disabled, expected) in [(false, "d"), (true, "dt")] {
+            let message = InterpreterMetadataMessage {
+                major: 3,
+                minor: 13,
+                interpreter: "cpython".to_string(),
+                implementation_name: "cpython".to_string(),
+                abiflags: None,
+                ext_suffix: Some("_d.pyd".to_string()),
+                platform: "win-amd64".to_string(),
+                executable: None,
+                soabi: None,
+                debug: true,
+                gil_disabled,
+                system: "windows".to_string(),
+            };
+            let interpreter =
+                from_metadata_message("python", &target, &BridgeModel::Bin(None), message)
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(interpreter.abiflags, expected);
+        }
+    }
+
+    #[test]
+    fn test_discovery_normalizes_abiflags() {
+        for (triple, system, platform, minor, flags, expected) in [
+            (
+                "x86_64-pc-windows-msvc",
+                "windows",
+                "win-amd64",
+                13,
+                None,
+                "t",
+            ),
+            (
+                "x86_64-unknown-linux-gnu",
+                "linux",
+                "linux-x86_64",
+                14,
+                Some("d"),
+                "dt",
+            ),
+            (
+                "x86_64-unknown-linux-gnu",
+                "linux",
+                "linux-x86_64",
+                14,
+                Some("dt"),
+                "dt",
+            ),
+        ] {
+            let target = Target::from_resolved_target_triple(triple).unwrap();
+            let message = InterpreterMetadataMessage {
+                major: 3,
+                minor,
+                interpreter: "cpython".to_string(),
+                implementation_name: "cpython".to_string(),
+                abiflags: flags.map(str::to_string),
+                ext_suffix: Some(".so".to_string()),
+                platform: platform.to_string(),
+                executable: None,
+                soabi: None,
+                debug: expected.contains('d'),
+                gil_disabled: true,
+                system: system.to_string(),
+            };
+            let interpreter =
+                from_metadata_message("python", &target, &BridgeModel::Bin(None), message)
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(interpreter.abiflags, expected);
+            assert!(interpreter.gil_disabled);
+        }
     }
 
     #[test]

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -35,8 +35,8 @@ metadata = {
     "system": platform.system().lower(),
     # This one is for generating a config file for pyo3
     "pointer_width": struct.calcsize("P") * 8,
-    "debug": sysconfig.get_config_var("Py_DEBUG") == 1,
     "gil_disabled": sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
+    "debug": sysconfig.get_config_var("Py_DEBUG") == 1,
 }
 
 print(json.dumps(metadata))

--- a/src/python_interpreter/get_interpreter_metadata.py
+++ b/src/python_interpreter/get_interpreter_metadata.py
@@ -35,6 +35,7 @@ metadata = {
     "system": platform.system().lower(),
     # This one is for generating a config file for pyo3
     "pointer_width": struct.calcsize("P") * 8,
+    "debug": sysconfig.get_config_var("Py_DEBUG") == 1,
     "gil_disabled": sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
 }
 

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -556,7 +556,7 @@ mod tests {
 
     #[test]
     fn environment_signature_includes_abiflags() {
-        for flags in ["", "d", "t", "dt"] {
+        for flags in ["", "d", "t", "td"] {
             let interp = interpreter(InterpreterKind::CPython, 14, flags, flags.contains('t'));
             assert_eq!(
                 interp.environment_signature(),

--- a/src/python_interpreter/mod.rs
+++ b/src/python_interpreter/mod.rs
@@ -470,13 +470,13 @@ impl PythonInterpreter {
         }
     }
 
-    /// An opaque string that uniquely identifies this Python interpreter.
+    /// An opaque fingerprint of this Python interpreter's version and ABI.
     /// Used to trigger rebuilds for `pyo3` when the Python interpreter changes.
     pub fn environment_signature(&self) -> String {
         let pointer_width = self.pointer_width.unwrap_or(64);
         format!(
-            "{}-{}.{}-{}bit",
-            self.implementation_name, self.major, self.minor, pointer_width
+            "{}-{}.{}{}-{}bit",
+            self.implementation_name, self.major, self.minor, self.abiflags, pointer_width
         )
     }
 
@@ -551,6 +551,17 @@ mod tests {
             runnable: false,
             implementation_name: kind.to_string().to_ascii_lowercase(),
             soabi: None,
+        }
+    }
+
+    #[test]
+    fn environment_signature_includes_abiflags() {
+        for flags in ["", "d", "t", "dt"] {
+            let interp = interpreter(InterpreterKind::CPython, 14, flags, flags.contains('t'));
+            assert_eq!(
+                interp.environment_signature(),
+                format!("cpython-3.14{flags}-64bit")
+            );
         }
     }
 

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -18,6 +18,7 @@ use super::{InterpreterConfig, InterpreterKind, PythonInterpreter};
 use crate::cross_compile::{
     find_build_details, find_sysconfigdata, parse_build_details_json_file, parse_sysconfigdata,
 };
+use crate::python_interpreter::abiflags::normalize_abiflags;
 use crate::{BridgeModel, StableAbiKind, Target};
 use anyhow::{Context, Result, bail, format_err};
 use pep440_rs::VersionSpecifiers;
@@ -835,13 +836,9 @@ impl<'a> InterpreterResolver<'a> {
             .context("version_minor is not defined")?
             .parse::<usize>()
             .context("Could not parse value of version_minor")?;
-        let abiflags = data
+        let mut abiflags = data
             .get("ABIFLAGS")
             .map(ToString::to_string)
-            .unwrap_or_default();
-        let gil_disabled = data
-            .get("Py_GIL_DISABLED")
-            .map(|x| x == "1")
             .unwrap_or_default();
         let ext_suffix = data
             .get("EXT_SUFFIX")
@@ -860,6 +857,11 @@ impl<'a> InterpreterResolver<'a> {
                 }
             })
             .context("unsupported Python interpreter")?;
+        let debug = data
+            .get("Py_DEBUG")
+            .is_some_and(|x| interpreter_kind == InterpreterKind::CPython && x == "1");
+        let gil_disabled = data.get("Py_GIL_DISABLED").is_some_and(|x| x == "1");
+        normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
         Ok(PythonInterpreter {
             config: InterpreterConfig {
                 major,
@@ -945,6 +947,54 @@ impl<'a> InterpreterResolver<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sysconfigdata_normalizes_abiflags() {
+        let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
+        let bridge = BridgeModel::Bin(None);
+        let resolver = InterpreterResolver::new(&target, &bridge, None, &[], false, false);
+        for (flags, debug, gil_disabled, expected) in [
+            (None, None, None, ""),
+            (None, None, Some("1"), "t"),
+            (Some(""), None, Some("1"), "t"),
+            (Some("d"), None, Some("1"), "dt"),
+            (Some("dt"), None, Some("1"), "dt"),
+            (Some("t"), None, None, "t"),
+            (None, Some("1"), None, "d"),
+            (None, Some("1"), Some("1"), "dt"),
+            (Some("t"), Some("1"), Some("1"), "dt"),
+        ] {
+            let mut data = std::collections::HashMap::from([
+                ("version_major".to_string(), "3".to_string()),
+                ("version_minor".to_string(), "14".to_string()),
+                (
+                    "SOABI".to_string(),
+                    format!("cpython-314{expected}-x86_64-linux-gnu"),
+                ),
+                (
+                    "EXT_SUFFIX".to_string(),
+                    format!(".cpython-314{expected}-x86_64-linux-gnu.so"),
+                ),
+            ]);
+            if let Some(flags) = flags {
+                data.insert("ABIFLAGS".to_string(), flags.to_string());
+            }
+            if let Some(debug) = debug {
+                data.insert("Py_DEBUG".to_string(), debug.to_string());
+            }
+            if let Some(gil_disabled) = gil_disabled {
+                data.insert("Py_GIL_DISABLED".to_string(), gil_disabled.to_string());
+            }
+            let interpreter = resolver.interpreter_from_sysconfigdata(&data).unwrap();
+            assert_eq!(interpreter.abiflags, expected);
+            assert_eq!(interpreter.gil_disabled, expected.contains('t'));
+            if expected.contains('t') {
+                data.insert("ABIFLAGS".to_string(), expected.to_string());
+                data.insert("Py_GIL_DISABLED".to_string(), "0".to_string());
+                assert!(resolver.interpreter_from_sysconfigdata(&data).is_err());
+            }
+        }
+    }
 
     #[test]
     fn test_interpreter_spec_cpython_versions() {

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -18,7 +18,7 @@ use super::{InterpreterConfig, InterpreterKind, PythonInterpreter};
 use crate::cross_compile::{
     find_build_details, find_sysconfigdata, parse_build_details_json_file, parse_sysconfigdata,
 };
-use crate::python_interpreter::abiflags::normalize_abiflags;
+use crate::python_interpreter::abiflags::{default_abiflags, validate_abiflags};
 use crate::{BridgeModel, StableAbiKind, Target};
 use anyhow::{Context, Result, bail, format_err};
 use pep440_rs::VersionSpecifiers;
@@ -836,10 +836,6 @@ impl<'a> InterpreterResolver<'a> {
             .context("version_minor is not defined")?
             .parse::<usize>()
             .context("Could not parse value of version_minor")?;
-        let mut abiflags = data
-            .get("ABIFLAGS")
-            .map(ToString::to_string)
-            .unwrap_or_default();
         let ext_suffix = data
             .get("EXT_SUFFIX")
             .context("sysconfig didn't define an `EXT_SUFFIX` ಠ_ಠ")?;
@@ -857,16 +853,27 @@ impl<'a> InterpreterResolver<'a> {
                 }
             })
             .context("unsupported Python interpreter")?;
-        // if sysconfig missing the Py_DEBUG or Py_GIL_DISABLED env vars, fall back to inferring from abiflags
-        let debug = data
-            .get("Py_DEBUG")
-            .map(|x| x == "1")
-            .unwrap_or(abiflags.contains("d"));
-        let gil_disabled = data
-            .get("Py_GIL_DISABLED")
-            .map(|x| x == "1")
-            .unwrap_or(abiflags.contains("t"));
-        normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
+        // if sysconfig missing the Py_DEBUG or Py_GIL_DISABLED env vars, fall back to inferring from abiflags (if present)
+        let abiflags = data.get("ABIFLAGS");
+        let debug = data.get("Py_DEBUG").map(|x| x == "1").unwrap_or(
+            abiflags
+                .map(String::as_str)
+                .unwrap_or_default()
+                .contains("d"),
+        );
+        let gil_disabled = data.get("Py_GIL_DISABLED").map(|x| x == "1").unwrap_or(
+            abiflags
+                .map(String::as_str)
+                .unwrap_or_default()
+                .contains("t"),
+        );
+        // and finally, if abiflags are missing, infer from Py_DEBUG and Py_GIL_DISABLED
+        let abiflags = if let Some(abiflags) = abiflags {
+            validate_abiflags(&abiflags, gil_disabled, debug)?;
+            abiflags.to_string()
+        } else {
+            default_abiflags(minor, gil_disabled, debug)
+        };
         Ok(PythonInterpreter {
             config: InterpreterConfig {
                 major,
@@ -958,16 +965,16 @@ mod tests {
         let target = Target::from_resolved_target_triple("x86_64-unknown-linux-gnu").unwrap();
         let bridge = BridgeModel::Bin(None);
         let resolver = InterpreterResolver::new(&target, &bridge, None, &[], false, false);
-        for (flags, debug, gil_disabled, expected) in [
+        for (flags, gil_disabled, debug, expected) in [
             (None, None, None, ""),
-            (None, None, Some("1"), "t"),
-            (Some(""), None, Some("1"), "t"),
-            (Some("d"), None, Some("1"), "dt"),
-            (Some("dt"), None, Some("1"), "dt"),
-            (Some("t"), None, None, "t"),
-            (None, Some("1"), None, "d"),
-            (None, Some("1"), Some("1"), "dt"),
-            (Some("t"), Some("1"), Some("1"), "dt"),
+            (None, Some("1"), None, "t"),
+            (Some(""), None, None, ""),
+            (Some("d"), None, Some("1"), "d"),
+            (Some("td"), Some("1"), Some("1"), "td"),
+            (Some("t"), Some("1"), None, "t"),
+            (None, Some("1"), None, "t"),
+            (None, Some("1"), Some("1"), "td"),
+            (Some("td"), Some("1"), Some("1"), "td"),
         ] {
             let mut data = std::collections::HashMap::from([
                 ("version_major".to_string(), "3".to_string()),

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -857,10 +857,15 @@ impl<'a> InterpreterResolver<'a> {
                 }
             })
             .context("unsupported Python interpreter")?;
+        // if sysconfig missing the Py_DEBUG or Py_GIL_DISABLED env vars, fall back to inferring from abiflags
         let debug = data
             .get("Py_DEBUG")
-            .is_some_and(|x| interpreter_kind == InterpreterKind::CPython && x == "1");
-        let gil_disabled = data.get("Py_GIL_DISABLED").is_some_and(|x| x == "1");
+            .map(|x| x == "1")
+            .unwrap_or(abiflags.contains("d"));
+        let gil_disabled = data
+            .get("Py_GIL_DISABLED")
+            .map(|x| x == "1")
+            .unwrap_or(abiflags.contains("t"));
         normalize_abiflags(&mut abiflags, debug, gil_disabled)?;
         Ok(PythonInterpreter {
             config: InterpreterConfig {

--- a/src/python_interpreter/resolver.rs
+++ b/src/python_interpreter/resolver.rs
@@ -869,7 +869,7 @@ impl<'a> InterpreterResolver<'a> {
         );
         // and finally, if abiflags are missing, infer from Py_DEBUG and Py_GIL_DISABLED
         let abiflags = if let Some(abiflags) = abiflags {
-            validate_abiflags(&abiflags, gil_disabled, debug)?;
+            validate_abiflags(abiflags, gil_disabled, debug)?;
             abiflags.to_string()
         } else {
             default_abiflags(minor, gil_disabled, debug)


### PR DESCRIPTION
`maturin` currently generates `PYO3_ENVIRONMENT_SIGNATURE` without accounting for abiflags. This in particular means that builds switching between regular and free-threaded Python can fail to invalidate `pyo3-ffi`'s cache and lead to compilation selecting the wrong ABI.

This PR corrects the generated environment signature, and attempts to make abiflag handling correct throughout `maturin`. In particular I found the following other deficiencies:
- Parsing `PYO3_CONFIG_FILE` did not infer (or validate) missing ABI flags from `Py_GIL_DISABLED` or `Py_DEBUG`.
- The default CPython extension suffix generated from `PYO3_CONFIG_FILE` omitted free-threaded and debug flags. (This would produce a wheel with an invalid extension for the free-threaded/debug interpreter.)
- Cross-compilation sysconfig parsing did not infer missing ABI flags from build settings.
- Interpreter discovery generally did not account for the possibility of the `d` debug abiflag.